### PR TITLE
feat(ui): add UI package with primitive components and Storybook

### DIFF
--- a/apps/docs/.storybook/main.ts
+++ b/apps/docs/.storybook/main.ts
@@ -1,0 +1,34 @@
+import type { StorybookConfig } from '@storybook/react-vite';
+import path from 'path';
+
+const config: StorybookConfig = {
+  stories: [
+    // Co-located stories from packages/ui
+    '../../../packages/ui/src/**/*.stories.@(js|jsx|mjs|ts|tsx)',
+    // Local stories
+    '../stories/**/*.stories.@(js|jsx|mjs|ts|tsx)',
+  ],
+  addons: [
+    '@storybook/addon-links',
+    '@storybook/addon-essentials',
+    '@storybook/addon-interactions',
+  ],
+  framework: {
+    name: '@storybook/react-vite',
+    options: {},
+  },
+  typescript: {
+    reactDocgen: 'react-docgen-typescript',
+  },
+  viteFinal: async (config) => {
+    if (config.resolve) {
+      config.resolve.alias = {
+        ...config.resolve.alias,
+        '@ui': path.resolve(__dirname, '../../../packages/ui/src'),
+      };
+    }
+    return config;
+  },
+};
+
+export default config;

--- a/apps/docs/.storybook/preview.tsx
+++ b/apps/docs/.storybook/preview.tsx
@@ -1,0 +1,61 @@
+import type { Preview } from '@storybook/react';
+
+// Import token CSS
+import '@blog/tokens/css';
+
+// Import Tailwind styles
+import '../styles/globals.css';
+
+const preview: Preview = {
+  parameters: {
+    controls: {
+      matchers: {
+        color: /(background|color)$/i,
+        date: /Date$/i,
+      },
+    },
+    backgrounds: {
+      default: 'light',
+      values: [
+        { name: 'light', value: 'var(--color-bg-primary)' },
+        { name: 'dark', value: '#09090b' },
+      ],
+    },
+  },
+  globalTypes: {
+    theme: {
+      description: 'Theme',
+      defaultValue: 'nyt',
+      toolbar: {
+        title: 'Theme',
+        icon: 'paintbrush',
+        items: ['nyt'],
+        dynamicTitle: true,
+      },
+    },
+    mode: {
+      description: 'Color mode',
+      defaultValue: 'light',
+      toolbar: {
+        title: 'Mode',
+        icon: 'sun',
+        items: ['light', 'dark'],
+        dynamicTitle: true,
+      },
+    },
+  },
+  decorators: [
+    (Story, context) => {
+      const theme = context.globals.theme || 'nyt';
+      const mode = context.globals.mode || 'light';
+
+      // Set data attributes on document for theme switching
+      document.documentElement.dataset.theme = theme;
+      document.documentElement.dataset.mode = mode;
+
+      return <Story />;
+    },
+  ],
+};
+
+export default preview;

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@blog/docs",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "storybook dev -p 6006",
+    "build": "storybook build -o dist",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@blog/tokens": "workspace:*",
+    "@blog/ui": "workspace:*",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@storybook/addon-essentials": "^8.4.0",
+    "@storybook/addon-interactions": "^8.4.0",
+    "@storybook/addon-links": "^8.4.0",
+    "@storybook/blocks": "^8.4.0",
+    "@storybook/react": "^8.4.0",
+    "@storybook/react-vite": "^8.4.0",
+    "@storybook/test": "^8.4.0",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "autoprefixer": "^10.4.0",
+    "postcss": "^8.4.0",
+    "storybook": "^8.4.0",
+    "tailwindcss": "^3.4.0",
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/apps/docs/postcss.config.js
+++ b/apps/docs/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/apps/docs/styles/globals.css
+++ b/apps/docs/styles/globals.css
@@ -1,0 +1,18 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+/* Set default theme */
+:root {
+  color-scheme: light dark;
+}
+
+[data-mode="dark"] {
+  color-scheme: dark;
+}
+
+body {
+  font-family: var(--font-family-body);
+  background-color: var(--color-bg-primary);
+  color: var(--color-text-primary);
+}

