### PR TITLE
feat: initialize monorepo for blog redesign

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,41 @@
-*.gem
-*.swp
-*~
+# Dependencies
+node_modules/
+
+# Build outputs
+dist/
+build/
+.next/
+out/
+storybook-static/
+
+# Turborepo
+.turbo/
+
+# Package manager
+pnpm-lock.yaml
+
+# Environment
+.env
+.env.local
+.env.*.local
+
+# Logs
+*.log
+npm-debug.log*
+pnpm-debug.log*
+
+# OS
 .DS_Store
+*~
+*.swp
+
+# IDE
+.idea/
+.vscode/
+*.sublime-*
+
+# Legacy (Hugo/Jekyll)
+*.gem
 .bundle/
 .byebug_history
 .jekyll-metadata

--- a/AGENT.md
+++ b/AGENT.md
@@ -1,0 +1,128 @@
+# Agent Guide
+
+This document provides context for AI agents working on this codebase.
+
+## Project Overview
+
+Personal blog rebuild from Hugo/PaperMod to Next.js + MDX with a design system monorepo.
+
+## Tech Stack
+
+- **Monorepo**: Turborepo + pnpm
+- **Framework**: Next.js 14 (App Router)
+- **Language**: TypeScript 5 (strict mode)
+- **Styling**: Tailwind CSS + Design Tokens
+- **Content**: MDX
+
+## Directory Structure
+
+```
+sarajevo/
+├── packages/
+│   ├── config/          # Shared TypeScript & Tailwind configs
+│   ├── tokens/          # Design tokens (Style Dictionary)
+│   └── ui/              # Component library (to be created)
+├── apps/
+│   └── blog/            # Next.js blog app (to be created)
+├── content/             # Legacy Hugo content (reference only)
+├── docs/                # Static export output (GitHub Pages)
+├── plan/                # Architecture and implementation docs
+├── package.json         # Workspace root
+├── pnpm-workspace.yaml  # Workspace packages
+└── turbo.json           # Build orchestration
+```
+
+## Package Naming
+
+- `@blog/config` - Shared configs
+- `@blog/tokens` - Design tokens
+- `@blog/ui` - UI components (to be created)
+- `@blog/blog` - Next.js app (to be created)
+
+## Import Conventions
+
+Always use absolute imports with path aliases:
+
+```typescript
+// In packages/ui - use @ui/*
+import { cn } from '@ui/lib/utils';
+
+// In apps/blog - use @/*
+import { PostCard } from '@/components/PostCard';
+import { Card } from '@blog/ui';
+```
+
+## Key Commands
+
+```bash
+# Install dependencies
+pnpm install
+
+# Build tokens (required before other packages)
+pnpm --filter @blog/tokens build
+
+# Run all dev servers
+pnpm dev
+
+# Build all packages
+pnpm build
+
+# Clean all build artifacts
+pnpm clean
+```
+
+## Implementation Status
+
+### Completed
+- [x] Phase 1: Monorepo Foundation
+  - Root workspace configuration
+  - packages/config (TypeScript configs)
+  - packages/tokens (Style Dictionary)
+
+### Pending
+- [ ] Phase 2: UI Package
+- [ ] Phase 3: Blog App Skeleton
+- [ ] Phase 4: MDX Configuration
+- [ ] Phase 5: Content Pages
+- [ ] Phase 6: Content Migration
+- [ ] Phase 7: Features & Polish
+- [ ] Phase 8: Deployment
+- [ ] Phase 9: Cleanup
+
+## Architecture
+
+5-layer design system:
+
+```
+Layer 5: Pages           → apps/blog/app/
+Layer 4: App Components  → apps/blog/components/
+Layer 3: Patterns        → packages/ui/ (complex)
+Layer 2: Primitives      → packages/ui/ (basic)
+Layer 1: Tokens          → packages/tokens/
+```
+
+**Rule**: Lower layers never import from higher layers.
+
+## Planning Documents
+
+See `plan/` directory for detailed documentation:
+
+- `ARCHITECTURE.md` - System architecture and tech decisions
+- `IMPLEMENTATION_PLAN.md` - Phase-by-phase tasks
+- `CONTENT_MIGRATION.md` - Hugo to MDX migration guide
+- `MDX_COMPONENTS.md` - Custom component specifications
+
+## Guidelines for Agents
+
+1. **Read the plan first**: Check `plan/` docs before making architectural decisions
+2. **Use absolute imports**: Never use relative imports like `./` or `../`
+3. **Build tokens first**: Always run `pnpm --filter @blog/tokens build` before other packages
+4. **Follow the layers**: Keep business logic in app components, not UI primitives
+5. **Minimal changes**: Don't over-engineer; only add what's needed
+6. **Test incrementally**: Verify each phase works before proceeding
+
+## Legacy Content
+
+The `content/` directory contains the original Hugo markdown files. These are for reference during migration only. Do not modify them directly.
+
+The `docs/` directory is the static export target for GitHub Pages. It will be overwritten by Next.js builds once migration is complete.

--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -1,0 +1,291 @@
+# Development Guide
+
+## Prerequisites
+
+- Node.js 18+
+- pnpm 9+
+
+```bash
+# Install pnpm if not already installed
+npm install -g pnpm
+```
+
+## Quick Start
+
+```bash
+# 1. Install dependencies
+pnpm install
+
+# 2. Build tokens (required before other packages)
+pnpm --filter @blog/tokens build
+
+# 3. Start development servers
+pnpm dev
+```
+
+## Initial Setup
+
+### First Time Setup
+
+```bash
+# Clone and enter the project
+cd sarajevo
+
+# Install all workspace dependencies
+pnpm install
+
+# Build design tokens
+pnpm --filter @blog/tokens build
+
+# Verify token build succeeded
+ls packages/tokens/build/
+# Should show: css/ js/
+```
+
+### After Pulling Changes
+
+```bash
+# Install any new dependencies
+pnpm install
+
+# Rebuild tokens if token files changed
+pnpm --filter @blog/tokens build
+```
+
+## Common Commands
+
+### Development
+
+```bash
+# Start all dev servers (once apps are created)
+pnpm dev
+
+# Start specific package
+pnpm --filter @blog/blog dev      # Blog app
+pnpm --filter @blog/tokens build  # Rebuild tokens
+```
+
+### Building
+
+```bash
+# Build all packages
+pnpm build
+
+# Build specific package
+pnpm --filter @blog/tokens build
+pnpm --filter @blog/ui build
+pnpm --filter @blog/blog build
+```
+
+### Cleaning
+
+```bash
+# Clean all build artifacts
+pnpm clean
+
+# Clean and reinstall
+pnpm clean && pnpm install
+```
+
+### Linting & Formatting
+
+```bash
+# Lint all packages
+pnpm lint
+
+# Format all files
+pnpm format
+```
+
+## Package Dependencies
+
+```
+@blog/blog (apps/blog)
+├── @blog/ui
+│   └── @blog/tokens
+└── @blog/config
+
+@blog/ui (packages/ui)
+├── @blog/tokens
+└── @blog/config
+
+@blog/tokens (packages/tokens)
+└── (no internal dependencies)
+
+@blog/config (packages/config)
+└── (no internal dependencies)
+```
+
+**Build Order**: tokens → ui → blog
+
+## Adding Dependencies
+
+```bash
+# Add to root (dev tools)
+pnpm add -D -w <package>
+
+# Add to specific package
+pnpm --filter @blog/ui add <package>
+pnpm --filter @blog/blog add <package>
+
+# Add workspace dependency
+pnpm --filter @blog/ui add @blog/tokens@workspace:*
+```
+
+## Creating New Packages
+
+### New UI Component
+
+1. Create component file:
+   ```
+   packages/ui/src/components/NewComponent.tsx
+   ```
+
+2. Export from index:
+   ```typescript
+   // packages/ui/src/index.tsx
+   export { NewComponent } from '@ui/components/NewComponent';
+   ```
+
+3. Add story (once Storybook is set up):
+   ```
+   apps/docs/stories/NewComponent.stories.tsx
+   ```
+
+### New Blog Component
+
+1. Create component file:
+   ```
+   apps/blog/components/NewComponent.tsx
+   ```
+
+2. Import UI primitives:
+   ```typescript
+   import { Card, Badge } from '@blog/ui';
+   ```
+
+### New Design Token
+
+1. Edit token JSON in `packages/tokens/src/`:
+   ```json
+   // packages/tokens/src/colors.json
+   {
+     "color": {
+       "brand": {
+         "primary": { "value": "#your-color" }
+       }
+     }
+   }
+   ```
+
+2. Rebuild tokens:
+   ```bash
+   pnpm --filter @blog/tokens build
+   ```
+
+3. Use in CSS or components:
+   ```css
+   color: var(--color-brand-primary);
+   ```
+
+## Troubleshooting
+
+### "Module not found" errors
+
+```bash
+# Rebuild tokens
+pnpm --filter @blog/tokens build
+
+# Clear turbo cache
+rm -rf .turbo
+
+# Reinstall dependencies
+pnpm install
+```
+
+### TypeScript path alias errors
+
+Ensure your `tsconfig.json` extends the correct base:
+
+```json
+{
+  "extends": "@blog/config/tsconfig/react.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@ui/*": ["src/*"]
+    }
+  }
+}
+```
+
+### Styles not applying
+
+1. Check Tailwind content paths include the UI package:
+   ```javascript
+   // tailwind.config.js
+   content: [
+     './src/**/*.{ts,tsx}',
+     '../../packages/ui/src/**/*.{ts,tsx}'
+   ]
+   ```
+
+2. Verify globals.css imports tokens before Tailwind:
+   ```css
+   @import '@blog/tokens/css';
+   @tailwind base;
+   @tailwind components;
+   @tailwind utilities;
+   ```
+
+### pnpm install fails
+
+```bash
+# Clear pnpm cache
+pnpm store prune
+
+# Remove lockfile and reinstall
+rm pnpm-lock.yaml
+pnpm install
+```
+
+## IDE Setup
+
+### VS Code
+
+Recommended extensions:
+- ESLint
+- Prettier
+- Tailwind CSS IntelliSense
+- TypeScript + JavaScript
+
+Workspace settings (`.vscode/settings.json`):
+```json
+{
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true,
+  "typescript.preferences.importModuleSpecifier": "non-relative"
+}
+```
+
+## Environment Variables
+
+Create `.env.local` in `apps/blog/` for local development:
+
+```bash
+# Example (none required yet)
+# NEXT_PUBLIC_SITE_URL=http://localhost:3000
+```
+
+## Deployment
+
+The blog deploys to GitHub Pages via static export:
+
+```bash
+# Build for production
+pnpm build
+
+# Static files are output to docs/
+```
+
+The `docs/` directory is served by GitHub Pages at `ftvision.github.io`.

--- a/app-starter-kit/AI_AGENT_PROMPT.md
+++ b/app-starter-kit/AI_AGENT_PROMPT.md
@@ -1,0 +1,377 @@
+# AI Agent Quick Start Prompt
+
+Copy this prompt to any AI coding agent to bootstrap a design system foundation.
+
+---
+
+## The Prompt
+
+```
+Initialize a design system monorepo foundation following these specifications:
+
+PHILOSOPHY: Scaffold structure and patterns, not a comprehensive component library.
+The agent creates the foundation. The user extends it with their specific components.
+
+TECH STACK:
+- Turborepo + pnpm (monorepo orchestration)
+- React 18 + TypeScript 5 (strict mode)
+- Tailwind CSS 3 (utility-first styling)
+- Style Dictionary (token transformation)
+- Next.js 14 App Router (example app)
+- Storybook 7 (documentation)
+- CVA (component variants)
+
+STRUCTURE:
+design-system/
+├── packages/
+│   ├── tokens/      Design tokens (JSON → CSS/JS/iOS/Android)
+│   ├── ui/          Component library (1-2 examples only)
+│   └── config/      Shared TypeScript & Tailwind configs
+├── apps/
+│   ├── web/         Next.js app (demonstrating consumption)
+│   └── docs/        Storybook (ready for component docs)
+└── [root configs]   turbo.json, pnpm-workspace.yaml, package.json
+
+WHAT TO CREATE:
+
+1. MONOREPO SCAFFOLDING
+   - Root package.json with scripts: dev, build, lint, clean
+   - pnpm-workspace.yaml defining packages/*, apps/*
+   - turbo.json with tasks for build (with dependsOn) and dev
+   - .gitignore for node_modules, dist, build, .next, .turbo
+
+2. TOKENS PACKAGE (@myapp/tokens)
+   - Style Dictionary config generating CSS vars and JS exports
+   - MINIMAL starter tokens (4 grays, 4 spacing values, 3 font sizes)
+   - README guiding users to add their own brand tokens
+   - package.json with build script
+   - Do NOT create extensive color palettes or spacing scales
+
+3. CONFIG PACKAGE (@myapp/config)
+   - tsconfig/base.json (strict TypeScript)
+   - tsconfig/react.json (extends base, adds DOM)
+   - tsconfig/nextjs.json (extends react)
+   - tailwind.config.js (base config for users to extend)
+   - No build step needed
+
+4. UI PACKAGE (@myapp/ui)
+   - src/lib/utils.ts with cn() utility (clsx + tailwind-merge)
+   - src/components/Button.tsx ONLY (demonstrates CVA pattern)
+     * 2 variants: primary, secondary
+     * 2 sizes: sm, md
+     * Uses forwardRef, full TypeScript types
+   - src/index.tsx exporting Button and cn
+   - README with detailed guide on adding new components
+   - Do NOT create Input, Card, Badge, Avatar, etc.
+   - Users will create components as they need them
+
+5. WEB APP (@myapp/web)
+   - Next.js 14 with App Router
+   - next.config.js with transpilePackages: ['@myapp/ui', '@myapp/tokens']
+   - tailwind.config.js with content: ['./src/**/*.tsx', '../../packages/ui/src/**/*.tsx']
+   - app/globals.css importing token CSS before Tailwind
+   - app/page.tsx showing Button variants only
+   - components/README.md explaining Layer 4 (app components) pattern
+   - Do NOT create pre-built app components
+
+6. DOCS APP (@myapp/docs)
+   - Storybook 7 with Vite
+   - stories/Button.stories.tsx with CSF 3 format
+   - stories/README.md explaining how to add stories
+   - Do NOT create stories for components that don't exist
+
+7. COMPREHENSIVE DOCUMENTATION
+   - Root README.md:
+     * 5-layer architecture diagram
+     * Getting started (install, build tokens, run dev)
+     * Project structure
+     * Links to package READMEs
+   - CONTRIBUTING.md:
+     * Architecture principles (5-layer model)
+     * When to create tokens vs primitives vs app components
+     * "Don't over-abstract" guidance
+     * Component development workflow
+   - Each package has README with extension guides
+
+CRITICAL CONFIGURATIONS:
+
+UI Package:
+- dependencies: @myapp/tokens, CVA, clsx, tailwind-merge
+- devDependencies: @myapp/config, react, tailwindcss, typescript
+- peerDependencies: react ^18.2.0
+
+Web App:
+- MUST transpile @myapp/ui and @myapp/tokens in next.config.js
+- MUST include UI package in Tailwind content paths
+- MUST import token CSS before Tailwind in globals.css
+
+All Packages:
+- Use workspace:* for internal dependencies
+- TypeScript strict mode enabled
+- Follow 5-layer architecture principles
+
+VALIDATION:
+After creation, verify:
+✓ pnpm install succeeds
+✓ pnpm --filter @myapp/tokens build generates CSS and JS
+✓ pnpm --filter @myapp/web dev starts on :3000
+✓ pnpm --filter @myapp/docs dev starts on :6006
+✓ pnpm dev runs both apps concurrently
+✓ Button component renders with Tailwind styles
+✓ Only Button component exists (not 20 components)
+✓ READMEs guide extension, don't prescribe implementation
+
+WHAT NOT TO DO:
+❌ Do NOT create Input, Card, Badge, Avatar components
+❌ Do NOT generate extensive token values (leave for users)
+❌ Do NOT create app-specific business logic
+❌ Do NOT make design decisions (colors, spacing)
+❌ Do NOT create form patterns or validation
+❌ Do NOT add auth/API integration examples
+
+WHY THIS APPROACH:
+Every app is different. Creating a bloated library wastes tokens and creates
+components users won't use. Instead, create a solid foundation with ONE example
+(Button) showing the pattern. Users extend it as needed for their app.
+
+START IMPLEMENTATION:
+Begin with Phase 1 (monorepo scaffolding) from BOOTSTRAP_GUIDE.md.
+Follow all phases sequentially. Test each phase before proceeding.
+```
+
+---
+
+## What You'll Get
+
+A **minimal, production-ready foundation** with:
+
+1. ✅ Working monorepo (Turborepo + pnpm)
+2. ✅ Token transformation pipeline (Style Dictionary)
+3. ✅ Button component demonstrating CVA pattern
+4. ✅ Next.js app consuming the UI package
+5. ✅ Storybook ready for documentation
+6. ✅ Comprehensive guides for extension
+7. ✅ 5-layer architecture documented
+
+**Not included** (users add as needed):
+- Additional components (Input, Card, etc.)
+- Extensive design tokens
+- Form patterns
+- Business logic
+- API integrations
+
+---
+
+## After Initialization
+
+### 1. Customize Design Tokens
+```bash
+# Edit starter tokens
+vim packages/tokens/src/colors.json
+vim packages/tokens/src/spacing.json
+vim packages/tokens/src/typography.json
+
+# Rebuild
+pnpm --filter @myapp/tokens build
+```
+
+### 2. Add Components as Needed
+```bash
+# Create Input component following Button pattern
+# packages/ui/src/components/Input.tsx
+
+# Export from index
+# packages/ui/src/index.tsx
+
+# Document in Storybook
+# apps/docs/stories/Input.stories.tsx
+```
+
+### 3. Build App Components
+```bash
+# Create business-specific components
+# apps/web/components/UserCard.tsx
+# apps/web/components/ProductList.tsx
+
+# These use UI primitives but have business logic
+```
+
+---
+
+## Time Estimate
+
+- **AI Agent**: 3-5 minutes
+- **Human Following Guide**: 30-45 minutes
+
+---
+
+## Architecture Reference
+
+```
+Layer 5: Pages (apps/web/app/)
+         Route handlers and full pages
+
+Layer 4: App Components (apps/web/components/)
+         Business logic, domain knowledge
+         Example: UserCard, CheckoutSummary
+
+Layer 3: Pattern Components (packages/ui/ - complex)
+         Reusable patterns, no business logic
+         Example: DataTable, Modal
+         (Start empty, add as needed)
+
+Layer 2: Primitive Components (packages/ui/ - basic)
+         Generic UI elements, no business logic
+         Example: Button (provided)
+         Add: Input, Card, Badge as needed
+
+Layer 1: Design Tokens (packages/tokens/)
+         Single source of truth
+         Minimal starters (customize to your brand)
+```
+
+**Key Rule**: Lower layers never import from higher layers.
+
+---
+
+## Extension Guides
+
+After scaffolding, see these guides:
+
+- **Add Tokens**: `packages/tokens/README.md`
+- **Add UI Components**: `packages/ui/README.md`
+- **Add App Components**: `apps/web/src/components/README.md`
+- **Document Components**: `apps/docs/stories/README.md`
+- **Architecture Principles**: `CONTRIBUTING.md`
+
+---
+
+## Troubleshooting
+
+**Styles not applying:**
+- Check Tailwind content includes `../../packages/ui/src/**/*.tsx`
+- Verify globals.css imports tokens before Tailwind
+- Confirm next.config.js transpiles packages
+
+**Build fails:**
+- Run `pnpm --filter @myapp/tokens build` first
+- Clear cache: `rm -rf .turbo`
+- Reinstall: `pnpm clean && pnpm install`
+
+**Type errors:**
+- Check workspace:* dependencies resolve
+- Verify TypeScript configs extend correctly
+- Ensure strict mode is enabled
+
+---
+
+## Comparison: Before vs After
+
+### ❌ Old Approach (Bloated)
+```
+packages/ui/src/components/
+├── Button.tsx (6 variants, 4 sizes)
+├── Input.tsx (with validation)
+├── Card.tsx (compound components)
+├── Badge.tsx (6 variants)
+├── Avatar.tsx (5 sizes, fallbacks)
+├── Select.tsx (dropdown logic)
+├── Modal.tsx (portal, focus trap)
+├── Table.tsx (sorting, pagination)
+├── Toast.tsx (queue management)
+├── Tooltip.tsx (positioning)
+... 20+ more components
+```
+
+**Problems:**
+- 80% unused in typical app
+- Makes assumptions about use cases
+- Increases bundle size
+- Harder to customize
+- Forces design decisions
+
+### ✅ New Approach (Scaffold)
+```
+packages/ui/src/components/
+└── Button.tsx (demonstrates pattern)
+
++ READMEs explaining how to add:
+  - Input (when you need forms)
+  - Card (when you need containers)
+  - Badge (when you need labels)
+  - etc.
+```
+
+**Benefits:**
+- Start small, grow as needed
+- No unused code
+- Users make design decisions
+- Faster setup
+- Clear patterns to follow
+
+---
+
+## Real-World Usage
+
+### Startup Building MVP
+```bash
+# Day 1: Initialize
+pnpm create design-system my-app
+
+# Day 2-3: Add tokens matching brand
+# Edit colors, spacing, typography
+
+# Week 1: Add 5 components as needed
+# Button (provided), Input, Card, Badge, Avatar
+
+# Month 1: 10-15 components total
+# Only what the app actually uses
+```
+
+### Enterprise Design System Team
+```bash
+# Sprint 1: Initialize foundation
+# Sprint 2: Define comprehensive tokens
+# Sprint 3-6: Build components iteratively
+# Sprint 7+: Add pattern components (forms, tables)
+
+# Result: 30-50 components built over time
+# Each validated by real use cases
+```
+
+---
+
+## Success Metrics
+
+After using this approach, you should have:
+
+1. ✅ **Clean foundation** in minutes, not hours
+2. ✅ **Clear patterns** to follow for new components
+3. ✅ **No unused code** in your bundles
+4. ✅ **Design control** (you choose colors, spacing)
+5. ✅ **Architecture understanding** (5-layer model)
+6. ✅ **Fast onboarding** (guides, not guesswork)
+
+---
+
+## Related Files
+
+- `BOOTSTRAP_GUIDE.md` - Detailed phase-by-phase guide
+- `/chapters/` - Full design systems course
+- `/references/cal.com` - Real-world monorepo example
+- `/references/supabase` - Production design system example
+
+---
+
+## Feedback
+
+Found issues or have suggestions? The scaffolding approach is intentionally
+minimal. If you find yourself needing a component repeatedly, that's a good
+signal it belongs in the guide as an example or reference.
+
+---
+
+**Version**: 2.0.0 (Scaffold-focused)
+**Last Updated**: 2025-12-10
+**Philosophy**: Give them the tools, not the toolbox
+**Course**: Design Systems - Tallinn v2

