### PR TITLE
docs: add brutalism theme vision and roadmap

### DIFF
--- a/packages/ui/docs/brutalism_theme/00_VISION.md
+++ b/packages/ui/docs/brutalism_theme/00_VISION.md
@@ -1,0 +1,209 @@
+# Brutalism Theme: Design Vision & Roadmap
+
+## Philosophy
+
+### The Essence
+
+Brutalism is honesty made visible.
+
+In architecture, brutalism emerged as a rejection of ornamentation—a belief that structure should not apologize for what it is. Concrete does not pretend to be marble. Steel does not hide behind plaster. The building announces its purpose through its bones.
+
+Digital brutalism carries this ethos forward. In a world of rounded corners, soft gradients, and interfaces designed to soothe, brutalism chooses clarity over comfort. It does not seduce. It informs.
+
+This theme exists for readers who want the content, not the container.
+
+### Three Principles
+
+**1. Raw Materials**
+
+Every pixel should justify its existence. A border is not decoration—it is structure. A typeface is not a mood—it is a voice. Monospace fonts expose the grid. High contrast demands attention. We use what works, nothing more.
+
+**2. Visible Seams**
+
+Traditional design hides complexity behind polish. Brutalism reveals it. Thick borders show where elements begin and end. Sharp corners mark boundaries without ambiguity. The interface does not pretend to be seamless—it shows you exactly how it's built.
+
+**3. Function as Form**
+
+Brutalism rejects the false dichotomy between beauty and utility. A well-structured page *is* beautiful. A clear hierarchy *is* elegant. When form follows function absolutely, aesthetics emerge from honesty.
+
+---
+
+## The Brutalist Vocabulary
+
+### What Brutalism Is
+
+- **High contrast**: Black and white are not limitations—they are clarity
+- **Monospace typography**: Every character occupies equal space, exposing the underlying grid
+- **Zero radius**: Corners are decisions, not accidents
+- **Thick borders**: Structure made visible
+- **Generous whitespace**: Silence between statements
+- **Single accent**: One color to command attention, used sparingly
+
+### What Brutalism Is Not
+
+- **Ugly for its own sake**: Brutalism is disciplined, not careless
+- **Anti-user**: Clarity serves the reader; confusion does not
+- **Minimalism**: Minimalism removes; brutalism reveals
+- **Retro nostalgia**: We are not recreating 1990s web pages—we are applying brutalist principles to modern interfaces
+
+---
+
+## The Gap Between Now and Excellence
+
+### What the Token System Provides
+
+The existing architecture supports brutalism well:
+- Three-layer token abstraction (primitives → semantic → themes)
+- Theme switching via data attributes
+- Semantic naming that separates intent from implementation
+- Storybook integration for visual testing
+
+### What Brutalism Requires
+
+**Typographic Rawness**: The current serif/sans stacks are designed for readability comfort. Brutalism needs a monospace-first approach—or at minimum, a geometric sans with no humanist curves.
+
+**Border as First-Class Citizen**: Current borders are subtle dividers. Brutalism uses borders as structural elements. We need more weight options and potentially box-shadow alternatives that feel solid, not soft.
+
+**Color Discipline**: The palette should be ruthlessly constrained. One accent color. No gradients. No opacity tricks. Status colors should feel urgent, not friendly.
+
+**Interaction Honesty**: Hover states should change decisively, not fade politely. Focus states should be visible from across the room.
+
+---
+
+## The Roadmap
+
+### Phase 1: Typographic Foundation
+
+**Goal**: Establish a type system that exposes structure.
+
+**Key Decisions**:
+- Primary typeface: Monospace for all text, or monospace headlines with geometric sans body
+- Scale relationship: Maintain mathematical harmony while feeling mechanical
+- Weight usage: Fewer weights, higher contrast between them
+
+**Success Criteria**: Text feels engineered, not designed. The grid is visible in every paragraph.
+
+---
+
+### Phase 2: Structural Color
+
+**Goal**: Define a palette that communicates through contrast, not decoration.
+
+**Key Decisions**:
+- Background: Pure white or near-black (no warm grays)
+- Text: Pure black or pure white (maximum contrast)
+- Accent: One saturated color (red, yellow, or cyan) for action and emphasis
+- Status: Functional colors that feel like warnings, not suggestions
+
+**Success Criteria**: A page rendered in grayscale loses no information. Color adds urgency, not beauty.
+
+---
+
+### Phase 3: Border System
+
+**Goal**: Make structure visible through deliberate edge treatment.
+
+**Key Decisions**:
+- Default border width: 2px minimum (visible at any size)
+- Border style: Solid only (no dashed, no dotted)
+- Border color: Match text color (high contrast)
+- Corner radius: Zero everywhere, no exceptions
+
+**Success Criteria**: Every container's boundaries are immediately clear. Nothing bleeds into nothing.
+
+---
+
+### Phase 4: Interaction Language
+
+**Goal**: Design state changes that feel decisive, not decorative.
+
+**Key Decisions**:
+- Hover: Instant state change (no transitions, or very fast)
+- Focus: Thick outline offset (not subtle ring)
+- Active: Invert colors or shift position
+- Disabled: Reduced contrast, strikethrough where appropriate
+
+**Success Criteria**: Users know exactly what is interactive and what state it's in. No guessing.
+
+---
+
+### Phase 5: Component Expression
+
+**Goal**: Translate brutalist principles into the component library.
+
+**Priority Components**:
+- **Button**: Rectangular, thick border, clear states
+- **Card**: Visible container with structural borders
+- **Callout**: High-contrast alert that demands attention
+- **Input**: Monospace text, visible boundaries, no floating labels
+- **Navigation**: Clear hierarchy, no hamburger menus unless necessary
+
+**Success Criteria**: Each component feels like it belongs in the same building.
+
+---
+
+### Phase 6: Editorial Application
+
+**Goal**: Prove the system works for long-form content.
+
+**Deliverables**:
+- Article template with brutalist typography
+- Code block styling that feels native
+- Blockquote treatment that adds weight, not decoration
+- Image captions that integrate with grid
+
+**Success Criteria**: A 2,000-word article is more readable in brutalism than in a conventional theme.
+
+---
+
+## Principles for Implementation
+
+### When Adding a Token, Ask:
+
+1. **Does it serve structure?** Every token should make the system more honest, not more decorative.
+2. **Is it decisive?** Avoid middle values. Prefer extremes: thick or thin, black or white, present or absent.
+3. **Does it respect the grid?** Spacing and sizing should reinforce the underlying structure.
+4. **Could it be simpler?** If two tokens could be one, they should be one.
+
+### When Building a Component, Ask:
+
+1. **Are its boundaries visible?** If you can't see where it starts and ends, it's not brutalist.
+2. **Does it announce its purpose?** A button should look like a button. A link should look like a link.
+3. **Are states distinct?** Hover, focus, active, and disabled should never be confused.
+4. **Does it work in monochrome?** If color is required for comprehension, the structure has failed.
+
+---
+
+## The Destination
+
+When this system is complete, a designer should be able to describe a page like this:
+
+> "The headline is monospace, bold, with a 2px underline. Below it, body text in the same face but normal weight, generous line height. The callout box has a 4px black border, no radius, inverted colors. Links are underlined, always. On hover, they invert."
+
+And a developer should implement it without asking "but what about the subtle shadow?" or "should I add a transition?"
+
+There are no subtle shadows. There are no transitions. There is only structure.
+
+---
+
+## A Note on Context
+
+Brutalism is not always appropriate. It suits:
+- Technical documentation where clarity trumps comfort
+- Editorial content that wants to feel authoritative, not friendly
+- Portfolios that prefer bold statements over soft impressions
+- Applications where users value efficiency over warmth
+
+It may not suit:
+- Consumer products optimized for mass appeal
+- Interfaces for anxious or unfamiliar users
+- Brands that need to feel approachable
+
+Know your audience. Brutalism respects the reader by assuming they can handle honesty.
+
+---
+
+*"Architecture is the will of an epoch translated into space."*
+— Ludwig Mies van der Rohe
+
+This theme is the will of clarity, translated into pixels.


### PR DESCRIPTION
## Summary

- Establish design philosophy for a new brutalism theme
- Define three core principles: Raw Materials, Visible Seams, Function as Form
- Create six-phase implementation roadmap

This vision document will guide the creation of a brutalism theme that coexists with the existing NYT theme, leveraging the 3-layer token architecture.

## Key Decisions

**Philosophy**: Brutalism is honesty made visible—structure without apology, clarity over comfort.

**Constraints**:
- Zero radius, always
- 2px minimum borders
- Monochrome-first (color adds urgency, not beauty)
- Monospace typography
- Maximum contrast

## Roadmap Phases

1. Typographic Foundation
2. Structural Color
3. Border System
4. Interaction Language
5. Component Expression
6. Editorial Application

## Test plan

- [x] Document follows existing vision doc structure (`nyt_theme/00_VISION.md`)
- [ ] Team review of design philosophy
- [ ] Alignment on implementation priorities

🤖 Generated with [Claude Code](https://claude.com/claude-code)