--- a/apps/docs/tailwind.config.js
+++ b/apps/docs/tailwind.config.js
@@ -1,0 +1,64 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './stories/**/*.{ts,tsx}',
+    '../../packages/ui/src/**/*.{ts,tsx}',
+  ],
+  theme: {
+    extend: {
+      colors: {
+        // Ground: background/surface colors (what things sit ON)
+        ground: {
+          primary: 'var(--color-bg-primary)',
+          secondary: 'var(--color-bg-secondary)',
+          tertiary: 'var(--color-bg-tertiary)',
+          inverse: 'var(--color-bg-inverse)',
+        },
+        // Figure: foreground/content colors (what you SEE)
+        figure: {
+          primary: 'var(--color-text-primary)',
+          secondary: 'var(--color-text-secondary)',
+          muted: 'var(--color-text-muted)',
+          inverse: 'var(--color-text-inverse)',
+        },
+        border: {
+          DEFAULT: 'var(--color-border-default)',
+          muted: 'var(--color-border-muted)',
+          strong: 'var(--color-border-strong)',
+        },
+        action: {
+          primary: 'var(--color-action-primary)',
+          'primary-hover': 'var(--color-action-primary-hover)',
+          secondary: 'var(--color-action-secondary)',
+          'secondary-hover': 'var(--color-action-secondary-hover)',
+        },
+        status: {
+          info: 'var(--color-status-info)',
+          'info-bg': 'var(--color-status-info-bg)',
+          success: 'var(--color-status-success)',
+          'success-bg': 'var(--color-status-success-bg)',
+          warning: 'var(--color-status-warning)',
+          'warning-bg': 'var(--color-status-warning-bg)',
+          danger: 'var(--color-status-danger)',
+          'danger-bg': 'var(--color-status-danger-bg)',
+        },
+      },
+      fontFamily: {
+        heading: 'var(--font-family-heading)',
+        body: 'var(--font-family-body)',
+        code: 'var(--font-family-code)',
+      },
+      borderRadius: {
+        DEFAULT: 'var(--radius-default)',
+        sm: 'var(--radius-sm)',
+        lg: 'var(--radius-lg)',
+        full: 'var(--radius-full)',
+      },
+      borderWidth: {
+        DEFAULT: 'var(--border-width-default)',
+        thick: 'var(--border-width-thick)',
+      },
+    },
+  },
+  plugins: [],
+};

--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": [".storybook/**/*", "stories/**/*"]
+}

--- a/apps/docs/vite.config.ts
+++ b/apps/docs/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import path from 'path';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@ui': path.resolve(__dirname, '../../packages/ui/src'),
+    },
+  },
+});