--- a/app-starter-kit/BOOTSTRAP_GUIDE.md
+++ b/app-starter-kit/BOOTSTRAP_GUIDE.md
@@ -1,0 +1,1213 @@
+# Design System Bootstrap Guide
+
+This guide enables AI coding agents to scaffold a production-ready design system foundation. The agent creates the architecture and structure, then guides users to implement components specific to their application needs.
+
+---
+
+## Philosophy: Scaffold, Don't Prescribe
+
+**What AI Agents Should Do:**
+- ✅ Create monorepo structure and configuration
+- ✅ Set up build tools and workflows
+- ✅ Establish token system foundation
+- ✅ Create 1-2 example components demonstrating patterns
+- ✅ Generate clear documentation for extending the system
+
+**What AI Agents Should NOT Do:**
+- ❌ Generate dozens of pre-built components
+- ❌ Make design decisions (colors, spacing values)
+- ❌ Create business logic or app-specific components
+- ❌ Prescribe exact styling or variants
+
+**Why:** Every app is different. The agent should create a foundation that makes it easy to add components as needed, not a bloated library of unused code.
+
+---
+
+## Quick Start for AI Agents
+
+```
+Initialize a design system monorepo foundation:
+
+ARCHITECTURE: 5-layer design system (tokens → primitives → patterns → app components → pages)
+TECH STACK: React + TypeScript + Tailwind CSS + Turborepo + pnpm
+APPROACH: Scaffold structure, create example components, guide user to extend
+
+Phases:
+1. Monorepo scaffolding (structure + build configs)
+2. Token system foundation (starter tokens + Style Dictionary pipeline)
+3. UI package skeleton (with Button example showing CVA pattern)
+4. Web app skeleton (demonstrating UI consumption)
+5. Storybook setup (ready to document new components)
+6. Developer guide (how to add components, tokens, apps)
+
+Focus on extensible foundations, not comprehensive libraries.
+```
+
+---
+
+## Phase 1: Monorepo Scaffolding
+
+### Objective
+Create the workspace structure and build orchestration.
+
+### What to Create
+
+**Directory Structure:**
+```
+design-system/
+├── packages/
+│   ├── tokens/          # Design tokens (JSON → CSS/JS)
+│   ├── ui/              # Component library
+│   └── config/          # Shared configs (TypeScript, Tailwind, ESLint)
+├── apps/
+│   ├── web/             # Example Next.js app
+│   └── docs/            # Storybook documentation
+├── .gitignore
+├── package.json         # Root workspace config
+├── pnpm-workspace.yaml  # Workspace packages
+├── turbo.json           # Build orchestration
+└── README.md            # Getting started guide
+```
+
+**Root Configuration Files:**
+
+`package.json`:
+```json
+{
+  "name": "design-system",
+  "private": true,
+  "packageManager": "pnpm@8.15.0",
+  "scripts": {
+    "dev": "turbo dev",
+    "build": "turbo build",
+    "lint": "turbo lint",
+    "clean": "turbo clean && rm -rf node_modules"
+  },
+  "devDependencies": {
+    "turbo": "^2.0.0",
+    "prettier": "^3.0.0",
+    "typescript": "^5.0.0"
+  }
+}
+```
+
+`pnpm-workspace.yaml`:
+```yaml
+packages:
+  - 'packages/*'
+  - 'apps/*'
+```
+
+`turbo.json`:
+```json
+{
+  "$schema": "https://turbo.build/schema.json",
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**", ".next/**", "build/**", "storybook-static/**"]
+    },
+    "dev": {
+      "cache": false,
+      "persistent": true
+    },
+    "lint": {
+      "dependsOn": ["^lint"]
+    }
+  }
+}
+```
+
+`.gitignore`:
+```
+node_modules/
+dist/
+build/
+.next/
+.turbo/
+storybook-static/
+*.log
+.DS_Store
+.env*.local
+```
+
+### Validation
+- [ ] `pnpm install` completes successfully
+- [ ] Directory structure matches specification
+- [ ] All config files are valid JSON/YAML
+
+---
+
+## Phase 2: Design Tokens Foundation
+
+### Objective
+Set up Style Dictionary to transform design tokens from JSON to multiple formats.
+
+### What to Create
+
+**Package Structure:**
+```
+packages/tokens/
+├── src/
+│   ├── colors.json      # Color palette (user will customize)
+│   ├── spacing.json     # Spacing scale (user will customize)
+│   ├── typography.json  # Font settings (user will customize)
+│   └── README.md        # Guide on adding/modifying tokens
+├── build/               # Generated (gitignored)
+├── package.json
+└── style-dictionary.config.js
+```
+
+**Key Files:**
+
+`package.json`:
+```json
+{
+  "name": "@myapp/tokens",
+  "version": "0.0.0",
+  "private": true,
+  "main": "build/js/tokens.js",
+  "types": "build/js/tokens.d.ts",
+  "scripts": {
+    "build": "style-dictionary build",
+    "clean": "rm -rf build"
+  },
+  "devDependencies": {
+    "style-dictionary": "^4.0.0"
+  }
+}
+```
+
+`style-dictionary.config.js`:
+```javascript
+module.exports = {
+  source: ['src/**/*.json'],
+  platforms: {
+    css: {
+      transformGroup: 'css',
+      buildPath: 'build/css/',
+      files: [{
+        destination: 'variables.css',
+        format: 'css/variables'
+      }]
+    },
+    js: {
+      transformGroup: 'js',
+      buildPath: 'build/js/',
+      files: [
+        { destination: 'tokens.js', format: 'javascript/es6' },
+        { destination: 'tokens.d.ts', format: 'typescript/es6-declarations' }
+      ]
+    }
+  }
+};
+```
+
+**Starter Token Files (Minimal):**
+
+`src/colors.json` - Provide basic grayscale:
+```json
+{
+  "color": {
+    "gray": {
+      "50": { "value": "#F9FAFB" },
+      "100": { "value": "#F3F4F6" },
+      "500": { "value": "#6B7280" },
+      "900": { "value": "#111827" }
+    }
+  }
+}
+```
+
+`src/spacing.json` - Basic scale:
+```json
+{
+  "spacing": {
+    "1": { "value": "0.25rem" },
+    "2": { "value": "0.5rem" },
+    "4": { "value": "1rem" },
+    "8": { "value": "2rem" }
+  }
+}
+```
+
+`src/typography.json` - System fonts:
+```json
+{
+  "font": {
+    "family": {
+      "sans": { "value": "system-ui, sans-serif" }
+    },
+    "size": {
+      "sm": { "value": "0.875rem" },
+      "base": { "value": "1rem" },
+      "lg": { "value": "1.125rem" }
+    }
+  }
+}
+```
+
+**src/README.md** - Guide users:
+```markdown
+# Design Tokens
+
+## Adding New Tokens
+
+1. Edit JSON files in `src/`
+2. Run `pnpm build` to regenerate outputs
+3. Tokens are available as CSS variables and JS exports
+
+## Examples
+
+### Adding a Color
+```json
+{
+  "color": {
+    "brand": {
+      "primary": { "value": "#3B82F6" }
+    }
+  }
+}
+```
+
+Generates:
+- CSS: `--color-brand-primary: #3B82F6;`
+- JS: `export const colorBrandPrimary = '#3B82F6';`
+
+### Adding Spacing
+Use rem units for responsive sizing.
+
+### Platform Extensions
+To add iOS/Android outputs, extend `style-dictionary.config.js` platforms.
+```
+
+### Validation
+- [ ] `pnpm --filter @myapp/tokens build` succeeds
+- [ ] Generates `build/css/variables.css` with CSS variables
+- [ ] Generates `build/js/tokens.js` with JS exports
+
+---
+
+## Phase 3: Shared Config Package
+
+### Objective
+Create reusable TypeScript and Tailwind configurations.
+
+### What to Create
+
+```
+packages/config/
+├── tsconfig/
+│   ├── base.json
+│   ├── react.json
+│   └── nextjs.json
+├── tailwind.config.js
+├── package.json
+└── README.md
+```
+
+**Key Configs:**
+
+`tsconfig/base.json` - Foundation:
+```json
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  }
+}
+```
+
+`tsconfig/react.json` - Extends base:
+```json
+{
+  "extends": "./base.json",
+  "compilerOptions": {
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx"
+  }
+}
+```
+
+`tailwind.config.js` - Base configuration (users extend):
+```javascript
+module.exports = {
+  theme: {
+    extend: {
+      // Users will extend with their token values
+    }
+  }
+};
+```
+
+### Validation
+- [ ] Config files are valid JSON
+- [ ] No build step needed (pure config)
+
+---
+
+## Phase 4: UI Package Skeleton
+
+### Objective
+Create component library structure with ONE example component showing the pattern.
+
+### What to Create
+
+```
+packages/ui/
+├── src/
+│   ├── components/
+│   │   └── Button.tsx       # Example component
+│   ├── lib/
+│   │   └── utils.ts         # cn() utility
+│   └── index.tsx            # Exports
+├── package.json
+├── tsconfig.json
+├── tailwind.config.js
+└── README.md                # Guide on adding components
+```
+
+**package.json** - Dependencies:
+```json
+{
+  "name": "@myapp/ui",
+  "version": "0.0.0",
+  "private": true,
+  "main": "src/index.tsx",
+  "dependencies": {
+    "@myapp/tokens": "workspace:*",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.0.0",
+    "tailwind-merge": "^2.0.0"
+  },
+  "devDependencies": {
+    "@myapp/config": "workspace:*",
+    "@types/react": "^18.2.0",
+    "react": "^18.2.0",
+    "tailwindcss": "^3.4.0",
+    "typescript": "^5.0.0"
+  },
+  "peerDependencies": {
+    "react": "^18.2.0"
+  }
+}
+```
+
+**src/lib/utils.ts** - Essential utility:
+```typescript
+import { type ClassValue, clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}
+```
+
+**src/components/Button.tsx** - Example showing CVA pattern:
+```typescript
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '../lib/utils';
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center rounded-md font-medium transition-colors',
+  {
+    variants: {
+      variant: {
+        primary: 'bg-gray-900 text-white hover:bg-gray-800',
+        secondary: 'bg-gray-100 text-gray-900 hover:bg-gray-200'
+      },
+      size: {
+        sm: 'h-8 px-3 text-sm',
+        md: 'h-10 px-4'
+      }
+    },
+    defaultVariants: {
+      variant: 'primary',
+      size: 'md'
+    }
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {}
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, ...props }, ref) => {
+    return (
+      <button
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = 'Button';
+```
+
+**src/index.tsx**:
+```typescript
+export { Button, type ButtonProps } from './components/Button';
+export { cn } from './lib/utils';
+```
+
+**README.md** - Component development guide:
+```markdown
+# UI Components
+
+## Architecture
+
+This package contains **primitive components** (Layer 2) - reusable UI building blocks with no business logic.
+
+## Adding a New Component
+
+### 1. Create Component File
+Create `src/components/YourComponent.tsx`:
+
+```typescript
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '../lib/utils';
+
+const yourComponentVariants = cva(
+  'base-classes-always-applied',
+  {
+    variants: {
+      variant: {
+        default: 'variant-specific-classes',
+        // Add more variants
+      },
+      size: {
+        sm: 'size-specific-classes',
+        md: 'size-specific-classes'
+      }
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'md'
+    }
+  }
+);
+
+export interface YourComponentProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof yourComponentVariants> {}
+
+export const YourComponent = React.forwardRef<HTMLDivElement, YourComponentProps>(
+  ({ className, variant, size, ...props }, ref) => {
+    return (
+      <div
+        className={cn(yourComponentVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+YourComponent.displayName = 'YourComponent';
+```
+
+### 2. Export from Index
+Add to `src/index.tsx`:
+```typescript
+export { YourComponent, type YourComponentProps } from './components/YourComponent';
+```
+
+### 3. Create Story
+Add `stories/YourComponent.stories.tsx` in docs app.
+
+## Component Patterns
+
+### Using forwardRef
+All interactive components should use `React.forwardRef` for ref forwarding.
+
+### Using CVA (Class Variance Authority)
+CVA provides type-safe variant management. Define variants in `cva()`, use with props.
+
+### Using cn() Utility
+Merge Tailwind classes safely: `cn(baseClasses, conditionalClasses, className)`.
+
+## What Belongs Here
+
+✅ Buttons, Inputs, Cards, Badges, Avatars (no business logic)
+✅ Layout components (Container, Stack, Grid)
+✅ Feedback components (Alert, Toast, Spinner)
+
+❌ User-specific components (UserCard, ProductCard) - these go in apps/
+❌ Forms with validation - these go in apps/
+❌ API-connected components - these go in apps/
+```
+
+### Validation
+- [ ] Button component exports and has types
+- [ ] cn() utility works
+- [ ] No TypeScript errors
+
+---
+
+## Phase 5: Web Application Skeleton
+
+### Objective
+Create a Next.js app demonstrating how to consume the UI library.
+
+### What to Create
+
+```
+apps/web/
+├── src/
+│   ├── app/
+│   │   ├── layout.tsx
+│   │   ├── page.tsx         # Examples using Button
+│   │   └── globals.css
+│   ├── components/          # Layer 4 (app-specific) - empty for now
+│   └── types/
+│       └── index.ts
+├── package.json
+├── next.config.js
+├── tsconfig.json
+└── tailwind.config.js
+```
+
+**package.json**:
+```json
+{
+  "name": "@myapp/web",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "@myapp/ui": "workspace:*",
+    "@myapp/tokens": "workspace:*",
+    "next": "^14.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@myapp/config": "workspace:*",
+    "@types/node": "^20.0.0",
+    "@types/react": "^18.2.0",
+    "autoprefixer": "^10.4.0",
+    "postcss": "^8.4.0",
+    "tailwindcss": "^3.4.0",
+    "typescript": "^5.0.0"
+  }
+}
+```
+
+**next.config.js** - Critical for monorepo:
+```javascript
+module.exports = {
+  transpilePackages: ['@myapp/ui', '@myapp/tokens']
+};
+```
+
+**tailwind.config.js** - Must include UI package:
+```javascript
+const baseConfig = require('@myapp/config/tailwind.config.js');
+
+module.exports = {
+  ...baseConfig,
+  content: [
+    './src/**/*.{js,ts,jsx,tsx,mdx}',
+    '../../packages/ui/src/**/*.{ts,tsx}'  // Critical!
+  ]
+};
+```
+
+**src/app/globals.css**:
+```css
+@import '@myapp/tokens/build/css/variables.css';
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+```
+
+**src/app/page.tsx** - Simple example:
+```typescript
+import { Button } from '@myapp/ui';
+
+export default function Home() {
+  return (
+    <main className="min-h-screen p-8">
+      <h1 className="text-2xl font-bold mb-4">Design System Demo</h1>
+      <div className="flex gap-2">
+        <Button variant="primary">Primary</Button>
+        <Button variant="secondary">Secondary</Button>
+      </div>
+    </main>
+  );
+}
+```
+
+**src/components/README.md** - Guide on app components:
+```markdown
+# App Components (Layer 4)
+
+This directory contains **app-specific components** that:
+- Have business logic
+- Know about your data models (User, Product, etc.)
+- Compose primitives from @myapp/ui
+- Should NOT be moved to packages/ui
+
+## Example: UserCard
+
+```typescript
+import { Card, Avatar, Badge, Button } from '@myapp/ui';
+import type { User } from '@/types';
+
+interface UserCardProps {
+  user: User;
+  onEdit?: (user: User) => void;
+}
+
+export function UserCard({ user, onEdit }: UserCardProps) {
+  return (
+    <Card>
+      <Avatar src={user.avatar} alt={user.name} />
+      <h3>{user.name}</h3>
+      <Badge>{user.role}</Badge>
+      {onEdit && <Button onClick={() => onEdit(user)}>Edit</Button>}
+    </Card>
+  );
+}
+```
+
+## When to Create App Components
+
+Create components here when they:
+1. Use your specific types (User, Product, Order)
+2. Make API calls
+3. Have business rules (e.g., admins can't be deleted)
+4. Are specific to this application
+
+## Don't Over-Abstract
+
+If you're only using a component in one place, keep it simple:
+- Don't add variants you don't need
+- Don't make it configurable if it doesn't need to be
+- Inline small components in pages if appropriate
+```
+
+### Validation
+- [ ] `pnpm --filter @myapp/web dev` starts successfully
+- [ ] App loads at localhost:3000
+- [ ] Buttons render with Tailwind styles
+
+---
+
+## Phase 6: Storybook Setup
+
+### Objective
+Create documentation site ready to document components.
+
+### What to Create
+
+```
+apps/docs/
+├── .storybook/
+│   ├── main.ts
+│   └── preview.ts
+├── stories/
+│   └── Button.stories.tsx   # Example for Button
+├── src/
+│   └── styles.css
+├── package.json
+└── tailwind.config.js
+```
+
+**package.json**:
+```json
+{
+  "name": "@myapp/docs",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "storybook dev -p 6006",
+    "build": "storybook build"
+  },
+  "dependencies": {
+    "@myapp/ui": "workspace:*",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@storybook/addon-essentials": "^7.5.0",
+    "@storybook/react": "^7.5.0",
+    "@storybook/react-vite": "^7.5.0",
+    "storybook": "^7.5.0",
+    "tailwindcss": "^3.4.0",
+    "vite": "^5.0.0"
+  }
+}
+```
+
+**.storybook/main.ts**:
+```typescript
+import type { StorybookConfig } from '@storybook/react-vite';
+
+const config: StorybookConfig = {
+  stories: ['../stories/**/*.stories.@(js|jsx|ts|tsx)'],
+  addons: ['@storybook/addon-essentials'],
+  framework: { name: '@storybook/react-vite', options: {} },
+  docs: { autodocs: 'tag' }
+};
+
+export default config;
+```
+
+**stories/Button.stories.tsx** - Example:
+```typescript
+import type { Meta, StoryObj } from '@storybook/react';
+import { Button } from '@myapp/ui';
+
+const meta: Meta<typeof Button> = {
+  title: 'Components/Button',
+  component: Button,
+  tags: ['autodocs']
+};
+
+export default meta;
+type Story = StoryObj<typeof Button>;
+
+export const Primary: Story = {
+  args: { children: 'Button', variant: 'primary' }
+};
+
+export const Secondary: Story = {
+  args: { children: 'Button', variant: 'secondary' }
+};
+```
+
+**stories/README.md** - Guide on documentation:
+```markdown
+# Storybook Documentation
+
+## Adding Stories for New Components
+
+When you add a component to @myapp/ui, create a story:
+
+1. Create `stories/YourComponent.stories.tsx`
+2. Import component from @myapp/ui
+3. Define stories showing different states
+
+## Story Template
+
+```typescript
+import type { Meta, StoryObj } from '@storybook/react';
+import { YourComponent } from '@myapp/ui';
+
+const meta: Meta<typeof YourComponent> = {
+  title: 'Components/YourComponent',
+  component: YourComponent,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: { control: 'select', options: ['default', 'other'] }
+  }
+};
+
+export default meta;
+type Story = StoryObj<typeof YourComponent>;
+
+export const Default: Story = {
+  args: { children: 'Content' }
+};
+```
+
+## Running Storybook
+
+```bash
+pnpm --filter @myapp/docs dev
+```
+
+Visit http://localhost:6006
+```
+
+### Validation
+- [ ] `pnpm --filter @myapp/docs dev` starts Storybook
+- [ ] Button stories render correctly
+- [ ] Controls work in Storybook
+
+---
+
+## Phase 7: Developer Documentation
+
+### Objective
+Create comprehensive guides for extending the system.
+
+### What to Create
+
+**Root README.md** - Overview:
+```markdown
+# Design System
+
+Production-ready design system monorepo built with React, TypeScript, and Tailwind CSS.
+
+## Architecture
+
+5-layer design system:
+```
+Layer 5: Pages/Views          apps/web/app/
+Layer 4: App Components       apps/web/components/
+Layer 3: Pattern Components   packages/ui/ (complex)
+Layer 2: Primitive Components packages/ui/ (basic)
+Layer 1: Design Tokens        packages/tokens/
+```
+
+## Getting Started
+
+### Prerequisites
+- Node.js 18+
+- pnpm 8+
+
+### Installation
+
+```bash
+# Install dependencies
+pnpm install
+
+# Build tokens (required first)
+pnpm --filter @myapp/tokens build
+
+# Start all apps
+pnpm dev
+```
+
+This starts:
+- Web app: http://localhost:3000
+- Storybook: http://localhost:6006
+
+## Project Structure
+
+```
+design-system/
+├── packages/
+│   ├── tokens/    # Design tokens (colors, spacing, typography)
+│   ├── ui/        # Reusable components (Button, Input, Card)
+│   └── config/    # Shared configs (TypeScript, Tailwind)
+├── apps/
+│   ├── web/       # Next.js application
+│   └── docs/      # Storybook documentation
+└── turbo.json     # Monorepo build orchestration
+```
+
+## Common Tasks
+
+### Adding a Design Token
+
+1. Edit `packages/tokens/src/*.json`
+2. Run `pnpm --filter @myapp/tokens build`
+3. Tokens available as CSS variables and JS exports
+
+[See packages/tokens/README.md](packages/tokens/README.md)
+
+### Adding a UI Component
+
+1. Create `packages/ui/src/components/YourComponent.tsx`
+2. Export from `packages/ui/src/index.tsx`
+3. Create story in `apps/docs/stories/YourComponent.stories.tsx`
+
+[See packages/ui/README.md](packages/ui/README.md)
+
+### Adding an App Component
+
+1. Create `apps/web/components/YourAppComponent.tsx`
+2. Import UI primitives: `import { Button } from '@myapp/ui'`
+3. Add business logic specific to your app
+
+[See apps/web/src/components/README.md](apps/web/src/components/README.md)
+
+## Development Workflow
+
+```bash
+# Start development servers
+pnpm dev
+
+# Build all packages
+pnpm build
+
+# Lint all packages
+pnpm lint
+
+# Clean build artifacts
+pnpm clean
+```
+
+## Package Dependencies
+
+```
+@myapp/web
+  ├── @myapp/ui
+  │   └── @myapp/tokens
+  └── @myapp/config
+
+@myapp/docs
+  └── @myapp/ui
+      └── @myapp/tokens
+```
+
+## Learn More
+
+- [Design Tokens Guide](packages/tokens/README.md)
+- [Component Development Guide](packages/ui/README.md)
+- [App Component Guide](apps/web/src/components/README.md)
+- [Storybook Guide](apps/docs/stories/README.md)
+
+## Customization
+
+This scaffold is intentionally minimal. Extend it by:
+- Adding more design tokens (colors, shadows, borders)
+- Creating components as you need them
+- Adding more apps (mobile, admin, marketing)
+- Adding pattern components (forms, tables, modals)
+```
+
+**CONTRIBUTING.md** - Development guide:
+```markdown
+# Contributing Guide
+
+## Architecture Principles
+
+### The 5-Layer Model
+
+**Layer 1: Design Tokens** (packages/tokens/)
+- Pure data, no code
+- Single source of truth for design decisions
+- Multi-platform output (web, mobile)
+
+**Layer 2: Primitive Components** (packages/ui/)
+- Reusable, generic UI elements
+- No business logic
+- Examples: Button, Input, Card
+- Can be used in any context
+
+**Layer 3: Pattern Components** (packages/ui/)
+- Complex components combining primitives
+- Reusable patterns, no business logic
+- Examples: DataTable, Modal, Dropdown
+
+**Layer 4: App Components** (apps/*/components/)
+- Application-specific components
+- Have business logic and domain knowledge
+- Examples: UserCard, ProductList
+- Compose primitives from Layer 2
+
+**Layer 5: Pages/Views** (apps/*/app/)
+- Full pages and routes
+- Compose app components from Layer 4
+
+### Key Rules
+
+1. **Lower layers never import from higher layers**
+2. **App components stay in apps/, not packages/**
+3. **No business logic in packages/ui**
+4. **Tokens are always JSON, never TypeScript**
+
+## When to Create What
+
+### Create a Design Token When:
+- You need a consistent value across multiple components
+- The value might need to change for theming
+- Example: colors, spacing, font sizes
+
+### Create a Primitive Component When:
+- It's a generic UI element with no business logic
+- It could be used in multiple apps or contexts
+- You'll use it more than once
+- Example: Button, Input, Badge
+
+### Create a Pattern Component When:
+- You need to combine multiple primitives in a reusable way
+- The pattern is generic enough for multiple contexts
+- Example: SearchableSelect, DataTable, ConfirmModal
+
+### Create an App Component When:
+- It's specific to your application domain
+- It has business logic or rules
+- It uses your data types (User, Product, etc.)
+- Example: UserProfileCard, CheckoutSummary
+
+### Keep in Page When:
+- It's only used on one page
+- It's simple enough to not need abstraction
+- Moving it would make code harder to understand
+
+## Component Development Workflow
+
+1. **Start simple**: Create component in the page where you need it
+2. **Identify reusability**: Used in 2+ places? Consider extraction
+3. **Remove business logic**: Strip domain knowledge for primitives
+4. **Add to UI package**: Move to packages/ui if generic enough
+5. **Document**: Create Storybook story
+6. **Test**: Ensure works in different contexts
+
+## Don't Over-Abstract
+
+Common mistakes:
+- Creating reusable components too early
+- Adding configuration for hypothetical use cases
+- Moving app-specific logic to UI package
+- Creating wrappers for single-use patterns
+
+Better approach:
+- Wait until you need a component 2-3 times
+- Only add props you actually need
+- Keep business logic in app components
+- Duplicate simple code rather than abstract prematurely
+
+## Performance Considerations
+
+- Turborepo caches builds for fast rebuilds
+- Only packages/tokens needs build step
+- UI package runs in dev mode (no build)
+- Changes to tokens trigger rebuilds
+- Changes to UI trigger hot reloads
+```
+
+### Validation
+- [ ] README explains how to add tokens, components, apps
+- [ ] Each package has its own README
+- [ ] Documentation guides users, doesn't prescribe
+
+---
+
+## Final Validation Checklist
+
+### Structure
+- [ ] Monorepo created with correct folder structure
+- [ ] All package.json files have correct workspace dependencies
+- [ ] Root scripts (dev, build, lint) work
+
+### Tokens
+- [ ] Style Dictionary generates CSS and JS outputs
+- [ ] Starter tokens provided but marked for customization
+- [ ] README explains how to add/modify tokens
+
+### UI Package
+- [ ] Button component demonstrates CVA pattern
+- [ ] cn() utility provided
+- [ ] README explains how to add components
+- [ ] Only 1-2 example components (not dozens)
+
+### Web App
+- [ ] Next.js app runs and displays UI components
+- [ ] Tailwind config includes UI package path
+- [ ] README explains app component pattern
+- [ ] components/ folder has guide, not pre-built components
+
+### Storybook
+- [ ] Storybook runs and shows Button component
+- [ ] README explains how to add stories
+- [ ] Ready to document new components
+
+### Documentation
+- [ ] Root README covers getting started
+- [ ] CONTRIBUTING.md explains architecture
+- [ ] Each package has its own README
+- [ ] Guides focus on "how to extend", not prescriptive components
+
+### Philosophy Adherence
+- [ ] Scaffold created, not comprehensive library
+- [ ] Users guided to create their own components
+- [ ] No more than 2-3 example components
+- [ ] Clear documentation on extending system
+- [ ] No design decisions made (colors, spacing values)
+
+---
+
+## Success Criteria
+
+After initialization, users should have:
+
+1. ✅ **Working monorepo** with build and dev scripts
+2. ✅ **Token pipeline** ready for their design decisions
+3. ✅ **Component pattern** demonstrated (CVA + forwardRef)
+4. ✅ **Clear architecture** (5-layer model documented)
+5. ✅ **Extension guides** for adding tokens, components, apps
+6. ✅ **Minimal but complete** foundation, not bloated library
+
+Users should be able to:
+- Add design tokens matching their brand
+- Create components following the pattern
+- Build app-specific components in apps/
+- Document components in Storybook
+- Understand where code belongs (layers)
+
+---
+
+## What NOT to Include
+
+The agent should explicitly avoid:
+- ❌ Pre-generating 20+ components users may not need
+- ❌ Making design decisions (specific colors, spacing)
+- ❌ Creating app-specific business logic
+- ❌ Complex form validation patterns
+- ❌ API integration examples
+- ❌ Authentication/authorization components
+- ❌ Prescriptive styling (let users choose)
+
+---
+
+## Customization Points
+
+After scaffolding, users customize:
+
+1. **Design Tokens**: Replace starter tokens with brand colors, spacing, typography
+2. **Components**: Add components as needed (Input, Card, Badge, etc.)
+3. **Patterns**: Create pattern components specific to needs (forms, tables)
+4. **Apps**: Add more apps (mobile, admin, marketing sites)
+5. **Build**: Add testing, linting, CI/CD as needed
+
+---
+
+## Quick Reference
+
+### Commands After Setup
+
+```bash
+# Install and build
+pnpm install
+pnpm --filter @myapp/tokens build
+
+# Start everything
+pnpm dev
+
+# Add a token
+# Edit packages/tokens/src/*.json
+pnpm --filter @myapp/tokens build
+
+# Add a UI component
+# Create packages/ui/src/components/NewComponent.tsx
+# Export from packages/ui/src/index.tsx
+# Create apps/docs/stories/NewComponent.stories.tsx
+
+# Add an app component
+# Create apps/web/components/NewAppComponent.tsx
+# Import UI primitives from @myapp/ui
+```
+
+### File Paths Reference
+
+- Tokens: `packages/tokens/src/*.json`
+- UI Components: `packages/ui/src/components/*.tsx`
+- App Components: `apps/web/components/*.tsx`
+- Pages: `apps/web/app/*/page.tsx`
+- Stories: `apps/docs/stories/*.stories.tsx`
+- Shared Configs: `packages/config/`
+
+---
+
+**Version**: 2.0.0 (Scaffold-focused)
+**Last Updated**: 2025-12-10
+**Philosophy**: Scaffold, don't prescribe

--- a/app-starter-kit/README.md
+++ b/app-starter-kit/README.md
@@ -1,0 +1,446 @@
+# App Starter Kit
+
+Bootstrap a new web app with a solid design system foundation using AI coding agents.
+
+## Contents
+
+| File | Purpose |
+|------|---------|
+| `AI_AGENT_PROMPT.md` | Copy-paste prompt for quick initialization |
+| `BOOTSTRAP_GUIDE.md` | Detailed phase-by-phase implementation guide |
+| `README_BOOTSTRAP.md` | Philosophy and architecture overview |
+
+## Quick Decision Guide
+
+| Your Goal | Use This File | How |
+|-----------|---------------|-----|
+| Initialize a new project FAST | `AI_AGENT_PROMPT.md` | Copy prompt → Paste to AI agent |
+| Learn step-by-step with AI assistance | `BOOTSTRAP_GUIDE.md` | Reference each phase during development |
+| Understand the overall approach | `README_BOOTSTRAP.md` | Read for context and philosophy |
+
+---
+
+## Method 1: Quick Initialization (Recommended)
+
+**Best for:** Starting a new project quickly, experienced developers, AI-assisted development
+
+### Steps
+
+1. **Open your AI coding agent** (Claude Code, Cursor, Copilot Chat, etc.)
+
+2. **Navigate to your target directory**
+   ```bash
+   cd /path/to/your/projects
+   mkdir my-app
+   cd my-app
+   ```
+
+3. **Copy the entire prompt** from `AI_AGENT_PROMPT.md` (everything inside the code block under "## The Prompt")
+
+4. **Paste to your AI agent** with a prefix like:
+   ```
+   Please execute the following instructions to bootstrap my new web app:
+
+   [paste prompt here]
+   ```
+
+5. **Wait for completion** (typically 3-5 minutes)
+
+6. **Verify the setup**
+   ```bash
+   pnpm install
+   pnpm --filter @myapp/tokens build
+   pnpm dev
+   ```
+
+7. **Open in browser**
+   - Web app: http://localhost:3000
+   - Storybook: http://localhost:6006
+
+### What You Get
+
+```
+my-app/
+├── packages/
+│   ├── tokens/     # Design tokens (JSON → CSS/JS)
+│   ├── ui/         # Button component + extension guide
+│   └── config/     # Shared TypeScript & Tailwind configs
+├── apps/
+│   ├── web/        # Next.js web app
+│   └── docs/       # Storybook documentation
+└── [configs]       # turbo.json, pnpm-workspace.yaml, etc.
+```
+
+---
+
+## Method 2: Guided Learning
+
+**Best for:** Learning design system concepts, understanding the "why", controlled step-by-step implementation
+
+### Steps
+
+1. **Read the overview** in `README_BOOTSTRAP.md` to understand the philosophy
+
+2. **Start a conversation** with your AI agent:
+   ```
+   I want to build a design system step by step. I have a guide
+   in BOOTSTRAP_GUIDE.md. Let's work through Phase 1 together.
+   Please read BOOTSTRAP_GUIDE.md first.
+   ```
+
+3. **Work through phases** one at a time:
+   - Phase 1: Monorepo Scaffolding
+   - Phase 2: Design Tokens Foundation
+   - Phase 3: Shared Config Package
+   - Phase 4: UI Package Skeleton
+   - Phase 5: Web Application Skeleton
+   - Phase 6: Storybook Setup
+   - Phase 7: Developer Documentation
+
+4. **Validate each phase** before proceeding:
+   ```
+   Let's verify Phase 2 is complete:
+   - Does pnpm --filter @myapp/tokens build succeed?
+   - Are CSS variables generated in build/css/variables.css?
+   - Are JS exports generated in build/js/tokens.js?
+   ```
+
+5. **Ask questions** as you go:
+   ```
+   Why do we use Style Dictionary instead of just writing CSS variables directly?
+   ```
+
+### Benefits
+
+- Deeper understanding of design system architecture
+- Opportunity to customize as you build
+- Learn the 5-layer model through practice
+- Catch issues early in each phase
+
+---
+
+## Method 3: Hybrid Approach
+
+**Best for:** Quick start with selective deep-dives
+
+1. **Initialize quickly** using Method 1 (AI_AGENT_PROMPT.md)
+
+2. **Study specific phases** from BOOTSTRAP_GUIDE.md that interest you:
+   ```
+   I've initialized a design system. Now explain Phase 2 (tokens)
+   in detail. Why did you set up Style Dictionary this way?
+   ```
+
+3. **Reference documentation** when extending:
+   ```
+   I want to add an Input component. Walk me through the process
+   following the patterns in packages/ui/README.md
+   ```
+
+---
+
+## Common Workflows After Setup
+
+### Adding Design Tokens
+
+```bash
+# 1. Edit token files
+vim packages/tokens/src/colors.json
+
+# Example: Add brand color
+{
+  "color": {
+    "brand": {
+      "primary": { "value": "#3B82F6" },
+      "secondary": { "value": "#10B981" }
+    }
+  }
+}
+
+# 2. Rebuild tokens
+pnpm --filter @myapp/tokens build
+
+# 3. Use in components
+# CSS: var(--color-brand-primary)
+# JS: import { colorBrandPrimary } from '@myapp/tokens'
+```
+
+### Adding a UI Component
+
+Ask your AI agent:
+```
+Add an Input component to packages/ui following the Button pattern.
+Use CVA for variants, forwardRef for ref forwarding, and create
+a Storybook story for it.
+```
+
+The agent will:
+1. Create `packages/ui/src/components/Input.tsx`
+2. Export from `packages/ui/src/index.tsx`
+3. Create `apps/docs/stories/Input.stories.tsx`
+
+### Adding an App Component
+
+Ask your AI agent:
+```
+Create a UserCard component in apps/web/components that uses
+Button and displays user name and avatar. This is a Layer 4
+component with business logic.
+```
+
+---
+
+## Best Practices for AI Agent Interaction
+
+### DO
+
+- **Be specific about file locations**
+  ```
+  Create the Input component at packages/ui/src/components/Input.tsx
+  ```
+
+- **Reference the architecture**
+  ```
+  This should be a Layer 2 primitive with no business logic
+  ```
+
+- **Ask for validation**
+  ```
+  After creating, verify Tailwind styles apply correctly
+  ```
+
+- **Request documentation updates**
+  ```
+  Also update the index.tsx exports and create a Storybook story
+  ```
+
+### DON'T
+
+- **Don't ask for too many components at once**
+  ```
+  # Bad: Create Button, Input, Card, Badge, Avatar, Select, Modal...
+  # Good: Create an Input component following the Button pattern
+  ```
+
+- **Don't skip the token build step**
+  ```bash
+  # Always run after token changes
+  pnpm --filter @myapp/tokens build
+  ```
+
+- **Don't put business logic in packages/ui**
+  ```
+  # Bad: A UserCard component in packages/ui
+  # Good: A generic Card in packages/ui, UserCard in apps/web
+  ```
+
+---
+
+## Troubleshooting
+
+### "Styles not applying to components"
+
+```bash
+# Check 1: Tailwind content paths in apps/web/tailwind.config.js
+content: [
+  './src/**/*.{ts,tsx}',
+  '../../packages/ui/src/**/*.{ts,tsx}'  # Must include UI package
+]
+
+# Check 2: CSS import order in apps/web/app/globals.css
+@import '@myapp/tokens/build/css/variables.css';  # Must be first
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+# Check 3: Next.js config includes transpile packages
+# apps/web/next.config.js
+module.exports = {
+  transpilePackages: ['@myapp/ui', '@myapp/tokens']
+};
+```
+
+### "Module not found: @myapp/..."
+
+```bash
+# Clear and reinstall
+pnpm clean
+pnpm install
+
+# Verify workspace dependencies use workspace:*
+# In package.json files:
+"@myapp/ui": "workspace:*"  # Correct
+"@myapp/ui": "^1.0.0"       # Wrong
+```
+
+### "Token build fails"
+
+```bash
+# Check Style Dictionary version
+pnpm --filter @myapp/tokens list style-dictionary
+
+# Verify JSON syntax in token files
+pnpm exec jsonlint packages/tokens/src/colors.json
+```
+
+### "Storybook doesn't show styles"
+
+```bash
+# Check Storybook has Tailwind configured
+# apps/docs/.storybook/preview.ts should import CSS
+import '../src/styles.css';
+
+# Verify styles.css includes Tailwind
+# apps/docs/src/styles.css
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+```
+
+---
+
+## FAQ
+
+### Q: Why only one Button component?
+
+**A:** Every app is different. Instead of generating 20+ components you might not use, we provide one example (Button) that demonstrates the pattern. You add components as you need them, ensuring:
+- No unused code in your bundle
+- Components match your actual needs
+- You understand the pattern through practice
+
+### Q: When should I use packages/ui vs apps/web/components?
+
+**A:** Use this decision tree:
+
+```
+Does the component have business logic (users, products, orders)?
+├── Yes → apps/web/components/ (Layer 4)
+└── No → Is it reusable across multiple apps?
+    ├── Yes → packages/ui/ (Layer 2 or 3)
+    └── No → Keep it in the page that uses it (Layer 5)
+```
+
+### Q: Can I use a different component library (Radix, Shadcn)?
+
+**A:** Yes! The scaffold is flexible. You can:
+1. Replace CVA with Radix primitives
+2. Copy Shadcn components into packages/ui
+3. Mix approaches as needed
+
+Just maintain the layer architecture (tokens → primitives → patterns → app components).
+
+### Q: Should I commit the generated token outputs?
+
+**A:** Usually no. Add to `.gitignore`:
+```
+packages/tokens/build/
+```
+
+Build tokens in CI/CD instead. However, if your team doesn't have CI/CD yet, committing build outputs is acceptable.
+
+### Q: How do I add a new app (mobile, admin)?
+
+```bash
+# 1. Create the app
+mkdir apps/admin
+
+# 2. Initialize (copy web structure or use Next.js create)
+# 3. Add workspace dependencies
+{
+  "name": "@myapp/admin",
+  "dependencies": {
+    "@myapp/ui": "workspace:*",
+    "@myapp/tokens": "workspace:*"
+  }
+}
+
+# 4. Configure Tailwind and Next.js like apps/web
+# 5. Build tokens first, then run
+pnpm --filter @myapp/tokens build
+pnpm --filter @myapp/admin dev
+```
+
+---
+
+## Quick Reference Card
+
+### Initial Setup
+```bash
+# Copy AI_AGENT_PROMPT.md prompt to AI agent, then:
+pnpm install
+pnpm --filter @myapp/tokens build
+pnpm dev
+```
+
+### Daily Development
+```bash
+pnpm dev                              # Start all apps
+pnpm --filter @myapp/web dev          # Start only web app
+pnpm --filter @myapp/docs dev         # Start only Storybook
+```
+
+### Adding Things
+```bash
+# Token: Edit packages/tokens/src/*.json → pnpm --filter @myapp/tokens build
+# UI Component: Create in packages/ui/src/components/ → Export from index.tsx
+# App Component: Create in apps/web/components/
+# Story: Create in apps/docs/stories/
+```
+
+### Building
+```bash
+pnpm build                            # Build everything
+pnpm --filter @myapp/tokens build     # Build only tokens
+pnpm clean                            # Remove all build artifacts
+```
+
+### Key Files
+```
+packages/tokens/src/*.json           # Design tokens
+packages/ui/src/components/*.tsx     # Reusable components
+packages/ui/src/index.tsx            # UI exports
+apps/web/app/page.tsx                # App pages
+apps/web/components/*.tsx            # App-specific components
+apps/docs/stories/*.stories.tsx      # Component documentation
+```
+
+---
+
+## Architecture Overview
+
+```
+Layer 5: Pages/Views (apps/web/app/)
+         Full pages and routes
+
+Layer 4: App Components (apps/web/components/)
+         Business logic, domain knowledge
+         Example: UserCard, CheckoutSummary
+
+Layer 3: Pattern Components (packages/ui/)
+         Complex reusable patterns
+         Example: DataTable, Modal
+         (Add as needed)
+
+Layer 2: Primitive Components (packages/ui/)
+         Generic UI elements
+         Example: Button (provided)
+         Add: Input, Card, Badge as needed
+
+Layer 1: Design Tokens (packages/tokens/)
+         Single source of truth
+         Minimal starters (customize to your brand)
+```
+
+**Key Rule:** Lower layers never import from higher layers.
+
+---
+
+## Philosophy
+
+**Scaffold, don't prescribe.**
+
+We create the foundation and one example component (Button). You add components as your app needs them.
+
+---
+
+Version: 2.0.0 | Course: Design Systems - Tallinn v2

--- a/app-starter-kit/README_BOOTSTRAP.md
+++ b/app-starter-kit/README_BOOTSTRAP.md
@@ -1,0 +1,398 @@
+# Bootstrap Your Design System
+
+Quick links to get started with creating a design system foundation.
+
+---
+
+## 🚀 For AI Coding Agents
+
+**Want to initialize a new design system project?**
+
+👉 **Copy the prompt from [`AI_AGENT_PROMPT.md`](./AI_AGENT_PROMPT.md)**
+
+This gives you:
+- Monorepo foundation (Turborepo + pnpm)
+- Token transformation pipeline (Style Dictionary)
+- Button component showing CVA pattern
+- Next.js app + Storybook ready to go
+- Comprehensive extension guides
+
+**Time: 3-5 minutes for AI agents**
+
+---
+
+## 📚 For Humans
+
+**Want to understand the architecture and build it yourself?**
+
+👉 **Read [`BOOTSTRAP_GUIDE.md`](./BOOTSTRAP_GUIDE.md)**
+
+This explains:
+- 7 implementation phases with exact configs
+- 5-layer architecture principles
+- When to create tokens vs primitives vs app components
+- Common pitfalls and troubleshooting
+- Extension patterns
+
+**Time: 30-45 minutes to follow guide**
+
+---
+
+## 🎯 Philosophy: Scaffold, Don't Prescribe
+
+Unlike typical "component library" tutorials that generate 20+ pre-built components, this approach:
+
+### ✅ What We Create
+- Monorepo structure and build tools
+- Token transformation pipeline
+- **ONE** Button component (demonstrates pattern)
+- Clear guides on adding your own components
+- Documentation on architecture decisions
+
+### ❌ What We Don't Create
+- Dozens of pre-built components you may not need
+- Design decisions (your brand colors, spacing)
+- Business logic or app-specific components
+- Form validation patterns
+- Auth/API integration examples
+
+### 💡 Why This Approach?
+
+**Every app is different.** Creating a bloated component library:
+- Wastes AI tokens generating unused code
+- Makes assumptions about your use cases
+- Forces design decisions you'll override
+- Increases bundle size unnecessarily
+- Makes customization harder
+
+**Instead:** Create a solid foundation with clear patterns, then users extend it with components they actually need.
+
+---
+
+## 📊 Comparison
+
+### Old Approach (Bloated)
+```bash
+packages/ui/src/components/
+├── Button.tsx (6 variants, 4 sizes)
+├── Input.tsx (with validation)
+├── Card.tsx (compound)
+├── Badge.tsx (6 variants)
+├── Avatar.tsx (5 sizes)
+├── Select.tsx
+├── Modal.tsx
+├── Table.tsx
+├── Toast.tsx
+├── Tooltip.tsx
+... 20+ more components
+
+Result: 80% unused, hard to customize
+```
+
+### New Approach (Scaffold)
+```bash
+packages/ui/src/components/
+└── Button.tsx (demonstrates pattern)
+
++ READMEs explaining how to add:
+  - Input (when you need forms)
+  - Card (when you need containers)
+  - etc.
+
+Result: Only what you need, easy to customize
+```
+
+---
+
+## 🏗️ Architecture Overview
+
+```
+Layer 5: Pages/Views (apps/web/app/)
+         Full pages and routes
+
+Layer 4: App Components (apps/web/components/)
+         Business logic, domain knowledge
+         Example: UserCard, CheckoutSummary
+
+Layer 3: Pattern Components (packages/ui/)
+         Complex reusable patterns
+         Example: DataTable, Modal
+         (Add as needed)
+
+Layer 2: Primitive Components (packages/ui/)
+         Generic UI elements
+         Example: Button (provided)
+         Add: Input, Card, Badge as needed
+
+Layer 1: Design Tokens (packages/tokens/)
+         Single source of truth
+         Minimal starters (customize to your brand)
+```
+
+**Key Rule:** Lower layers never import from higher layers.
+
+---
+
+## 🎓 Learning Path
+
+### If You're New to Design Systems
+1. Start with [Chapter 1: Understanding Design Systems](./chapters/01-understanding/)
+2. Learn about [Design Tokens](./chapters/02-design-tokens/)
+3. Explore [Primitive Components](./chapters/03-primitive-components/)
+4. Understand [Monorepo Architecture](./chapters/04-monorepo-architecture/)
+5. Then use the bootstrap guide
+
+### If You Just Want to Start Building
+1. Copy prompt from [`AI_AGENT_PROMPT.md`](./AI_AGENT_PROMPT.md)
+2. Paste to your AI coding agent
+3. Customize tokens to match your brand
+4. Add components as you need them
+
+---
+
+## 📦 What You Get After Bootstrap
+
+### Working Monorepo
+```bash
+pnpm install           # Install dependencies
+pnpm dev              # Start all apps
+pnpm build            # Build everything
+```
+
+### Token System
+```bash
+# Edit your brand tokens
+packages/tokens/src/colors.json
+packages/tokens/src/spacing.json
+packages/tokens/src/typography.json
+
+# Rebuild
+pnpm --filter @myapp/tokens build
+```
+
+### Component Pattern
+```typescript
+// packages/ui/src/components/Button.tsx
+// Shows CVA pattern, forwardRef, TypeScript types
+// Copy this pattern for new components
+```
+
+### Documentation
+```bash
+pnpm --filter @myapp/docs dev
+# Visit http://localhost:6006
+# Add stories for each new component
+```
+
+---
+
+## 🛠️ Common Tasks After Setup
+
+### Add a Design Token
+```bash
+# 1. Edit packages/tokens/src/colors.json
+{
+  "color": {
+    "brand": {
+      "primary": { "value": "#3B82F6" }
+    }
+  }
+}
+
+# 2. Rebuild
+pnpm --filter @myapp/tokens build
+
+# 3. Use in components
+className="bg-blue-600"  # Or use CSS var --color-brand-primary
+```
+
+### Add a UI Component
+```bash
+# 1. Create packages/ui/src/components/Input.tsx
+#    Follow Button.tsx pattern (CVA + forwardRef)
+
+# 2. Export from packages/ui/src/index.tsx
+export { Input } from './components/Input';
+
+# 3. Create story apps/docs/stories/Input.stories.tsx
+
+# 4. Use in app
+import { Input } from '@myapp/ui';
+```
+
+### Add an App Component
+```bash
+# 1. Create apps/web/components/UserCard.tsx
+import { Card, Avatar, Button } from '@myapp/ui';
+import type { User } from '@/types';
+
+export function UserCard({ user }: { user: User }) {
+  return (
+    <Card>
+      <Avatar src={user.avatar} />
+      <h3>{user.name}</h3>
+      <Button>Edit</Button>
+    </Card>
+  );
+}
+
+# 2. Use in pages
+import { UserCard } from '@/components/UserCard';
+```
+
+---
+
+## ⏱️ Time Estimates
+
+| Task | AI Agent | Human |
+|------|----------|-------|
+| Initial scaffold | 3-5 min | 30-45 min |
+| Add design tokens | 1 min | 5 min |
+| Add UI component | 2 min | 10-15 min |
+| Add app component | 1 min | 5-10 min |
+
+---
+
+## 🔍 Real-World Examples
+
+### Startup MVP (Week 1)
+```bash
+Day 1: Bootstrap foundation
+Day 2-3: Customize tokens (brand colors)
+Day 4-5: Add 5 components (Button, Input, Card, Badge, Avatar)
+Day 6-7: Build app components (UserCard, ProductCard)
+
+Result: Minimal design system with only needed components
+```
+
+### Enterprise Team (Month 1)
+```bash
+Sprint 1: Bootstrap + define comprehensive tokens
+Sprint 2: Build 10 primitive components
+Sprint 3: Create 5 pattern components (forms, tables)
+Sprint 4: Build app-specific components
+
+Result: Production design system with 15-20 components
+```
+
+---
+
+## 📖 Documentation Structure
+
+After bootstrap, you'll have these guides:
+
+```
+/
+├── README.md                           # Getting started
+├── CONTRIBUTING.md                     # Architecture principles
+├── packages/
+│   ├── tokens/README.md               # How to add tokens
+│   ├── ui/README.md                   # How to add UI components
+│   └── config/README.md               # Shared configs
+├── apps/
+│   ├── web/src/components/README.md   # How to add app components
+│   └── docs/stories/README.md         # How to document
+```
+
+Each README guides you on extending that part of the system.
+
+---
+
+## ✅ Validation Checklist
+
+After bootstrap, verify:
+
+- [ ] `pnpm install` succeeds
+- [ ] `pnpm --filter @myapp/tokens build` generates CSS and JS
+- [ ] `pnpm --filter @myapp/web dev` starts on localhost:3000
+- [ ] `pnpm --filter @myapp/docs dev` starts on localhost:6006
+- [ ] Button component renders with Tailwind styles
+- [ ] Only Button component exists (not 20+ components)
+- [ ] Each package has README with extension guide
+- [ ] Root README explains architecture
+
+---
+
+## 🐛 Troubleshooting
+
+### Styles Not Applying
+```bash
+# Check Tailwind content paths
+# apps/web/tailwind.config.js must include:
+content: [
+  './src/**/*.{ts,tsx}',
+  '../../packages/ui/src/**/*.{ts,tsx}'  # This line is critical
+]
+
+# Check CSS imports
+# apps/web/app/globals.css must have:
+@import '@myapp/tokens/build/css/variables.css';  # Before Tailwind
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+```
+
+### Build Fails
+```bash
+# Build tokens first
+pnpm --filter @myapp/tokens build
+
+# Clear cache
+rm -rf .turbo
+rm -rf node_modules
+pnpm install
+```
+
+### TypeScript Errors
+```bash
+# Check workspace dependencies
+# All internal deps should use workspace:*
+"@myapp/ui": "workspace:*"
+
+# Verify TypeScript configs extend correctly
+# packages/ui/tsconfig.json should extend @myapp/config
+```
+
+---
+
+## 🎯 Success Metrics
+
+You'll know the bootstrap succeeded when:
+
+1. ✅ Foundation works in 5 minutes (AI) or 45 minutes (manual)
+2. ✅ You can add a new token in 1 minute
+3. ✅ You can add a new component in 10 minutes
+4. ✅ No unused code in your bundles
+5. ✅ Clear patterns to follow for everything
+6. ✅ Documentation guides, doesn't prescribe
+
+---
+
+## 🔗 Related Resources
+
+### In This Repo
+- [`AI_AGENT_PROMPT.md`](./AI_AGENT_PROMPT.md) - Copy-paste prompt for agents
+- [`BOOTSTRAP_GUIDE.md`](./BOOTSTRAP_GUIDE.md) - Detailed phase-by-phase guide
+- [`chapters/`](./chapters/) - Full design systems course (9 chapters)
+- [`references/cal.com`](./references/cal.com) - Real-world monorepo example
+- [`references/supabase`](./references/supabase) - Production design system
+
+### External
+- [Turborepo Docs](https://turbo.build/repo/docs)
+- [Style Dictionary](https://amzn.github.io/style-dictionary)
+- [CVA Docs](https://cva.style/docs)
+- [Tailwind CSS](https://tailwindcss.com/docs)
+
+---
+
+## 💬 Questions?
+
+**For design system concepts:** See [chapters/](./chapters/)
+**For bootstrap issues:** Check [BOOTSTRAP_GUIDE.md](./BOOTSTRAP_GUIDE.md) troubleshooting
+**For architecture decisions:** Read [CONTRIBUTING.md](./CONTRIBUTING.md)
+
+---
+
+**Version**: 2.0.0
+**Philosophy**: Scaffold, don't prescribe
+**Course**: Design Systems - Tallinn v2

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "blog",
+  "private": true,
+  "packageManager": "pnpm@9.15.0",
+  "scripts": {
+    "dev": "turbo dev",
+    "build": "turbo build",
+    "lint": "turbo lint",
+    "clean": "turbo clean && rm -rf node_modules",
+    "format": "prettier --write \"**/*.{ts,tsx,md,mdx,json}\""
+  },
+  "devDependencies": {
+    "turbo": "^2.3.3",
+    "prettier": "^3.4.2",
+    "typescript": "^5.7.2"
+  }
+}

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@blog/config",
+  "version": "0.0.0",
+  "private": true,
+  "exports": {
+    "./tsconfig/base.json": "./tsconfig/base.json",
+    "./tsconfig/react.json": "./tsconfig/react.json",
+    "./tsconfig/nextjs.json": "./tsconfig/nextjs.json",
+    "./tailwind.config": "./tailwind.config.js"
+  }
+}

--- a/packages/config/tailwind.config.js
+++ b/packages/config/tailwind.config.js
@@ -1,0 +1,10 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  darkMode: 'class',
+  theme: {
+    extend: {
+      // Users will extend with their token values
+    },
+  },
+  plugins: [],
+};

--- a/packages/config/tsconfig/base.json
+++ b/packages/config/tsconfig/base.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "declaration": true,
+    "declarationMap": true
+  },
+  "exclude": ["node_modules"]
+}

--- a/packages/config/tsconfig/nextjs.json
+++ b/packages/config/tsconfig/nextjs.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./react.json",
+  "compilerOptions": {
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "allowJs": true,
+    "incremental": true
+  }
+}

--- a/packages/config/tsconfig/react.json
+++ b/packages/config/tsconfig/react.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./base.json",
+  "compilerOptions": {
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx"
+  }
+}

--- a/packages/tokens/config.js
+++ b/packages/tokens/config.js
@@ -1,0 +1,29 @@
+module.exports = {
+  source: ['src/**/*.json'],
+  platforms: {
+    css: {
+      transformGroup: 'css',
+      buildPath: 'build/css/',
+      files: [
+        {
+          destination: 'variables.css',
+          format: 'css/variables',
+        },
+      ],
+    },
+    js: {
+      transformGroup: 'js',
+      buildPath: 'build/js/',
+      files: [
+        {
+          destination: 'tokens.js',
+          format: 'javascript/es6',
+        },
+        {
+          destination: 'tokens.d.ts',
+          format: 'typescript/es6-declarations',
+        },
+      ],
+    },
+  },
+};

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@blog/tokens",
+  "version": "0.0.0",
+  "private": true,
+  "main": "build/js/tokens.js",
+  "types": "build/js/tokens.d.ts",
+  "exports": {
+    ".": {
+      "types": "./build/js/tokens.d.ts",
+      "default": "./build/js/tokens.js"
+    },
+    "./css": "./build/css/variables.css"
+  },
+  "scripts": {
+    "build": "style-dictionary build",
+    "clean": "rm -rf build"
+  },
+  "devDependencies": {
+    "style-dictionary": "^4.2.0"
+  }
+}

--- a/packages/tokens/src/colors.json
+++ b/packages/tokens/src/colors.json
@@ -1,0 +1,20 @@
+{
+  "color": {
+    "gray": {
+      "50": { "value": "#fafafa" },
+      "100": { "value": "#f4f4f5" },
+      "200": { "value": "#e4e4e7" },
+      "300": { "value": "#d4d4d8" },
+      "400": { "value": "#a1a1aa" },
+      "500": { "value": "#71717a" },
+      "600": { "value": "#52525b" },
+      "700": { "value": "#3f3f46" },
+      "800": { "value": "#27272a" },
+      "900": { "value": "#18181b" }
+    },
+    "accent": {
+      "primary": { "value": "#3b82f6" },
+      "secondary": { "value": "#8b5cf6" }
+    }
+  }
+}

--- a/packages/tokens/src/spacing.json
+++ b/packages/tokens/src/spacing.json
@@ -1,0 +1,13 @@
+{
+  "spacing": {
+    "0": { "value": "0" },
+    "1": { "value": "0.25rem" },
+    "2": { "value": "0.5rem" },
+    "3": { "value": "0.75rem" },
+    "4": { "value": "1rem" },
+    "6": { "value": "1.5rem" },
+    "8": { "value": "2rem" },
+    "12": { "value": "3rem" },
+    "16": { "value": "4rem" }
+  }
+}

--- a/packages/tokens/src/typography.json
+++ b/packages/tokens/src/typography.json
@@ -1,0 +1,30 @@
+{
+  "font": {
+    "family": {
+      "sans": { "value": "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" },
+      "serif": { "value": "Georgia, 'Times New Roman', serif" },
+      "mono": { "value": "ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace" }
+    },
+    "size": {
+      "xs": { "value": "0.75rem" },
+      "sm": { "value": "0.875rem" },
+      "base": { "value": "1rem" },
+      "lg": { "value": "1.125rem" },
+      "xl": { "value": "1.25rem" },
+      "2xl": { "value": "1.5rem" },
+      "3xl": { "value": "1.875rem" },
+      "4xl": { "value": "2.25rem" }
+    },
+    "weight": {
+      "normal": { "value": "400" },
+      "medium": { "value": "500" },
+      "semibold": { "value": "600" },
+      "bold": { "value": "700" }
+    },
+    "lineHeight": {
+      "tight": { "value": "1.25" },
+      "normal": { "value": "1.5" },
+      "relaxed": { "value": "1.75" }
+    }
+  }
+}

--- a/plan/ARCHITECTURE.md
+++ b/plan/ARCHITECTURE.md
@@ -1,0 +1,536 @@
+# Blog Redesign Architecture
+
+## Overview
+
+This document describes the architecture for rebuilding the personal blog from Hugo/PaperMod to a Next.js + MDX design system approach.
+
+---
+
+## Current State Analysis
+
+### Existing Structure
+```
+sarajevo/
+├── content/
+│   ├── about/          # About pages (zh/en)
+│   ├── blog/           # Blog posts (~10 posts)
+│   ├── collection/     # Curated collections
+│   ├── digest/         # Weekly digests (~22 entries)
+│   ├── library/        # Paper notes/reviews
+│   └── logging/        # Dev logs
+├── docs/               # Built output (GitHub Pages)
+├── archetypes/         # Hugo templates
+├── config.yml          # Hugo configuration
+└── themes/PaperMod/    # Hugo theme (external)
+```
+
+### Current Features
+- Multi-language (Chinese primary, English secondary)
+- PaperMod theme with dark/light mode
+- Categories and tags
+- Search (Fuse.js)
+- Table of contents
+- Reading time estimation
+
+---
+
+## Proposed Architecture
+
+### 5-Layer Design System
+
+```
+Layer 5: Pages/Views        → apps/blog/app/
+         Route handlers, full pages, layouts
+
+Layer 4: App Components     → apps/blog/components/
+         Blog-specific: PostCard, DigestList, PaperNote
+
+Layer 3: Pattern Components → packages/ui/ (complex)
+         Reusable patterns: Modal, Tabs, SearchDialog
+
+Layer 2: Primitive Components → packages/ui/ (basic)
+         Generic UI: Button, Card, Badge, Input
+
+Layer 1: Design Tokens      → packages/tokens/
+         Colors, spacing, typography, shadows
+```
+
+### Directory Structure
+
+```
+sarajevo/
+├── packages/
+│   ├── tokens/
+│   │   ├── src/
+│   │   │   ├── colors.json
+│   │   │   ├── spacing.json
+│   │   │   ├── typography.json
+│   │   │   └── shadows.json
+│   │   ├── build/              # Generated CSS/JS
+│   │   ├── style-dictionary.config.js
+│   │   └── package.json
+│   │
+│   ├── ui/
+│   │   ├── src/
+│   │   │   ├── components/
+│   │   │   │   ├── Button.tsx
+│   │   │   │   ├── Card.tsx
+│   │   │   │   ├── Badge.tsx
+│   │   │   │   ├── Input.tsx
+│   │   │   │   ├── Tabs.tsx
+│   │   │   │   └── ...
+│   │   │   ├── lib/
+│   │   │   │   └── utils.ts    # cn() utility
+│   │   │   └── index.tsx
+│   │   ├── package.json
+│   │   └── tailwind.config.js
+│   │
+│   └── config/
+│       ├── tsconfig/
+│       │   ├── base.json
+│       │   ├── react.json
+│       │   └── nextjs.json
+│       ├── tailwind.config.js
+│       └── package.json
+│
+├── apps/
+│   └── blog/
+│       ├── app/
+│       │   ├── layout.tsx
+│       │   ├── page.tsx
+│       │   ├── globals.css
+│       │   ├── [locale]/
+│       │   │   ├── layout.tsx
+│       │   │   ├── page.tsx
+│       │   │   ├── blog/
+│       │   │   │   ├── page.tsx
+│       │   │   │   └── [slug]/page.tsx
+│       │   │   ├── collection/
+│       │   │   ├── library/
+│       │   │   └── about/
+│       │   └── ...
+│       ├── components/
+│       │   ├── PostCard.tsx
+│       │   ├── PostList.tsx
+│       │   ├── DigestEntry.tsx
+│       │   ├── PaperNote.tsx
+│       │   ├── TableOfContents.tsx
+│       │   ├── LanguageSwitcher.tsx
+│       │   └── ThemeToggle.tsx
+│       ├── content/            # MDX content files
+│       │   ├── blog/
+│       │   │   └── zh/
+│       │   │       └── 10k-code.mdx
+│       │   ├── collection/
+│       │   ├── library/
+│       │   └── about/
+│       ├── lib/
+│       │   ├── mdx.ts          # MDX utilities
+│       │   ├── content.ts      # Content fetching
+│       │   └── i18n.ts         # Internationalization
+│       ├── mdx-components.tsx  # Custom MDX components
+│       ├── next.config.js
+│       ├── tailwind.config.js
+│       └── package.json
+│
+├── content/                    # Legacy Hugo content (reference)
+├── docs/                       # Static export output
+├── package.json
+├── pnpm-workspace.yaml
+├── turbo.json
+└── .gitignore
+```
+
+---
+
+## Technology Stack
+
+### Core
+| Technology | Purpose | Version |
+|------------|---------|---------|
+| Next.js | Framework | 14.x (App Router) |
+| React | UI Library | 18.x |
+| TypeScript | Type Safety | 5.x |
+| Tailwind CSS | Styling | 3.x |
+
+### Monorepo
+| Technology | Purpose |
+|------------|---------|
+| Turborepo | Build orchestration |
+| pnpm | Package management |
+
+### Content
+| Technology | Purpose |
+|------------|---------|
+| MDX | Interactive markdown |
+| @next/mdx | MDX integration |
+| gray-matter | Frontmatter parsing |
+| rehype-pretty-code | Code highlighting |
+| remark-gfm | GitHub-flavored markdown |
+
+### Design System
+| Technology | Purpose |
+|------------|---------|
+| Style Dictionary | Token transformation |
+| CVA | Component variants |
+| clsx + tailwind-merge | Class utilities |
+
+### i18n
+| Technology | Purpose |
+|------------|---------|
+| next-intl | Internationalization |
+
+---
+
+## Path Aliases Configuration
+
+All packages use absolute imports via TypeScript path aliases for cleaner imports.
+
+### UI Package (`packages/ui/tsconfig.json`)
+```json
+{
+  "extends": "@blog/config/tsconfig/react.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@ui/*": ["src/*"]
+    }
+  },
+  "include": ["src/**/*"]
+}
+```
+
+### Blog App (`apps/blog/tsconfig.json`)
+```json
+{
+  "extends": "@blog/config/tsconfig/nextjs.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"],
+      "@/components/*": ["components/*"],
+      "@/lib/*": ["lib/*"],
+      "@/content/*": ["content/*"]
+    }
+  },
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}
+```
+
+### Import Examples
+```typescript
+// In packages/ui/src/components/Card.tsx
+import { cn } from '@ui/lib/utils';
+
+// In apps/blog/components/PostCard.tsx
+import { Card, Badge } from '@blog/ui';
+import { formatDate } from '@/lib/utils';
+import type { Post } from '@/lib/content';
+```
+
+---
+
+## Content Model
+
+### Blog Post (MDX)
+```mdx
+---
+title: "10000行代码后对软件工程的思考"
+date: 2019-02-01
+locale: zh
+categories:
+  - 软件开发
+tags:
+  - C++
+  - software-engineering
+summary: "第一个10,000行代码的思考..."
+---
+
+# Content here
+
+<Callout type="info">
+  Interactive component example
+</Callout>
+```
+
+### Frontmatter Schema
+```typescript
+interface PostFrontmatter {
+  title: string;
+  date: string;
+  locale: 'zh' | 'en';
+  categories?: string[];
+  tags?: string[];
+  summary?: string;
+  draft?: boolean;
+}
+
+interface CollectionFrontmatter {
+  title: string;
+  description: string;
+  locale: 'zh' | 'en';
+}
+
+interface LibraryFrontmatter {
+  title: string;
+  authors: string[];
+  year: number;
+  venue?: string;
+  locale: 'zh' | 'en';
+  tags?: string[];
+}
+```
+
+---
+
+## Routing Structure
+
+### URL Patterns
+```
+/                           → Home (redirects to /zh)
+/zh                         → Chinese home
+/en                         → English home
+/zh/blog                    → Chinese blog listing
+/zh/blog/10k-code           → Chinese blog post
+/en/blog                    → English blog listing
+/zh/collection              → Collections
+/zh/library                 → Paper notes
+/zh/about                   → About page
+```
+
+### File-based Routing
+```
+apps/blog/app/
+├── [locale]/
+│   ├── layout.tsx          → Locale layout with i18n provider
+│   ├── page.tsx            → Home page
+│   ├── blog/
+│   │   ├── page.tsx        → Blog listing
+│   │   └── [slug]/
+│   │       └── page.tsx    → Individual post
+│   ├── collection/
+│   │   ├── page.tsx
+│   │   └── [slug]/page.tsx
+│   ├── library/
+│   │   ├── page.tsx
+│   │   └── [slug]/page.tsx
+│   └── about/
+│       └── page.tsx
+└── layout.tsx              → Root layout
+```
+
+---
+
+## Component Architecture
+
+### UI Package Components (Layer 2)
+
+```typescript
+// packages/ui/src/index.tsx
+// Primitive components - no business logic
+// Uses absolute imports via path alias (@ui/*)
+export { Button } from '@ui/components/Button';
+export { Card } from '@ui/components/Card';
+export { Badge } from '@ui/components/Badge';
+export { Input } from '@ui/components/Input';
+export { Tabs, TabsList, TabsTrigger, TabsContent } from '@ui/components/Tabs';
+export { ThemeProvider, useTheme } from '@ui/components/ThemeProvider';
+export { cn } from '@ui/lib/utils';
+```
+
+### Blog App Components (Layer 4)
+
+```typescript
+// apps/blog/components/index.ts
+// Blog-specific components with business logic
+// Uses absolute imports via path alias (@/*)
+export { PostCard } from '@/components/PostCard';        // Uses Card, Badge
+export { PostList } from '@/components/PostList';        // Uses PostCard
+export { TableOfContents } from '@/components/TableOfContents';
+export { LanguageSwitcher } from '@/components/LanguageSwitcher';
+export { SearchDialog } from '@/components/SearchDialog'; // Uses Input, Card
+export { ThemeToggle } from '@/components/ThemeToggle';  // Uses Button
+```
+
+### MDX Components
+
+```typescript
+// Custom components available in MDX
+const mdxComponents = {
+  // Override default elements
+  h1: (props) => <h1 className="..." {...props} />,
+  h2: (props) => <h2 className="..." {...props} />,
+  pre: (props) => <CodeBlock {...props} />,
+
+  // Custom components
+  Callout: CalloutComponent,
+  Tabs: TabsComponent,
+  CodeBlock: CodeBlockComponent,
+  Citation: CitationComponent,
+  Diagram: DiagramComponent,
+};
+```
+
+---
+
+## Design Tokens
+
+### Color Palette (Minimal Starter)
+```json
+{
+  "color": {
+    "gray": {
+      "50": { "value": "#fafafa" },
+      "100": { "value": "#f4f4f5" },
+      "200": { "value": "#e4e4e7" },
+      "300": { "value": "#d4d4d8" },
+      "400": { "value": "#a1a1aa" },
+      "500": { "value": "#71717a" },
+      "600": { "value": "#52525b" },
+      "700": { "value": "#3f3f46" },
+      "800": { "value": "#27272a" },
+      "900": { "value": "#18181b" }
+    },
+    "accent": {
+      "primary": { "value": "#3b82f6" },
+      "secondary": { "value": "#8b5cf6" }
+    }
+  }
+}
+```
+
+### Typography
+```json
+{
+  "font": {
+    "family": {
+      "sans": { "value": "system-ui, -apple-system, sans-serif" },
+      "serif": { "value": "Georgia, serif" },
+      "mono": { "value": "ui-monospace, monospace" }
+    },
+    "size": {
+      "xs": { "value": "0.75rem" },
+      "sm": { "value": "0.875rem" },
+      "base": { "value": "1rem" },
+      "lg": { "value": "1.125rem" },
+      "xl": { "value": "1.25rem" },
+      "2xl": { "value": "1.5rem" },
+      "3xl": { "value": "1.875rem" }
+    }
+  }
+}
+```
+
+---
+
+## Build & Deployment
+
+### Build Pipeline
+```
+1. pnpm install
+2. pnpm --filter @blog/tokens build    → Generate CSS/JS tokens
+3. pnpm --filter @blog/blog build      → Build Next.js app
+4. next export                          → Static HTML to docs/
+```
+
+### GitHub Pages Deployment
+- Output directory: `docs/`
+- CNAME file preserved
+- Static export with `output: 'export'` in next.config.js
+
+### Turborepo Configuration
+```json
+{
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**", ".next/**", "out/**"]
+    },
+    "dev": {
+      "cache": false,
+      "persistent": true
+    }
+  }
+}
+```
+
+---
+
+## Performance Considerations
+
+### Static Generation
+- All pages statically generated at build time
+- MDX compiled to optimized JavaScript
+- Images optimized with next/image
+
+### Bundle Optimization
+- Only import components actually used
+- Code splitting per route
+- Tailwind CSS purging
+
+### Caching
+- Turborepo caching for faster rebuilds
+- Browser caching for static assets
+
+---
+
+## Migration Path
+
+### Phase 1: Preserve
+- Keep existing `docs/` output working
+- Hugo site remains functional during development
+
+### Phase 2: Parallel Development
+- New Next.js app in `apps/blog/`
+- Content migrated to `apps/blog/content/`
+
+### Phase 3: Switch
+- Update build script to use Next.js export
+- Verify all URLs work
+- Remove Hugo configuration
+
+### Phase 4: Cleanup
+- Archive old Hugo content
+- Remove theme dependencies
+- Update documentation
+
+---
+
+## Future Extensibility
+
+### Potential Additions
+- **RSS Feed**: Generate at build time
+- **Search**: Client-side with Fuse.js or Algolia
+- **Comments**: Giscus (GitHub Discussions)
+- **Analytics**: Plausible or simple-analytics
+- **Newsletter**: Integration with email service
+
+### New Content Types
+- Interactive tutorials
+- Code playgrounds
+- Data visualizations
+- Timeline/changelog
+
+---
+
+## Decision Log
+
+| Decision | Rationale |
+|----------|-----------|
+| Next.js over Astro | Better React ecosystem, MDX support, familiar to author |
+| App Router over Pages | Latest patterns, better layouts, server components |
+| MDX over plain Markdown | Interactive components, custom styling |
+| Monorepo structure | Reusable design system, clear separation |
+| Static export | Simple hosting, GitHub Pages compatible |
+| next-intl over next-i18n-routing | Better App Router support, simpler API |
+
+---
+
+## References
+
+- [Next.js App Router](https://nextjs.org/docs/app)
+- [MDX Documentation](https://mdxjs.com/)
+- [Tailwind CSS](https://tailwindcss.com/)
+- [Style Dictionary](https://amzn.github.io/style-dictionary/)
+- [next-intl](https://next-intl-docs.vercel.app/)

--- a/plan/CONTENT_MIGRATION.md
+++ b/plan/CONTENT_MIGRATION.md
@@ -1,0 +1,486 @@
+# Content Migration Guide
+
+## Overview
+
+This document provides detailed guidance for migrating content from Hugo markdown to Next.js MDX format.
+
+---
+
+## Content Inventory
+
+### Blog Posts
+| File | Language | Title | Notes |
+|------|----------|-------|-------|
+| `10k-code.md` | zh | 10000行代码后对软件工程的思考 | Has footnotes |
+| `10k-cpp.md` | zh | C++相关 | |
+| `job_search_reflection.en.md` | en | Job Search Reflection | |
+| `meeting-how-to.md` | zh | 会议相关 | |
+| `offer_negotiation.en.md` | en | Offer Negotiation | |
+| `programmer_quality.md` | zh | 程序员素质 | |
+| `programming_augmenting_intelligence.md` | zh | 编程增强智能 | |
+| `reverse-interview.md` | zh | 反向面试 | |
+| `short_pr.md` | zh | 短PR | |
+
+### Collections
+| File | Language | Title |
+|------|----------|-------|
+| `psych-writing.md` | zh | 心理学写作 |
+| `system_design_interview.en.md` | en | System Design Interview |
+| `vision-100.md` | zh | Vision 100 |
+| `vision-100.en.md` | en | Vision 100 |
+
+### Library (Paper Notes)
+15+ paper review files, primarily in English.
+
+### Digests
+22 digest entries (`digest-001.md` through `digest-022.md`).
+
+---
+
+## Frontmatter Transformation
+
+### Hugo Format (Current)
+```yaml
+---
+title: 10000行代码后对软件工程的思考
+date: 2019-02-01
+categories:
+- 软件开发
+tags:
+- C++
+---
+```
+
+### MDX Format (Target)
+```yaml
+---
+title: "10000行代码后对软件工程的思考"
+date: "2019-02-01"
+locale: "zh"
+categories:
+  - "软件开发"
+tags:
+  - "C++"
+  - "software-engineering"
+summary: "第一个10,000行代码的思考..."
+---
+```
+
+### Key Changes
+1. Add `locale` field (derive from filename or folder)
+2. Add `summary` field (extract from first paragraph)
+3. Quote all string values for consistency
+4. Normalize tag naming (lowercase, hyphenated)
+
+---
+
+## Content Transformations
+
+### Footnotes
+Hugo/Markdown footnotes work in MDX:
+```markdown
+<!-- Input (works as-is) -->
+这是一段文字[^1]
+
+[^1]: 这是脚注内容
+```
+
+### Code Blocks
+Standard fenced code blocks work:
+```markdown
+<!-- Input (works as-is) -->
+```cpp
+int main() {
+    return 0;
+}
+```
+```
+
+### Images
+Transform Hugo image references:
+```markdown
+<!-- Hugo Format -->
+![Alt text](/images/post/image.png)
+
+<!-- MDX Format -->
+![Alt text](/images/post/image.png)
+<!-- or with next/image -->
+<Image src="/images/post/image.png" alt="Alt text" width={800} height={600} />
+```
+
+### Internal Links
+Transform Hugo-style links:
+```markdown
+<!-- Hugo Format -->
+[Link text]({{< ref "other-post.md" >}})
+
+<!-- MDX Format -->
+[Link text](/zh/blog/other-post)
+```
+
+### Hugo Shortcodes
+Transform to MDX components:
+
+```markdown
+<!-- Hugo: info/warning boxes -->
+{{< hint info >}}
+This is info
+{{< /hint >}}
+
+<!-- MDX: Custom component -->
+<Callout type="info">
+This is info
+</Callout>
+```
+
+```markdown
+<!-- Hugo: tabs -->
+{{< tabs "uniqueid" >}}
+{{< tab "Tab1" >}}Content 1{{< /tab >}}
+{{< tab "Tab2" >}}Content 2{{< /tab >}}
+{{< /tabs >}}
+
+<!-- MDX: Custom component -->
+<Tabs defaultValue="tab1">
+  <TabsList>
+    <TabsTrigger value="tab1">Tab1</TabsTrigger>
+    <TabsTrigger value="tab2">Tab2</TabsTrigger>
+  </TabsList>
+  <TabsContent value="tab1">Content 1</TabsContent>
+  <TabsContent value="tab2">Content 2</TabsContent>
+</Tabs>
+```
+
+---
+
+## File Organization
+
+### Current Structure (Hugo)
+```
+content/
+├── blog/
+│   ├── _index.md
+│   ├── _index.en.md
+│   ├── 10k-code.md
+│   └── job_search_reflection.en.md
+├── collection/
+│   ├── _index.md
+│   └── vision-100.md
+└── library/
+    ├── _index.md
+    └── Paper_Author_Year.en.md
+```
+
+### Target Structure (MDX)
+```
+apps/blog/content/
+├── blog/
+│   ├── zh/
+│   │   ├── 10k-code.mdx
+│   │   └── meeting-how-to.mdx
+│   └── en/
+│       └── job-search-reflection.mdx
+├── collection/
+│   ├── zh/
+│   │   └── vision-100.mdx
+│   └── en/
+│       └── vision-100.mdx
+└── library/
+    └── en/
+        └── paper-author-year.mdx
+```
+
+### Naming Conventions
+- Use lowercase with hyphens: `job-search-reflection.mdx`
+- Group by locale in subdirectories
+- Remove `_index.md` files (handled by page components)
+
+---
+
+## Migration Script
+
+### Automated Migration
+```typescript
+// scripts/migrate-content.ts
+
+import fs from 'fs';
+import path from 'path';
+import matter from 'gray-matter';
+
+interface MigrationResult {
+  success: boolean;
+  sourcePath: string;
+  targetPath: string;
+  errors: string[];
+}
+
+function migratePost(sourcePath: string, targetDir: string): MigrationResult {
+  const result: MigrationResult = {
+    success: true,
+    sourcePath,
+    targetPath: '',
+    errors: [],
+  };
+
+  try {
+    // Read source file
+    const content = fs.readFileSync(sourcePath, 'utf-8');
+    const { data: frontmatter, content: body } = matter(content);
+
+    // Determine locale
+    const filename = path.basename(sourcePath);
+    const locale = filename.includes('.en.') ? 'en' : 'zh';
+
+    // Transform frontmatter
+    const newFrontmatter = {
+      title: frontmatter.title,
+      date: frontmatter.date,
+      locale,
+      categories: frontmatter.categories || [],
+      tags: frontmatter.tags || [],
+      summary: extractSummary(body),
+      draft: frontmatter.draft || false,
+    };
+
+    // Transform content
+    const newBody = transformContent(body);
+
+    // Generate new filename
+    const slug = generateSlug(filename);
+    const targetPath = path.join(targetDir, locale, `${slug}.mdx`);
+    result.targetPath = targetPath;
+
+    // Write new file
+    const newContent = matter.stringify(newBody, newFrontmatter);
+    fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+    fs.writeFileSync(targetPath, newContent);
+
+  } catch (error) {
+    result.success = false;
+    result.errors.push(error.message);
+  }
+
+  return result;
+}
+
+function extractSummary(content: string): string {
+  // Extract first paragraph as summary
+  const match = content.match(/^[^#\n].+/m);
+  if (match) {
+    return match[0].slice(0, 200).trim();
+  }
+  return '';
+}
+
+function transformContent(content: string): string {
+  let result = content;
+
+  // Transform Hugo shortcodes to MDX components
+  result = transformShortcodes(result);
+
+  // Transform internal links
+  result = transformLinks(result);
+
+  return result;
+}
+
+function transformShortcodes(content: string): string {
+  // Transform hint shortcode to Callout
+  content = content.replace(
+    /\{\{<\s*hint\s+(info|warning|danger)\s*>\}\}([\s\S]*?)\{\{<\s*\/hint\s*>\}\}/g,
+    '<Callout type="$1">$2</Callout>'
+  );
+
+  return content;
+}
+
+function transformLinks(content: string): string {
+  // Transform Hugo ref links
+  content = content.replace(
+    /\{\{<\s*ref\s+"([^"]+)"\s*>\}\}/g,
+    (_, ref) => {
+      const slug = ref.replace('.md', '').replace('.en', '');
+      return `/blog/${slug}`;
+    }
+  );
+
+  return content;
+}
+
+function generateSlug(filename: string): string {
+  return filename
+    .replace('.en.md', '')
+    .replace('.md', '')
+    .replace(/_/g, '-')
+    .toLowerCase();
+}
+
+// Run migration
+const SOURCE_DIR = './content';
+const TARGET_DIR = './apps/blog/content';
+
+// Migrate blog posts
+const blogDir = path.join(SOURCE_DIR, 'blog');
+fs.readdirSync(blogDir)
+  .filter(f => f.endsWith('.md') && !f.startsWith('_'))
+  .forEach(file => {
+    const result = migratePost(
+      path.join(blogDir, file),
+      path.join(TARGET_DIR, 'blog')
+    );
+    console.log(result.success ? '✓' : '✗', file, result.targetPath);
+    if (result.errors.length) console.log('  Errors:', result.errors);
+  });
+```
+
+### Manual Review Checklist
+After automated migration, manually review each file:
+
+- [ ] Frontmatter is valid YAML
+- [ ] Title displays correctly (especially quotes in Chinese)
+- [ ] Date parses correctly
+- [ ] Categories and tags migrated
+- [ ] Code blocks render
+- [ ] Internal links work
+- [ ] Images display
+- [ ] Footnotes work
+- [ ] No broken MDX components
+
+---
+
+## Content-Specific Notes
+
+### Blog Post: 10k-code.md
+- Contains Chinese text with footnotes
+- Has code examples (C++)
+- References other posts
+
+**Migration steps:**
+1. Add `locale: "zh"` to frontmatter
+2. Verify footnotes render
+3. Test code highlighting
+
+### Collection: vision-100.md
+- Has both Chinese and English versions
+- May have special formatting
+
+**Migration steps:**
+1. Create separate `zh/vision-100.mdx` and `en/vision-100.mdx`
+2. Cross-link between language versions
+
+### Library Posts
+- Academic paper reviews
+- May have citations, tables
+
+**Migration steps:**
+1. Preserve citation formatting
+2. Consider adding `Citation` MDX component
+
+### Digests
+- 22 short entries
+- Weekly summaries
+
+**Migration decision:**
+- **Option A**: Migrate all individually
+- **Option B**: Consolidate into year-based archives
+- **Option C**: Create single "digest archive" page with all entries
+
+---
+
+## Testing Migration
+
+### Validation Script
+```typescript
+// scripts/validate-migration.ts
+
+import fs from 'fs';
+import path from 'path';
+import matter from 'gray-matter';
+
+const CONTENT_DIR = './apps/blog/content';
+
+function validateFile(filePath: string): string[] {
+  const errors: string[] = [];
+  const content = fs.readFileSync(filePath, 'utf-8');
+
+  try {
+    const { data } = matter(content);
+
+    // Check required fields
+    if (!data.title) errors.push('Missing title');
+    if (!data.date) errors.push('Missing date');
+    if (!data.locale) errors.push('Missing locale');
+
+    // Check date format
+    if (data.date && isNaN(Date.parse(data.date))) {
+      errors.push(`Invalid date: ${data.date}`);
+    }
+
+    // Check locale value
+    if (data.locale && !['zh', 'en'].includes(data.locale)) {
+      errors.push(`Invalid locale: ${data.locale}`);
+    }
+
+  } catch (e) {
+    errors.push(`Parse error: ${e.message}`);
+  }
+
+  return errors;
+}
+
+// Run validation
+function walkDir(dir: string, callback: (file: string) => void) {
+  fs.readdirSync(dir).forEach(f => {
+    const filePath = path.join(dir, f);
+    if (fs.statSync(filePath).isDirectory()) {
+      walkDir(filePath, callback);
+    } else if (f.endsWith('.mdx')) {
+      callback(filePath);
+    }
+  });
+}
+
+let hasErrors = false;
+walkDir(CONTENT_DIR, (file) => {
+  const errors = validateFile(file);
+  if (errors.length) {
+    hasErrors = true;
+    console.log(`\n✗ ${file}`);
+    errors.forEach(e => console.log(`  - ${e}`));
+  } else {
+    console.log(`✓ ${file}`);
+  }
+});
+
+process.exit(hasErrors ? 1 : 0);
+```
+
+### Visual Comparison
+1. Run old Hugo site and new Next.js site side by side
+2. Compare each page visually
+3. Check:
+   - Layout matches (or improved)
+   - Typography consistent
+   - Code highlighting works
+   - Links navigate correctly
+
+---
+
+## Rollback Plan
+
+If migration fails or issues are found:
+
+1. **Keep old content**: Don't delete `content/` until fully validated
+2. **Git branches**: Work on migration in feature branch
+3. **Parallel deployment**: Both sites can coexist during transition
+4. **Quick revert**: `git checkout` to restore Hugo setup
+
+---
+
+## Post-Migration Tasks
+
+1. **Set up redirects** (if URLs change)
+2. **Update sitemap**
+3. **Submit to search engines**
+4. **Update any external links** (social profiles, etc.)
+5. **Archive old Hugo config** or delete

--- a/plan/IMPLEMENTATION_PLAN.md
+++ b/plan/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,451 @@
+# Implementation Plan
+
+## Overview
+
+This document outlines the step-by-step implementation plan for rebuilding the blog with Next.js + MDX.
+
+---
+
+## Phase 1: Monorepo Foundation
+
+### Objective
+Set up the monorepo structure with Turborepo, pnpm, and basic configuration.
+
+### Tasks
+
+#### 1.1 Initialize Monorepo Root
+- [ ] Create root `package.json` with workspace scripts
+- [ ] Create `pnpm-workspace.yaml`
+- [ ] Create `turbo.json` for build orchestration
+- [ ] Update `.gitignore` for new structure
+
+#### 1.2 Create Config Package
+```
+packages/config/
+├── tsconfig/
+│   ├── base.json
+│   ├── react.json
+│   └── nextjs.json
+├── tailwind.config.js
+├── package.json
+└── README.md
+```
+
+#### 1.3 Create Tokens Package
+```
+packages/tokens/
+├── src/
+│   ├── colors.json
+│   ├── spacing.json
+│   ├── typography.json
+│   └── shadows.json
+├── style-dictionary.config.js
+├── package.json
+└── README.md
+```
+
+### Validation Checklist
+- [ ] `pnpm install` succeeds
+- [ ] `pnpm --filter @blog/tokens build` generates CSS/JS
+- [ ] TypeScript configs extend correctly
+
+---
+
+## Phase 2: UI Package
+
+### Objective
+Create the component library with essential primitives.
+
+### Tasks
+
+#### 2.1 Package Setup
+- [ ] Create `packages/ui/package.json` with dependencies
+- [ ] Set up TypeScript configuration
+- [ ] Configure Tailwind for the package
+- [ ] Create `cn()` utility function
+
+#### 2.2 Core Components
+Create minimal set of components needed for the blog:
+
+| Component | Priority | Description |
+|-----------|----------|-------------|
+| Button | High | Basic button with variants |
+| Card | High | Content container |
+| Badge | High | Category/tag labels |
+| Input | Medium | Search input |
+| Tabs | Medium | Tabbed content for code examples |
+| ThemeProvider | High | Dark/light mode |
+
+#### 2.3 Component Pattern
+Each component follows CVA pattern:
+```typescript
+// Example: Button.tsx
+import { cva, type VariantProps } from 'class-variance-authority';
+
+const buttonVariants = cva('base-classes', {
+  variants: {
+    variant: { primary: '...', secondary: '...' },
+    size: { sm: '...', md: '...', lg: '...' }
+  },
+  defaultVariants: { variant: 'primary', size: 'md' }
+});
+```
+
+### Validation Checklist
+- [ ] All components export correctly
+- [ ] TypeScript types are complete
+- [ ] Components render with Tailwind styles
+
+---
+
+## Phase 3: Blog App Skeleton
+
+### Objective
+Create the Next.js 14 blog application with basic routing.
+
+### Tasks
+
+#### 3.1 Initialize Next.js App
+```bash
+cd apps
+pnpm create next-app@latest blog --typescript --tailwind --app --src-dir
+```
+
+#### 3.2 Configure for Monorepo
+- [ ] Update `next.config.js` with `transpilePackages`
+- [ ] Configure Tailwind to include UI package paths
+- [ ] Import token CSS in `globals.css`
+- [ ] Set up static export configuration
+
+#### 3.3 Create Basic Layouts
+```
+apps/blog/app/
+├── layout.tsx          # Root layout
+├── [locale]/
+│   ├── layout.tsx      # Locale layout
+│   └── page.tsx        # Home page
+```
+
+#### 3.4 Configure i18n
+- [ ] Install and configure next-intl
+- [ ] Create locale routing middleware
+- [ ] Set up message files for zh/en
+
+### Validation Checklist
+- [ ] `pnpm --filter @blog/blog dev` starts on :3000
+- [ ] Root layout renders
+- [ ] Theme toggle works
+- [ ] Locale switching works
+
+---
+
+## Phase 4: MDX Configuration
+
+### Objective
+Set up MDX for content authoring with custom components.
+
+### Tasks
+
+#### 4.1 Install MDX Dependencies
+```bash
+pnpm --filter @blog/blog add @next/mdx @mdx-js/loader @mdx-js/react
+pnpm --filter @blog/blog add gray-matter
+pnpm --filter @blog/blog add rehype-pretty-code shiki
+pnpm --filter @blog/blog add remark-gfm
+```
+
+#### 4.2 Configure next.config.js
+```javascript
+const withMDX = require('@next/mdx')({
+  extension: /\.mdx?$/,
+  options: {
+    remarkPlugins: [remarkGfm],
+    rehypePlugins: [[rehypePrettyCode, { theme: 'github-dark' }]],
+  },
+});
+
+module.exports = withMDX({
+  pageExtensions: ['js', 'jsx', 'ts', 'tsx', 'md', 'mdx'],
+  // ... other config
+});
+```
+
+#### 4.3 Create MDX Components File
+```typescript
+// apps/blog/mdx-components.tsx
+import type { MDXComponents } from 'mdx/types';
+import { Callout, CodeBlock, Tabs } from '@/components/mdx';
+
+export function useMDXComponents(components: MDXComponents): MDXComponents {
+  return {
+    ...components,
+    Callout,
+    CodeBlock,
+    Tabs,
+    // Custom heading styles, etc.
+  };
+}
+```
+
+#### 4.4 Create Content Utilities
+```typescript
+// apps/blog/lib/content.ts
+- getPostBySlug(slug, locale)
+- getAllPosts(locale)
+- getPostSlugs()
+```
+
+### Validation Checklist
+- [ ] MDX files render correctly
+- [ ] Custom components work in MDX
+- [ ] Code highlighting works
+- [ ] Frontmatter parsing works
+
+---
+
+## Phase 5: Content Pages
+
+### Objective
+Build out all content page types with proper layouts.
+
+### Tasks
+
+#### 5.1 Blog Section
+- [ ] Create blog listing page (`/[locale]/blog/page.tsx`)
+- [ ] Create blog post page (`/[locale]/blog/[slug]/page.tsx`)
+- [ ] Implement PostCard component
+- [ ] Implement PostList component
+- [ ] Add pagination (if needed)
+
+#### 5.2 Collection Section
+- [ ] Create collection listing page
+- [ ] Create collection detail page
+- [ ] Implement CollectionCard component
+
+#### 5.3 Library Section
+- [ ] Create library listing page
+- [ ] Create paper note page
+- [ ] Implement PaperNote component
+
+#### 5.4 About Section
+- [ ] Create about page
+- [ ] Create resume subpage
+- [ ] Implement profile components
+
+#### 5.5 Shared Components
+- [ ] TableOfContents (auto-generated from headings)
+- [ ] ReadingTime component
+- [ ] ShareButtons component
+- [ ] NavigationLinks (prev/next post)
+
+### Validation Checklist
+- [ ] All routes accessible
+- [ ] Content renders correctly
+- [ ] Navigation works
+- [ ] Locale switching preserves route
+
+---
+
+## Phase 6: Content Migration
+
+### Objective
+Migrate existing Hugo content to MDX format.
+
+### Tasks
+
+#### 6.1 Create Migration Script
+```typescript
+// scripts/migrate-content.ts
+- Read Hugo markdown files
+- Parse frontmatter
+- Transform to MDX format
+- Handle footnotes
+- Handle shortcodes
+```
+
+#### 6.2 Migrate Blog Posts
+| Post | Status |
+|------|--------|
+| 10k-code.md | Pending |
+| 10k-cpp.md | Pending |
+| job_search_reflection.en.md | Pending |
+| meeting-how-to.md | Pending |
+| offer_negotiation.en.md | Pending |
+| programmer_quality.md | Pending |
+| programming_augmenting_intelligence.md | Pending |
+| reverse-interview.md | Pending |
+| short_pr.md | Pending |
+
+#### 6.3 Migrate Collections
+- [ ] psych-writing.md
+- [ ] system_design_interview.en.md
+- [ ] vision-100.md / vision-100.en.md
+
+#### 6.4 Migrate Library
+- [ ] All paper notes (15+ files)
+
+#### 6.5 Migrate Digests
+Decision: Keep or archive?
+- Option A: Migrate all 22 digests
+- Option B: Archive digests, keep only recent
+- Option C: Create digest archive page without individual routes
+
+### Validation Checklist
+- [ ] All content renders correctly
+- [ ] Links work
+- [ ] Images display
+- [ ] Code blocks highlight properly
+- [ ] Footnotes work
+
+---
+
+## Phase 7: Features & Polish
+
+### Objective
+Add remaining features and polish the experience.
+
+### Tasks
+
+#### 7.1 Search
+- [ ] Implement client-side search with Fuse.js
+- [ ] Create search index at build time
+- [ ] Add SearchDialog component
+- [ ] Add keyboard shortcut (Cmd/Ctrl + K)
+
+#### 7.2 RSS Feed
+- [ ] Generate RSS at build time
+- [ ] Add feed link to layout
+
+#### 7.3 SEO
+- [ ] Configure metadata for all pages
+- [ ] Add Open Graph images
+- [ ] Add structured data (JSON-LD)
+- [ ] Create sitemap
+
+#### 7.4 Performance
+- [ ] Optimize images with next/image
+- [ ] Add font optimization
+- [ ] Verify Core Web Vitals
+
+#### 7.5 Accessibility
+- [ ] Test with screen reader
+- [ ] Verify keyboard navigation
+- [ ] Check color contrast
+
+### Validation Checklist
+- [ ] Search works
+- [ ] RSS feed validates
+- [ ] Lighthouse score > 90
+- [ ] No accessibility errors
+
+---
+
+## Phase 8: Deployment
+
+### Objective
+Configure static export and deploy to GitHub Pages.
+
+### Tasks
+
+#### 8.1 Static Export Configuration
+```javascript
+// next.config.js
+module.exports = {
+  output: 'export',
+  distDir: 'docs',
+  images: { unoptimized: true }, // Required for static export
+  trailingSlash: true,
+};
+```
+
+#### 8.2 Build Script
+```json
+{
+  "scripts": {
+    "build": "next build",
+    "export": "next build && touch docs/.nojekyll"
+  }
+}
+```
+
+#### 8.3 GitHub Pages Setup
+- [ ] Ensure CNAME file is copied to output
+- [ ] Add `.nojekyll` file
+- [ ] Test deployment
+
+#### 8.4 CI/CD (Optional)
+- [ ] GitHub Actions workflow for auto-deploy
+- [ ] Build validation on PRs
+
+### Validation Checklist
+- [ ] Static export succeeds
+- [ ] All pages accessible
+- [ ] CNAME preserved
+- [ ] Site works on GitHub Pages
+
+---
+
+## Phase 9: Cleanup
+
+### Objective
+Remove old Hugo setup and finalize migration.
+
+### Tasks
+
+#### 9.1 Archive Old Content
+- [ ] Move old `content/` to `content-archive/` or delete
+- [ ] Remove Hugo `config.yml`
+- [ ] Remove `archetypes/` directory
+
+#### 9.2 Update Documentation
+- [ ] Update root README.md
+- [ ] Document content authoring workflow
+- [ ] Document deployment process
+
+#### 9.3 Final Verification
+- [ ] All URLs match old structure (or set up redirects)
+- [ ] No broken links
+- [ ] Analytics working (if applicable)
+
+---
+
+## Timeline Estimates
+
+| Phase | Complexity | Dependencies |
+|-------|------------|--------------|
+| Phase 1: Foundation | Low | None |
+| Phase 2: UI Package | Medium | Phase 1 |
+| Phase 3: Blog Skeleton | Medium | Phase 1, 2 |
+| Phase 4: MDX Setup | Medium | Phase 3 |
+| Phase 5: Content Pages | Medium | Phase 4 |
+| Phase 6: Migration | High | Phase 5 |
+| Phase 7: Features | Medium | Phase 6 |
+| Phase 8: Deployment | Low | Phase 7 |
+| Phase 9: Cleanup | Low | Phase 8 |
+
+---
+
+## Risk Mitigation
+
+### Risk: Static Export Limitations
+**Mitigation**: Use `output: 'export'` from start, avoid features requiring server.
+
+### Risk: i18n Complexity
+**Mitigation**: Start with simple file-based approach, add complexity as needed.
+
+### Risk: Content Migration Errors
+**Mitigation**: Run parallel sites during migration, verify each page.
+
+### Risk: Breaking URLs
+**Mitigation**: Map old URLs to new, set up redirects if needed.
+
+---
+
+## Success Criteria
+
+1. **Functional Parity**: All existing content accessible
+2. **Performance**: Lighthouse score > 90
+3. **Interactivity**: MDX components work as expected
+4. **Maintainability**: Clear component structure
+5. **Developer Experience**: Fast local development
+6. **Deployment**: Automated build to GitHub Pages

--- a/plan/MDX_COMPONENTS.md
+++ b/plan/MDX_COMPONENTS.md
@@ -1,0 +1,726 @@
+# MDX Component Specifications
+
+## Overview
+
+This document specifies the custom MDX components available for use in blog content. These components enable interactive and rich content experiences while maintaining consistency with the design system.
+
+---
+
+## Component Categories
+
+### 1. Content Enhancement
+- Callout
+- Quote
+- Definition
+
+### 2. Code & Technical
+- CodeBlock
+- CodeGroup
+- LiveCode (future)
+
+### 3. Navigation & Structure
+- Tabs
+- Accordion
+- TableOfContents
+
+### 4. Media
+- Image (enhanced)
+- Video
+- Diagram
+
+### 5. Academic
+- Citation
+- Footnote
+- Math (KaTeX)
+
+---
+
+## Component Specifications
+
+### Callout
+
+Highlighted message boxes for tips, warnings, and information.
+
+**Props:**
+```typescript
+interface CalloutProps {
+  type: 'info' | 'warning' | 'danger' | 'success' | 'note';
+  title?: string;
+  children: React.ReactNode;
+}
+```
+
+**Usage:**
+```mdx
+<Callout type="info" title="Did you know?">
+  This is an informational callout with helpful context.
+</Callout>
+
+<Callout type="warning">
+  Be careful with this operation!
+</Callout>
+
+<Callout type="danger">
+  This action is irreversible.
+</Callout>
+```
+
+**Visual Design:**
+| Type | Background | Border | Icon |
+|------|------------|--------|------|
+| info | blue-50 | blue-500 | ℹ️ |
+| warning | amber-50 | amber-500 | ⚠️ |
+| danger | red-50 | red-500 | 🚫 |
+| success | green-50 | green-500 | ✅ |
+| note | gray-50 | gray-500 | 📝 |
+
+**Implementation:**
+```typescript
+// apps/blog/components/mdx/Callout.tsx
+import { cn } from '@blog/ui';
+import type { CalloutProps } from '@/components/mdx/types';
+
+const calloutStyles = {
+  info: 'bg-blue-50 border-blue-500 text-blue-900',
+  warning: 'bg-amber-50 border-amber-500 text-amber-900',
+  danger: 'bg-red-50 border-red-500 text-red-900',
+  success: 'bg-green-50 border-green-500 text-green-900',
+  note: 'bg-gray-50 border-gray-500 text-gray-900',
+};
+
+const icons = {
+  info: 'ℹ️',
+  warning: '⚠️',
+  danger: '🚫',
+  success: '✅',
+  note: '📝',
+};
+
+export function Callout({ type = 'info', title, children }: CalloutProps) {
+  return (
+    <div className={cn('border-l-4 p-4 my-4 rounded-r', calloutStyles[type])}>
+      <div className="flex items-start gap-2">
+        <span className="text-xl">{icons[type]}</span>
+        <div>
+          {title && <p className="font-semibold mb-1">{title}</p>}
+          <div className="prose-sm">{children}</div>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+---
+
+### CodeBlock
+
+Enhanced code blocks with syntax highlighting, copy button, filename, and line highlighting.
+
+**Props:**
+```typescript
+interface CodeBlockProps {
+  language?: string;
+  filename?: string;
+  highlightLines?: number[];
+  showLineNumbers?: boolean;
+  children: string;
+}
+```
+
+**Usage:**
+```mdx
+<CodeBlock language="typescript" filename="utils.ts" highlightLines={[2, 3]}>
+{`function add(a: number, b: number): number {
+  const sum = a + b;
+  return sum;
+}`}
+</CodeBlock>
+```
+
+**Features:**
+- Syntax highlighting via Shiki/rehype-pretty-code
+- Copy to clipboard button
+- Optional filename header
+- Optional line numbers
+- Line highlighting
+- Dark/light theme support
+
+**Note:** Most code blocks will use standard markdown fenced code blocks, which are automatically enhanced by rehype-pretty-code. The `<CodeBlock>` component is for advanced cases.
+
+---
+
+### CodeGroup
+
+Group multiple code blocks (e.g., for different languages or before/after).
+
+**Props:**
+```typescript
+interface CodeGroupProps {
+  children: React.ReactNode;
+}
+
+interface CodeGroupItemProps {
+  title: string;
+  children: React.ReactNode;
+}
+```
+
+**Usage:**
+```mdx
+<CodeGroup>
+  <CodeGroupItem title="TypeScript">
+    ```typescript
+    const greeting: string = "Hello";
+    ```
+  </CodeGroupItem>
+  <CodeGroupItem title="JavaScript">
+    ```javascript
+    const greeting = "Hello";
+    ```
+  </CodeGroupItem>
+</CodeGroup>
+```
+
+---
+
+### Tabs
+
+Generic tabbed content container.
+
+**Props:**
+```typescript
+interface TabsProps {
+  defaultValue: string;
+  children: React.ReactNode;
+}
+
+interface TabsListProps {
+  children: React.ReactNode;
+}
+
+interface TabsTriggerProps {
+  value: string;
+  children: React.ReactNode;
+}
+
+interface TabsContentProps {
+  value: string;
+  children: React.ReactNode;
+}
+```
+
+**Usage:**
+```mdx
+<Tabs defaultValue="concept">
+  <TabsList>
+    <TabsTrigger value="concept">Concept</TabsTrigger>
+    <TabsTrigger value="example">Example</TabsTrigger>
+    <TabsTrigger value="exercise">Exercise</TabsTrigger>
+  </TabsList>
+  <TabsContent value="concept">
+    The concept explanation goes here...
+  </TabsContent>
+  <TabsContent value="example">
+    A practical example...
+  </TabsContent>
+  <TabsContent value="exercise">
+    Try this yourself...
+  </TabsContent>
+</Tabs>
+```
+
+**Implementation:**
+Use Radix UI Tabs primitive with custom styling.
+
+---
+
+### Accordion
+
+Collapsible content sections.
+
+**Props:**
+```typescript
+interface AccordionProps {
+  type?: 'single' | 'multiple';
+  children: React.ReactNode;
+}
+
+interface AccordionItemProps {
+  value: string;
+  title: string;
+  children: React.ReactNode;
+}
+```
+
+**Usage:**
+```mdx
+<Accordion type="single">
+  <AccordionItem value="q1" title="What is MDX?">
+    MDX is a format that lets you write JSX in your markdown documents.
+  </AccordionItem>
+  <AccordionItem value="q2" title="Why use MDX?">
+    MDX enables interactive and reusable content components.
+  </AccordionItem>
+</Accordion>
+```
+
+---
+
+### Image (Enhanced)
+
+Enhanced image component with caption, zoom, and lazy loading.
+
+**Props:**
+```typescript
+interface ImageProps {
+  src: string;
+  alt: string;
+  caption?: string;
+  width?: number;
+  height?: number;
+  priority?: boolean;
+}
+```
+
+**Usage:**
+```mdx
+<Image
+  src="/images/architecture-diagram.png"
+  alt="System architecture diagram"
+  caption="Figure 1: High-level system architecture"
+  width={800}
+  height={600}
+/>
+```
+
+**Features:**
+- Optimized loading via next/image
+- Optional caption below image
+- Click to zoom (using a modal)
+- Responsive sizing
+
+---
+
+### Citation
+
+Academic citation reference.
+
+**Props:**
+```typescript
+interface CitationProps {
+  id: string;
+  authors: string;
+  year: number;
+  title: string;
+  venue?: string;
+  url?: string;
+}
+```
+
+**Usage:**
+```mdx
+Recent research <Citation id="smith2023" authors="Smith et al." year={2023} title="Deep Learning Advances" venue="NeurIPS" /> shows that...
+
+## References
+<CitationList />
+```
+
+**Features:**
+- Inline citation markers
+- Auto-generated reference list
+- Link to paper if URL provided
+
+---
+
+### Definition
+
+Inline term definition with tooltip.
+
+**Props:**
+```typescript
+interface DefinitionProps {
+  term: string;
+  children: React.ReactNode;
+}
+```
+
+**Usage:**
+```mdx
+The <Definition term="API">Application Programming Interface</Definition> provides
+a way for different software systems to communicate.
+```
+
+**Features:**
+- Dotted underline on term
+- Tooltip on hover with definition
+- Works on mobile (tap to show)
+
+---
+
+### Math
+
+Mathematical equations using KaTeX.
+
+**Usage:**
+```mdx
+Inline math: $E = mc^2$
+
+Block math:
+$$
+\int_{-\infty}^{\infty} e^{-x^2} dx = \sqrt{\pi}
+$$
+```
+
+**Implementation:**
+Configure remark-math and rehype-katex in MDX pipeline:
+```javascript
+// next.config.js
+const withMDX = require('@next/mdx')({
+  options: {
+    remarkPlugins: [remarkMath],
+    rehypePlugins: [rehypeKatex],
+  },
+});
+```
+
+Add KaTeX CSS to globals.css:
+```css
+@import 'katex/dist/katex.min.css';
+```
+
+---
+
+### Diagram
+
+Embed diagrams using Mermaid or custom SVG.
+
+**Props:**
+```typescript
+interface DiagramProps {
+  type?: 'mermaid' | 'svg';
+  caption?: string;
+  children: string;
+}
+```
+
+**Usage (Mermaid):**
+```mdx
+<Diagram type="mermaid" caption="User flow diagram">
+{`
+graph TD
+    A[User visits] --> B{Logged in?}
+    B -->|Yes| C[Dashboard]
+    B -->|No| D[Login page]
+`}
+</Diagram>
+```
+
+**Usage (SVG):**
+```mdx
+<Diagram type="svg" caption="Custom diagram">
+  <svg>...</svg>
+</Diagram>
+```
+
+---
+
+### Quote
+
+Enhanced blockquote with attribution.
+
+**Props:**
+```typescript
+interface QuoteProps {
+  author?: string;
+  source?: string;
+  children: React.ReactNode;
+}
+```
+
+**Usage:**
+```mdx
+<Quote author="Donald Knuth" source="The Art of Computer Programming">
+  Premature optimization is the root of all evil.
+</Quote>
+```
+
+---
+
+## Typography Overrides
+
+These components override default markdown elements:
+
+### Headings
+
+```typescript
+// All headings get anchor links and custom styling
+const components = {
+  h1: (props) => (
+    <h1 className="text-3xl font-bold mt-8 mb-4" {...props}>
+      <a href={`#${props.id}`} className="anchor-link">
+        {props.children}
+      </a>
+    </h1>
+  ),
+  h2: (props) => (
+    <h2 className="text-2xl font-semibold mt-6 mb-3" {...props}>
+      <a href={`#${props.id}`} className="anchor-link">
+        {props.children}
+      </a>
+    </h2>
+  ),
+  // ...
+};
+```
+
+### Links
+
+```typescript
+// External links get icon and open in new tab
+const components = {
+  a: ({ href, children, ...props }) => {
+    const isExternal = href?.startsWith('http');
+    return (
+      <a
+        href={href}
+        target={isExternal ? '_blank' : undefined}
+        rel={isExternal ? 'noopener noreferrer' : undefined}
+        className="text-blue-600 hover:underline"
+        {...props}
+      >
+        {children}
+        {isExternal && <ExternalLinkIcon className="inline ml-1 w-3 h-3" />}
+      </a>
+    );
+  },
+};
+```
+
+### Code (Inline)
+
+```typescript
+const components = {
+  code: ({ children, ...props }) => (
+    <code
+      className="bg-gray-100 dark:bg-gray-800 px-1.5 py-0.5 rounded text-sm font-mono"
+      {...props}
+    >
+      {children}
+    </code>
+  ),
+};
+```
+
+### Tables
+
+```typescript
+const components = {
+  table: (props) => (
+    <div className="overflow-x-auto my-4">
+      <table className="min-w-full border-collapse" {...props} />
+    </div>
+  ),
+  th: (props) => (
+    <th className="border-b-2 border-gray-200 px-4 py-2 text-left font-semibold" {...props} />
+  ),
+  td: (props) => (
+    <td className="border-b border-gray-100 px-4 py-2" {...props} />
+  ),
+};
+```
+
+---
+
+## MDX Component Registration
+
+### mdx-components.tsx
+
+```typescript
+// apps/blog/mdx-components.tsx
+import type { MDXComponents } from 'mdx/types';
+import {
+  Callout,
+  CodeBlock,
+  CodeGroup,
+  CodeGroupItem,
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  TabsContent,
+  Accordion,
+  AccordionItem,
+  Image,
+  Citation,
+  CitationList,
+  Definition,
+  Diagram,
+  Quote,
+} from '@/components/mdx';
+import {
+  CustomH1,
+  CustomH2,
+  CustomH3,
+  CustomLink,
+  CustomInlineCode,
+  CustomPre,
+  CustomTable,
+  CustomTh,
+  CustomTd,
+} from '@/components/mdx/typography';
+
+export function useMDXComponents(components: MDXComponents): MDXComponents {
+  return {
+    // Custom components
+    Callout,
+    CodeBlock,
+    CodeGroup,
+    CodeGroupItem,
+    Tabs,
+    TabsList,
+    TabsTrigger,
+    TabsContent,
+    Accordion,
+    AccordionItem,
+    Image,
+    Citation,
+    CitationList,
+    Definition,
+    Diagram,
+    Quote,
+
+    // Typography overrides
+    h1: CustomH1,
+    h2: CustomH2,
+    h3: CustomH3,
+    a: CustomLink,
+    code: CustomInlineCode,
+    pre: CustomPre,
+    table: CustomTable,
+    th: CustomTh,
+    td: CustomTd,
+
+    // Spread any additional components
+    ...components,
+  };
+}
+```
+
+---
+
+## Implementation Priority
+
+### Phase 1: Essential (MVP)
+1. **Callout** - Critical for tips/warnings
+2. **CodeBlock** - Enhanced via rehype-pretty-code
+3. **Image** - Enhanced images with captions
+4. **Typography overrides** - Consistent styling
+
+### Phase 2: Content Structure
+5. **Tabs** - For multi-language examples
+6. **Quote** - For citations
+7. **Accordion** - For FAQs
+
+### Phase 3: Academic Features
+8. **Citation** - Paper references
+9. **Math** - Equations
+10. **Diagram** - Mermaid diagrams
+
+### Phase 4: Advanced
+11. **Definition** - Glossary terms
+12. **CodeGroup** - Multi-file examples
+13. **LiveCode** - Interactive code playground
+
+---
+
+## Dependencies
+
+```json
+{
+  "dependencies": {
+    "@radix-ui/react-tabs": "^1.0.0",
+    "@radix-ui/react-accordion": "^1.0.0",
+    "@radix-ui/react-tooltip": "^1.0.0",
+    "mermaid": "^10.0.0",
+    "katex": "^0.16.0"
+  },
+  "devDependencies": {
+    "rehype-pretty-code": "^0.12.0",
+    "rehype-katex": "^7.0.0",
+    "remark-math": "^6.0.0",
+    "remark-gfm": "^4.0.0",
+    "shiki": "^1.0.0"
+  }
+}
+```
+
+---
+
+## Example Blog Post with Components
+
+```mdx
+---
+title: "Building a Design System"
+date: "2024-01-15"
+locale: "en"
+tags: ["design-system", "react", "typescript"]
+---
+
+# Building a Design System
+
+<Callout type="info">
+  This post covers the fundamentals of building a design system from scratch.
+</Callout>
+
+## Why Design Systems Matter
+
+<Quote author="Brad Frost" source="Atomic Design">
+  Design systems are the core building blocks of modern web applications.
+</Quote>
+
+## Implementation
+
+<Tabs defaultValue="typescript">
+  <TabsList>
+    <TabsTrigger value="typescript">TypeScript</TabsTrigger>
+    <TabsTrigger value="javascript">JavaScript</TabsTrigger>
+  </TabsList>
+  <TabsContent value="typescript">
+    ```typescript
+    interface ButtonProps {
+      variant: 'primary' | 'secondary';
+      children: React.ReactNode;
+    }
+    ```
+  </TabsContent>
+  <TabsContent value="javascript">
+    ```javascript
+    // Button component
+    function Button({ variant, children }) {
+      return <button className={variant}>{children}</button>;
+    }
+    ```
+  </TabsContent>
+</Tabs>
+
+## Architecture
+
+<Diagram type="mermaid" caption="Design system architecture">
+{`
+graph TB
+    A[Tokens] --> B[Primitives]
+    B --> C[Patterns]
+    C --> D[App Components]
+    D --> E[Pages]
+`}
+</Diagram>
+
+## Key Takeaways
+
+<Callout type="success" title="Summary">
+  - Start with tokens
+  - Build primitives
+  - Compose patterns
+  - Keep it simple
+</Callout>
+```

--- a/plan/README.md
+++ b/plan/README.md
@@ -1,0 +1,80 @@
+# Blog Redesign Plan
+
+## Overview
+
+This directory contains the planning documentation for rebuilding the personal blog from Hugo/PaperMod to a Next.js + MDX design system approach.
+
+## Documents
+
+| Document | Description |
+|----------|-------------|
+| [ARCHITECTURE.md](./ARCHITECTURE.md) | System architecture, 5-layer design system, technology stack, directory structure |
+| [IMPLEMENTATION_PLAN.md](./IMPLEMENTATION_PLAN.md) | Phase-by-phase implementation plan with tasks and validation checklists |
+| [CONTENT_MIGRATION.md](./CONTENT_MIGRATION.md) | Content inventory, transformation rules, migration scripts |
+| [MDX_COMPONENTS.md](./MDX_COMPONENTS.md) | Custom MDX component specifications and usage examples |
+
+## Quick Summary
+
+### Current State
+- Hugo static site with PaperMod theme
+- Markdown content (blog, collections, library, digests)
+- Multi-language (zh/en)
+- GitHub Pages deployment
+
+### Target State
+- Next.js 14 with App Router
+- MDX for interactive content
+- Design system monorepo (Turborepo + pnpm)
+- Same GitHub Pages deployment
+
+### Key Features
+- Interactive MDX components (Callout, Tabs, CodeBlock, Diagram)
+- Design tokens for consistent styling
+- Reusable UI component library
+- i18n support preserved
+- Static export to `docs/`
+
+## Implementation Phases
+
+```
+Phase 1: Monorepo Foundation     → Turborepo, pnpm, configs
+Phase 2: UI Package              → Button, Card, Badge components
+Phase 3: Blog App Skeleton       → Next.js with routing
+Phase 4: MDX Configuration       → MDX pipeline setup
+Phase 5: Content Pages           → Blog, collection, library pages
+Phase 6: Content Migration       → Hugo markdown → MDX
+Phase 7: Features & Polish       → Search, RSS, SEO
+Phase 8: Deployment              → Static export, GitHub Pages
+Phase 9: Cleanup                 → Remove Hugo, update docs
+```
+
+## Getting Started
+
+Once you're ready to begin implementation:
+
+1. Read [ARCHITECTURE.md](./ARCHITECTURE.md) for the big picture
+2. Follow [IMPLEMENTATION_PLAN.md](./IMPLEMENTATION_PLAN.md) phase by phase
+3. Reference [CONTENT_MIGRATION.md](./CONTENT_MIGRATION.md) when moving content
+4. Use [MDX_COMPONENTS.md](./MDX_COMPONENTS.md) for component guidelines
+
+## Decisions Needed
+
+Before starting, consider:
+
+1. **Keep multi-language?** Current site has zh/en. Simplify to one?
+2. **Digest archive?** Keep all 22 digests or consolidate?
+3. **Design aesthetic?** Minimal like PaperMod or more visual?
+4. **Interactive priorities?** Which MDX components are most important?
+
+## Next Steps
+
+1. Review and approve this plan
+2. Set up the monorepo foundation (Phase 1)
+3. Create the UI package (Phase 2)
+4. Build the blog skeleton (Phase 3)
+5. Iterate from there
+
+---
+
+*Created: 2024-12-13*
+*Status: Planning*

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - 'packages/*'
+  - 'apps/*'

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**", ".next/**", "out/**", "build/**", "storybook-static/**"]
+    },
+    "dev": {
+      "cache": false,
+      "persistent": true
+    },
+    "lint": {
+      "dependsOn": ["^lint"]
+    },
+    "clean": {
+      "cache": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Set up Turborepo + pnpm monorepo structure for blog redesign
- Created `@blog/config` package with shared TypeScript and Tailwind configs
- Created `@blog/tokens` package with Style Dictionary for design tokens (colors, spacing, typography)
- Added planning documentation for architecture, implementation phases, content migration, and MDX components
- Added `AGENT.md` and `DEV_GUIDE.md` for developer onboarding

## Phase 1: Monorepo Foundation

This PR completes Phase 1 of the blog redesign from Hugo/PaperMod to Next.js + MDX.

### New Structure
```
packages/
├── config/      # TypeScript & Tailwind configs
└── tokens/      # Design tokens (Style Dictionary)
apps/
└── blog/        # (to be created in Phase 3)
plan/            # Architecture & implementation docs
```

### Next Steps
- Phase 2: UI Package (`@blog/ui`)
- Phase 3: Blog App Skeleton (`@blog/blog`)
- Phase 4: MDX Configuration
- Phase 5-9: Content pages, migration, polish, deployment

## Test plan

- [x] `pnpm install` succeeds
- [x] `pnpm --filter @blog/tokens build` generates CSS and JS tokens
- [ ] Review planning docs in `plan/` directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)