--- a/packages/ui/docs/ARCHITECTURE.md
+++ b/packages/ui/docs/ARCHITECTURE.md
@@ -1,0 +1,130 @@
+# UI Package Architecture
+
+## Overview
+
+`@blog/ui` is the shared component library for the blog design system. It provides primitive and pattern components that consume design tokens from `@blog/tokens`.
+
+## Layer Model
+
+```
+Layer 3: Patterns    → Callout, (future: Tabs, Modal, Accordion)
+Layer 2: Primitives  → Button, Card
+Layer 1: Tokens      → @blog/tokens (colors, typography, spacing)
+```
+
+**Rule**: Components only import from same or lower layers.
+
+## Component Structure
+
+Each component lives in its own folder with co-located stories:
+
+```
+src/components/
+├── Button/
+│   ├── Button.tsx         # Component implementation
+│   ├── Button.stories.tsx # Storybook stories
+│   └── index.ts           # Public exports
+```
+
+## Technology Choices
+
+| Tool | Purpose |
+|------|---------|
+| CVA (class-variance-authority) | Variant management for component styles |
+| Tailwind CSS | Utility-first styling with semantic tokens |
+| forwardRef | All components support ref forwarding |
+| TypeScript | Full type safety |
+
+## Styling Approach
+
+Components use Tailwind classes that map to CSS custom properties from `@blog/tokens`:
+
+```tsx
+// Button uses semantic token classes
+<button className="bg-action-primary text-figure-inverse hover:bg-action-primary-hover">
+```
+
+### Color Categories
+
+| Category | Purpose | Tailwind prefix |
+|----------|---------|-----------------|
+| `ground` | Background/surface colors | `bg-ground-*` |
+| `figure` | Text/foreground colors | `text-figure-*` |
+| `border` | Border colors | `border-border-*` |
+| `action` | Interactive elements | `bg-action-*`, `text-action-*` |
+| `status` | Semantic feedback | `bg-status-*`, `text-status-*` |
+
+See [Design Language](./DESIGN_LANGUAGE.md) for the ground/figure naming rationale.
+
+## Adding a New Component
+
+1. Create folder: `src/components/ComponentName/`
+2. Add implementation: `ComponentName.tsx`
+3. Add stories: `ComponentName.stories.tsx`
+4. Add barrel export: `index.ts`
+5. Export from `src/index.tsx`
+
+### Component Template
+
+```tsx
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@ui/lib/utils';
+
+const componentVariants = cva(
+  'base-classes',
+  {
+    variants: {
+      variant: {
+        default: 'default-classes',
+      },
+      size: {
+        md: 'size-classes',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'md',
+    },
+  }
+);
+
+export interface ComponentProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof componentVariants> {}
+
+const Component = React.forwardRef<HTMLDivElement, ComponentProps>(
+  ({ className, variant, size, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={cn(componentVariants({ variant, size, className }))}
+        {...props}
+      />
+    );
+  }
+);
+Component.displayName = 'Component';
+
+export { Component, componentVariants };
+```
+
+## Utilities
+
+### `cn()` - Class Name Merger
+
+Located in `src/lib/utils.ts`, combines `clsx` and `tailwind-merge`:
+
+```tsx
+import { cn } from '@ui/lib/utils';
+
+// Merges classes and resolves Tailwind conflicts
+cn('px-4 py-2', 'px-6', className) // → 'py-2 px-6 ...'
+```
+
+## Dependencies
+
+- `@blog/tokens` - Design tokens (CSS custom properties)
+- `class-variance-authority` - Variant management
+- `clsx` - Conditional class joining
+- `tailwind-merge` - Tailwind class conflict resolution

--- a/packages/ui/docs/DESIGN_LANGUAGE.md
+++ b/packages/ui/docs/DESIGN_LANGUAGE.md
@@ -1,0 +1,122 @@
+# Design Language
+
+## Color Naming: Ground & Figure
+
+We use **ground** and **figure** as semantic color categories to avoid redundant Tailwind class names.
+
+### The Problem
+
+If we named our token categories `bg` and `text`, we'd get awkward class names:
+- `bg-bg-primary` (background using background color)
+- `text-text-primary` (text using text color)
+
+### The Solution
+
+Rename categories using Gestalt psychology terminology:
+
+**Ground** = Background/surface colors (what things sit ON)
+- Page backgrounds, card surfaces, input fields
+- The "canvas" or "stage"
+- Usage: `bg-ground-primary`, `bg-ground-secondary`
+
+**Figure** = Foreground/content colors (what you SEE)
+- Text, icons, labels
+- The "actors" on the stage
+- Usage: `text-figure-primary`, `text-figure-muted`
+
+### Examples
+
+```tsx
+// Clear, readable classes
+<div className="bg-ground-secondary text-figure-primary">
+  <h2 className="text-figure-primary">Title</h2>
+  <p className="text-figure-muted">Description</p>
+</div>
+
+// vs what we avoided
+<div className="bg-bg-secondary text-text-primary">
+```
+
+### One-Directional Usage
+
+The naming is intentionally constrained:
+- `ground` only with `bg-` → `bg-ground-*`
+- `figure` only with `text-` → `text-figure-*`
+
+You would never write `bg-figure-*` or `text-ground-*`.
+
+### Full Color Palette
+
+| Category | CSS Variable Pattern | Tailwind Usage |
+|----------|---------------------|----------------|
+| Ground | `--color-bg-*` | `bg-ground-{variant}` |
+| Figure | `--color-text-*` | `text-figure-{variant}` |
+| Border | `--color-border-*` | `border-border-{variant}` |
+| Action | `--color-action-*` | `bg-action-*`, `text-action-*` |
+| Status | `--color-status-*` | `bg-status-*`, `text-status-*` |
+
+### Variants
+
+**Ground variants:**
+- `primary` - Main page background
+- `secondary` - Elevated surfaces (cards, modals)
+- `tertiary` - Nested surfaces
+- `inverse` - Dark backgrounds for contrast
+
+**Figure variants:**
+- `primary` - Main text color
+- `secondary` - Supporting text
+- `muted` - De-emphasized text
+- `inverse` - Text on dark backgrounds
+
+## Typography
+
+Font families are assigned semantically:
+
+| Token | Usage |
+|-------|-------|
+| `font-heading` | Headlines, titles |
+| `font-body` | Body text, UI labels |
+| `font-code` | Code blocks, inline code |
+
+```tsx
+<h1 className="font-heading">Article Title</h1>
+<p className="font-body">Body content...</p>
+<code className="font-code">const x = 1</code>
+```
+
+## Spacing & Sizing
+
+Spacing uses Tailwind's default scale. Border radius and widths use semantic tokens:
+
+```tsx
+// Radius
+<div className="rounded">     {/* default */}
+<div className="rounded-sm">  {/* small */}
+<div className="rounded-lg">  {/* large */}
+<div className="rounded-full">{/* pill/circle */}
+
+// Border width
+<div className="border">       {/* default */}
+<div className="border-thick"> {/* emphasized */}
+```
+
+## Theming
+
+All colors support theming via CSS custom properties. Themes override these variables:
+
+```css
+/* NYT Light theme */
+[data-theme="nyt"][data-mode="light"] {
+  --color-bg-primary: #ffffff;
+  --color-text-primary: #121212;
+}
+
+/* NYT Dark theme */
+[data-theme="nyt"][data-mode="dark"] {
+  --color-bg-primary: #121212;
+  --color-text-primary: #f5f5f5;
+}
+```
+
+Components automatically adapt to theme changes without code modifications.

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@blog/ui",
+  "version": "0.0.0",
+  "private": true,
+  "main": "src/index.tsx",
+  "types": "src/index.tsx",
+  "exports": {
+    ".": "./src/index.tsx",
+    "./lib/utils": "./src/lib/utils.ts"
+  },
+  "scripts": {
+    "lint": "eslint src/",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "dependencies": {
+    "@blog/tokens": "workspace:*",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "tailwind-merge": "^2.6.0"
+  },
+  "devDependencies": {
+    "@blog/config": "workspace:*",
+    "@storybook/react": "^8.4.0",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "tailwindcss": "^3.4.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/packages/ui/src/components/Button/Button.stories.tsx
+++ b/packages/ui/src/components/Button/Button.stories.tsx
@@ -1,0 +1,98 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Button } from './Button';
+
+const meta: Meta<typeof Button> = {
+  title: 'Components/Button',
+  component: Button,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['primary', 'secondary', 'ghost', 'link'],
+    },
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+  args: {
+    variant: 'primary',
+    children: 'Primary Button',
+  },
+};
+
+export const Secondary: Story = {
+  args: {
+    variant: 'secondary',
+    children: 'Secondary Button',
+  },
+};
+
+export const Ghost: Story = {
+  args: {
+    variant: 'ghost',
+    children: 'Ghost Button',
+  },
+};
+
+export const Link: Story = {
+  args: {
+    variant: 'link',
+    children: 'Link Button',
+  },
+};
+
+export const Small: Story = {
+  args: {
+    size: 'sm',
+    children: 'Small Button',
+  },
+};
+
+export const Medium: Story = {
+  args: {
+    size: 'md',
+    children: 'Medium Button',
+  },
+};
+
+export const Large: Story = {
+  args: {
+    size: 'lg',
+    children: 'Large Button',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+    children: 'Disabled Button',
+  },
+};
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4">
+      <div className="flex gap-4 items-center">
+        <Button variant="primary">Primary</Button>
+        <Button variant="secondary">Secondary</Button>
+        <Button variant="ghost">Ghost</Button>
+        <Button variant="link">Link</Button>
+      </div>
+      <div className="flex gap-4 items-center">
+        <Button size="sm">Small</Button>
+        <Button size="md">Medium</Button>
+        <Button size="lg">Large</Button>
+      </div>
+    </div>
+  ),
+};

--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@ui/lib/utils';
+
+const buttonVariants = cva(
+  // Base styles
+  'inline-flex items-center justify-center font-body transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-action-primary focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+  {
+    variants: {
+      variant: {
+        primary:
+          'bg-action-primary text-figure-inverse hover:bg-action-primary-hover',
+        secondary:
+          'bg-action-secondary text-figure-primary border border-border hover:bg-action-secondary-hover',
+        ghost: 'hover:bg-action-secondary text-figure-primary',
+        link: 'text-action-primary underline-offset-4 hover:underline',
+      },
+      size: {
+        sm: 'h-8 px-3 text-sm rounded-sm',
+        md: 'h-10 px-4 text-base rounded',
+        lg: 'h-12 px-6 text-lg rounded-lg',
+      },
+    },
+    defaultVariants: {
+      variant: 'primary',
+      size: 'md',
+    },
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, ...props }, ref) => {
+    return (
+      <button
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = 'Button';
+
+export { Button, buttonVariants };

--- a/packages/ui/src/components/Button/index.ts
+++ b/packages/ui/src/components/Button/index.ts
@@ -1,0 +1,1 @@
+export { Button, buttonVariants, type ButtonProps } from './Button';

--- a/packages/ui/src/components/Callout/Callout.stories.tsx
+++ b/packages/ui/src/components/Callout/Callout.stories.tsx
@@ -1,0 +1,104 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Callout } from './Callout';
+
+const meta: Meta<typeof Callout> = {
+  title: 'Components/Callout',
+  component: Callout,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    type: {
+      control: 'select',
+      options: ['info', 'success', 'warning', 'danger', 'note'],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Info: Story = {
+  args: {
+    type: 'info',
+    title: 'Did you know?',
+    children: 'This is an informational callout with helpful context for the reader.',
+  },
+};
+
+export const Success: Story = {
+  args: {
+    type: 'success',
+    title: 'Success!',
+    children: 'The operation completed successfully. You can proceed with the next step.',
+  },
+};
+
+export const Warning: Story = {
+  args: {
+    type: 'warning',
+    title: 'Caution',
+    children: 'Be careful with this operation. Make sure you understand the implications.',
+  },
+};
+
+export const Danger: Story = {
+  args: {
+    type: 'danger',
+    title: 'Danger',
+    children: 'This action is irreversible. Please proceed with extreme caution.',
+  },
+};
+
+export const Note: Story = {
+  args: {
+    type: 'note',
+    title: 'Note',
+    children: 'This is a general note that provides additional context or information.',
+  },
+};
+
+export const WithoutTitle: Story = {
+  args: {
+    type: 'info',
+    children: 'A simple callout without a title. Just the content.',
+  },
+};
+
+export const WithRichContent: Story = {
+  args: {
+    type: 'info',
+    title: 'Code Example',
+    children: (
+      <div>
+        <p className="mb-2">Use the following command to install:</p>
+        <code className="bg-bg-tertiary px-2 py-1 rounded text-sm font-code">
+          pnpm add @blog/ui
+        </code>
+      </div>
+    ),
+  },
+};
+
+export const AllTypes: Story = {
+  render: () => (
+    <div className="space-y-4 max-w-2xl">
+      <Callout type="info" title="Info">
+        This is an informational message.
+      </Callout>
+      <Callout type="success" title="Success">
+        Operation completed successfully.
+      </Callout>
+      <Callout type="warning" title="Warning">
+        Please review before proceeding.
+      </Callout>
+      <Callout type="danger" title="Danger">
+        This action cannot be undone.
+      </Callout>
+      <Callout type="note" title="Note">
+        Additional context for the reader.
+      </Callout>
+    </div>
+  ),
+};

--- a/packages/ui/src/components/Callout/Callout.tsx
+++ b/packages/ui/src/components/Callout/Callout.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@ui/lib/utils';
+
+const calloutVariants = cva(
+  'border-l-4 p-4 my-4 rounded-r font-body',
+  {
+    variants: {
+      type: {
+        info: 'bg-status-info-bg border-status-info text-figure-primary',
+        success: 'bg-status-success-bg border-status-success text-figure-primary',
+        warning: 'bg-status-warning-bg border-status-warning text-figure-primary',
+        danger: 'bg-status-danger-bg border-status-danger text-figure-primary',
+        note: 'bg-ground-secondary border-border-strong text-figure-primary',
+      },
+    },
+    defaultVariants: {
+      type: 'info',
+    },
+  }
+);
+
+const calloutIcons: Record<string, string> = {
+  info: 'ℹ️',
+  success: '✅',
+  warning: '⚠️',
+  danger: '🚫',
+  note: '📝',
+};
+
+export interface CalloutProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof calloutVariants> {
+  title?: string;
+}
+
+const Callout = React.forwardRef<HTMLDivElement, CalloutProps>(
+  ({ className, type = 'info', title, children, ...props }, ref) => {
+    const icon = calloutIcons[type || 'info'];
+
+    return (
+      <div
+        ref={ref}
+        className={cn(calloutVariants({ type }), className)}
+        {...props}
+      >
+        <div className="flex items-start gap-3">
+          <span className="text-xl flex-shrink-0" aria-hidden="true">
+            {icon}
+          </span>
+          <div className="flex-1 min-w-0">
+            {title && (
+              <p className="font-semibold mb-1 font-heading">{title}</p>
+            )}
+            <div className="text-sm">{children}</div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+);
+Callout.displayName = 'Callout';
+
+export { Callout, calloutVariants };

--- a/packages/ui/src/components/Callout/index.ts
+++ b/packages/ui/src/components/Callout/index.ts
@@ -1,0 +1,1 @@
+export { Callout, calloutVariants, type CalloutProps } from './Callout';

--- a/packages/ui/src/components/Card/Card.stories.tsx
+++ b/packages/ui/src/components/Card/Card.stories.tsx
@@ -1,0 +1,102 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardFooter,
+} from './Card';
+import { Button } from '../Button';
+
+const meta: Meta<typeof Card> = {
+  title: 'Components/Card',
+  component: Card,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <Card className="w-[350px]">
+      <CardHeader>
+        <CardTitle>Card Title</CardTitle>
+        <CardDescription>Card description goes here.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <p>This is the main content of the card. You can put any content here.</p>
+      </CardContent>
+      <CardFooter>
+        <Button>Action</Button>
+      </CardFooter>
+    </Card>
+  ),
+};
+
+export const Simple: Story = {
+  render: () => (
+    <Card className="w-[350px] p-6">
+      <p>A simple card with just content and padding.</p>
+    </Card>
+  ),
+};
+
+export const WithImage: Story = {
+  render: () => (
+    <Card className="w-[350px] overflow-hidden">
+      <div className="h-48 bg-bg-tertiary flex items-center justify-center text-text-muted">
+        Image placeholder
+      </div>
+      <CardHeader>
+        <CardTitle>Blog Post Title</CardTitle>
+        <CardDescription>Published on Dec 13, 2025</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <p className="text-text-secondary">
+          A brief excerpt from the blog post that gives readers a preview of the content...
+        </p>
+      </CardContent>
+      <CardFooter className="gap-2">
+        <Button variant="primary" size="sm">Read More</Button>
+        <Button variant="ghost" size="sm">Share</Button>
+      </CardFooter>
+    </Card>
+  ),
+};
+
+export const PostCard: Story = {
+  render: () => (
+    <Card className="w-full max-w-2xl">
+      <CardHeader>
+        <div className="flex gap-2 mb-2">
+          <span className="px-2 py-1 text-xs rounded bg-bg-tertiary text-text-secondary">
+            TypeScript
+          </span>
+          <span className="px-2 py-1 text-xs rounded bg-bg-tertiary text-text-secondary">
+            React
+          </span>
+        </div>
+        <CardTitle>Building a Design System from Scratch</CardTitle>
+        <CardDescription>
+          Learn how to create a scalable design system using modern tools and best practices.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <p className="text-text-secondary">
+          In this article, we'll explore the key concepts behind building a design system,
+          including token architecture, component composition, and documentation strategies.
+        </p>
+      </CardContent>
+      <CardFooter className="text-sm text-text-muted">
+        <span>5 min read</span>
+        <span className="mx-2">•</span>
+        <span>Dec 13, 2025</span>
+      </CardFooter>
+    </Card>
+  ),
+};

--- a/packages/ui/src/components/Card/Card.tsx
+++ b/packages/ui/src/components/Card/Card.tsx
@@ -1,0 +1,92 @@
+import * as React from 'react';
+import { cn } from '@ui/lib/utils';
+
+export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+const Card = React.forwardRef<HTMLDivElement, CardProps>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn(
+        'rounded bg-ground-secondary border border-border text-figure-primary',
+        className
+      )}
+      {...props}
+    />
+  )
+);
+Card.displayName = 'Card';
+
+export interface CardHeaderProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+const CardHeader = React.forwardRef<HTMLDivElement, CardHeaderProps>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn('flex flex-col space-y-1.5 p-6', className)}
+      {...props}
+    />
+  )
+);
+CardHeader.displayName = 'CardHeader';
+
+export interface CardTitleProps
+  extends React.HTMLAttributes<HTMLHeadingElement> {}
+
+const CardTitle = React.forwardRef<HTMLParagraphElement, CardTitleProps>(
+  ({ className, ...props }, ref) => (
+    <h3
+      ref={ref}
+      className={cn('font-heading text-2xl font-semibold leading-none', className)}
+      {...props}
+    />
+  )
+);
+CardTitle.displayName = 'CardTitle';
+
+export interface CardDescriptionProps
+  extends React.HTMLAttributes<HTMLParagraphElement> {}
+
+const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  CardDescriptionProps
+>(({ className, ...props }, ref) => (
+  <p
+    ref={ref}
+    className={cn('text-sm text-figure-secondary', className)}
+    {...props}
+  />
+));
+CardDescription.displayName = 'CardDescription';
+
+export interface CardContentProps
+  extends React.HTMLAttributes<HTMLDivElement> {}
+
+const CardContent = React.forwardRef<HTMLDivElement, CardContentProps>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('p-6 pt-0', className)} {...props} />
+  )
+);
+CardContent.displayName = 'CardContent';
+
+export interface CardFooterProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+const CardFooter = React.forwardRef<HTMLDivElement, CardFooterProps>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn('flex items-center p-6 pt-0', className)}
+      {...props}
+    />
+  )
+);
+CardFooter.displayName = 'CardFooter';
+
+export {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardFooter,
+};

--- a/packages/ui/src/components/Card/index.ts
+++ b/packages/ui/src/components/Card/index.ts
@@ -1,0 +1,14 @@
+export {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardFooter,
+  type CardProps,
+  type CardHeaderProps,
+  type CardTitleProps,
+  type CardDescriptionProps,
+  type CardContentProps,
+  type CardFooterProps,
+} from './Card';

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -1,0 +1,20 @@
+// Components
+export { Button, buttonVariants, type ButtonProps } from '@ui/components/Button';
+export {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardFooter,
+  type CardProps,
+  type CardHeaderProps,
+  type CardTitleProps,
+  type CardDescriptionProps,
+  type CardContentProps,
+  type CardFooterProps,
+} from '@ui/components/Card';
+export { Callout, calloutVariants, type CalloutProps } from '@ui/components/Callout';
+
+// Utilities
+export { cn } from '@ui/lib/utils';

--- a/packages/ui/src/lib/utils.ts
+++ b/packages/ui/src/lib/utils.ts
@@ -1,0 +1,9 @@
+import { type ClassValue, clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+/**
+ * Merge class names with Tailwind CSS conflict resolution
+ */
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/packages/ui/tailwind.config.js
+++ b/packages/ui/tailwind.config.js
@@ -1,0 +1,61 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        // Ground: background/surface colors (what things sit ON)
+        ground: {
+          primary: 'var(--color-bg-primary)',
+          secondary: 'var(--color-bg-secondary)',
+          tertiary: 'var(--color-bg-tertiary)',
+          inverse: 'var(--color-bg-inverse)',
+        },
+        // Figure: foreground/content colors (what you SEE)
+        figure: {
+          primary: 'var(--color-text-primary)',
+          secondary: 'var(--color-text-secondary)',
+          muted: 'var(--color-text-muted)',
+          inverse: 'var(--color-text-inverse)',
+        },
+        border: {
+          DEFAULT: 'var(--color-border-default)',
+          muted: 'var(--color-border-muted)',
+          strong: 'var(--color-border-strong)',
+        },
+        action: {
+          primary: 'var(--color-action-primary)',
+          'primary-hover': 'var(--color-action-primary-hover)',
+          secondary: 'var(--color-action-secondary)',
+          'secondary-hover': 'var(--color-action-secondary-hover)',
+        },
+        status: {
+          info: 'var(--color-status-info)',
+          'info-bg': 'var(--color-status-info-bg)',
+          success: 'var(--color-status-success)',
+          'success-bg': 'var(--color-status-success-bg)',
+          warning: 'var(--color-status-warning)',
+          'warning-bg': 'var(--color-status-warning-bg)',
+          danger: 'var(--color-status-danger)',
+          'danger-bg': 'var(--color-status-danger-bg)',
+        },
+      },
+      fontFamily: {
+        heading: 'var(--font-family-heading)',
+        body: 'var(--font-family-body)',
+        code: 'var(--font-family-code)',
+      },
+      borderRadius: {
+        DEFAULT: 'var(--radius-default)',
+        sm: 'var(--radius-sm)',
+        lg: 'var(--radius-lg)',
+        full: 'var(--radius-full)',
+      },
+      borderWidth: {
+        DEFAULT: 'var(--border-width-default)',
+        thick: 'var(--border-width-thick)',
+      },
+    },
+  },
+  plugins: [],
+};

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@blog/config/tsconfig/react.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@ui/*": ["src/*"]
+    },
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/plan/ARCHITECTURE.md
+++ b/plan/ARCHITECTURE.md
@@ -141,6 +141,43 @@ packages/tokens/
 --border-width-default
 ```
 
+### Tailwind Color Naming: Ground & Figure
+
+To avoid redundant class names like `bg-bg-primary` or `text-text-primary`, we use **ground** and **figure** as semantic color categories in Tailwind.
+
+**Ground** - Background/surface colors (what things sit ON)
+- Page backgrounds, card backgrounds, input backgrounds
+- Surfaces, containers, overlays
+- The "canvas" or "stage" that content appears on
+- Usage: `bg-ground-primary`, `bg-ground-secondary`
+
+**Figure** - Foreground/content colors (what you SEE)
+- Text, icons, labels
+- Visual content that sits on top of ground
+- The "actors" that appear on the stage
+- Usage: `text-figure-primary`, `text-figure-muted`
+
+This naming comes from **figure-ground perception** in Gestalt psychology—the visual principle of distinguishing objects (figures) from their backgrounds (grounds).
+
+```tsx
+// Result: clear, non-redundant classes
+<div className="bg-ground-secondary text-figure-primary">
+  <span className="text-figure-muted">Subtitle</span>
+</div>
+
+// vs the redundant alternative we avoided:
+<div className="bg-bg-secondary text-text-primary">
+```
+
+**Full Tailwind color categories:**
+| Category | Purpose | Example classes |
+|----------|---------|-----------------|
+| `ground` | Background/surface colors | `bg-ground-primary`, `bg-ground-inverse` |
+| `figure` | Text/foreground colors | `text-figure-primary`, `text-figure-muted` |
+| `border` | Border colors | `border-border`, `border-border-strong` |
+| `action` | Interactive element colors | `bg-action-primary`, `hover:bg-action-primary-hover` |
+| `status` | Semantic status colors | `bg-status-info-bg`, `text-status-danger` |
+
 ---
 
 ## UI Package Architecture


### PR DESCRIPTION
## Summary

- Add `packages/ui` with Button, Card, and Callout components using CVA (class-variance-authority)
- Add `apps/docs` as Storybook 8 aggregator for co-located stories
- Implement **ground/figure** color naming convention to avoid redundant `bg-bg-*` / `text-text-*` classes
- Add documentation in `packages/ui/docs/` explaining architecture and design language

## What's Included

### Components
- **Button** - Primary, secondary, ghost, and link variants with sm/md/lg sizes
- **Card** - Container with CardHeader, CardTitle, CardDescription, CardContent, CardFooter sub-components
- **Callout** - Info, success, warning, danger, and note variants for content emphasis

### Infrastructure
- Storybook 8 with React + Vite
- Co-located stories (`*.stories.tsx` next to components)
- Path alias resolution (`@ui/*`)
- Tailwind CSS with semantic token integration

### Documentation
- `packages/ui/docs/ARCHITECTURE.md` - Component structure, technology choices, adding new components
- `packages/ui/docs/DESIGN_LANGUAGE.md` - Ground/figure naming rationale, color system, typography

## Test plan

- [x] `pnpm --filter @blog/ui typecheck` passes
- [x] `pnpm --filter @blog/docs build` (Storybook) succeeds
- [ ] Run `pnpm --filter @blog/docs dev` and verify components render in Storybook

🤖 Generated with [Claude Code](https://claude.com/claude-code)