### PR TITLE
docs: Add vision documents for 4 design school themes

### DIFF
--- a/packages/ui/docs/bauhaus_theme/00_VISION.md
+++ b/packages/ui/docs/bauhaus_theme/00_VISION.md
@@ -1,0 +1,237 @@
+# Bauhaus Theme: Design Vision & Roadmap
+
+## Philosophy
+
+### The Essence
+
+Bauhaus is unity made systematic.
+
+In 1919, Walter Gropius opened a school with a radical premise: art, craft, and technology are not separate disciplines—they are one. A chair is sculpture. A poster is architecture. A teacup is industrial design. The Bauhaus rejected the hierarchy that placed "fine art" above "applied art" and proposed something more democratic: *good design for everyone*.
+
+This theme carries that ethos into the digital age. Where modern interfaces often feel either coldly corporate or chaotically expressive, Bauhaus offers a third path: systematic beauty. Every element—every button, every card, every headline—emerges from the same geometric vocabulary. Circle, square, triangle. Red, yellow, blue. Not as arbitrary choices, but as fundamental forms that create harmony through relationship.
+
+The Bauhaus believed design should serve society. This theme believes design should serve the reader.
+
+### Three Principles
+
+**1. Geometric Truth**
+
+At the Bauhaus, students began by mastering basic forms. Kandinsky taught that the circle is blue (calm, infinite), the square is red (stable, grounded), the triangle is yellow (sharp, dynamic). Whether or not we accept his color theory, the principle endures: *fundamental forms carry meaning*. Our interface is built from these primitives—no decorative flourishes, no arbitrary curves. Every shape can be traced to circle, square, or triangle.
+
+**2. Primary Clarity**
+
+The primary colors are not a limitation—they are a liberation. When your palette is red, yellow, blue, black, and white, every color choice is deliberate. There is no agonizing over "should this be teal or cyan?" There is only: *is this a primary moment, or not?* The constraint creates clarity. The reader always knows what demands attention.
+
+**3. Form Follows Function (Honestly)
+
+The phrase is overused, but Bauhaus meant it literally. A building should look like what it does. A handle should invite the hand. A button should look pressable. We reject dark patterns and deceptive UI. If something is interactive, it announces itself. If something is informational, it recedes. The interface never tricks, never flatters, never manipulates.
+
+---
+
+## The Bauhaus Vocabulary
+
+### What Bauhaus Is
+
+- **Geometric foundation**: Circle, square, triangle as compositional elements
+- **Primary palette**: Red, yellow, blue as accents; black, white, and warm grays as structure
+- **Sans-serif typography**: Geometric faces (Futura, DIN, or their modern equivalents) that echo the formal vocabulary
+- **Asymmetric balance**: Not centered symmetry, but dynamic equilibrium
+- **Visible structure**: Grids that organize without confining
+- **Functional ornamentation**: Geometric patterns that emerge from the system, not applied decoration
+
+### What Bauhaus Is Not
+
+- **Cold minimalism**: Bauhaus has warmth—in craft, in color, in the human hand that guided the system
+- **Random geometry**: Shapes have meaning and relationship, not scattered for visual interest
+- **Retro pastiche**: We are not recreating 1920s posters—we are applying Bauhaus thinking to modern problems
+- **Anti-technology**: Bauhaus embraced the machine. We embrace the browser.
+- **Purely decorative**: Every geometric element serves a purpose
+
+---
+
+## The Gap Between Now and Excellence
+
+### What the Token System Provides
+
+The existing architecture supports Bauhaus well:
+- Three-layer token abstraction (primitives → semantic → themes)
+- Theme switching via data attributes
+- CVA for component variants
+- Semantic color naming
+
+### What Bauhaus Requires
+
+**Geometric Typography**: The current serif/sans stacks lean editorial. Bauhaus needs a geometric sans-serif—letterforms built from circles and lines, not calligraphic tradition. Think Futura, Avant Garde, or their open-source equivalents (e.g., Josefin Sans, Questrial).
+
+**Primary Color System**: The current palette is subtle and muted. Bauhaus demands saturated primaries—not as the dominant colors, but as accent vocabulary. Red must be *red*. Yellow must be *yellow*. Blue must be *blue*.
+
+**Geometric Components**: Buttons should feel like rectangles. Icons should feel like primitives. Decorative elements should emerge from circle, square, and triangle—not arbitrary blob shapes or soft curves.
+
+**Asymmetric Grid**: The default centered layouts feel static. Bauhaus composition lives in dynamic tension—elements offset, balanced but not mirrored.
+
+---
+
+## The Roadmap
+
+### Phase 1: Typographic Foundation
+
+**Goal**: Establish a type system built from geometric principles.
+
+**Key Decisions**:
+- Primary typeface: Geometric sans-serif for all text
+- Scale relationship: Mathematical intervals (golden ratio or musical scale)
+- Weight usage: Limited weights with clear contrast (light, regular, bold)
+- Letter-spacing: Slightly open for headlines, tighter for body
+
+**Deliverables**:
+- Font selection and loading strategy
+- Complete type scale with semantic naming
+- Line-height and weight assignments
+
+**Success Criteria**: Text feels constructed, not handwritten. Letterforms echo the geometric vocabulary.
+
+---
+
+### Phase 2: Primary Color Palette
+
+**Goal**: Define a palette centered on primary colors as accents.
+
+**Key Decisions**:
+- Primaries: Pure red (#E53935), yellow (#FDD835), blue (#1E88E5)—or historically accurate Bauhaus values
+- Neutrals: Warm white, warm grays, deep black (not cold blue-blacks)
+- Application: Primaries for action/emphasis only; neutrals for structure
+
+**Deliverables**:
+- Extended primitive colors
+- Semantic mappings for Bauhaus theme
+- Light and dark mode variants
+
+**Success Criteria**: Color feels intentional and energetic. Primary colors command attention without overwhelming.
+
+---
+
+### Phase 3: Geometric System
+
+**Goal**: Provide tools for geometric composition.
+
+**Key Decisions**:
+- Shape tokens: Border-radius options (square default, circle available)
+- Pattern system: Repeating geometric motifs for backgrounds/decorations
+- Icon style: Strictly geometric (no hand-drawn or organic icons)
+
+**Deliverables**:
+- Geometric utility classes
+- Shape component primitives
+- Optional decorative pattern library
+
+**Success Criteria**: Every visual element can be traced to fundamental geometric forms.
+
+---
+
+### Phase 4: Interaction Design
+
+**Goal**: Create interactions that feel mechanical and precise.
+
+**Key Decisions**:
+- Transitions: Crisp and deliberate (ease-out, moderate duration)
+- Hover: Scale, color inversion, or position shift—all precise
+- Focus: Bold, geometric focus indicators
+- Loading: Geometric animation (rotating shapes, not spinners)
+
+**Deliverables**:
+- Motion token definitions
+- Interaction state specifications
+- Animation guidelines
+
+**Success Criteria**: Interactions feel like a well-designed machine—satisfying and predictable.
+
+---
+
+### Phase 5: Component Expression
+
+**Goal**: Translate Bauhaus principles into the component library.
+
+**Priority Components**:
+- **Button**: Rectangular, primary-colored variants, geometric hover states
+- **Card**: Strong borders, optional geometric accents, asymmetric layouts
+- **Badge**: Circle, square, or pill—each with semantic meaning
+- **Input**: Clean geometric containers, clear states
+- **Navigation**: Grid-based, possibly with geometric indicators
+
+**Success Criteria**: Each component feels like it was designed by the same hand, following the same rules.
+
+---
+
+### Phase 6: Composition Patterns
+
+**Goal**: Demonstrate asymmetric, balanced layouts.
+
+**Deliverables**:
+- Layout templates with Bauhaus composition principles
+- Guidelines for asymmetric balance
+- Example pages showing the system at scale
+
+**Success Criteria**: Layouts feel dynamic and balanced without relying on centered symmetry.
+
+---
+
+## Principles for Implementation
+
+### When Adding a Token, Ask:
+
+1. **Is it geometric?** Every value should relate to the fundamental vocabulary.
+2. **Is it primary or structural?** Know which role a color or element plays.
+3. **Does it serve the system?** Individual cleverness undermines collective harmony.
+4. **Is it honest?** If it looks interactive, it should be interactive.
+
+### When Building a Component, Ask:
+
+1. **Could it be built from circles, squares, and triangles?** If not, reconsider the form.
+2. **Is color used for meaning?** Primaries should signal action or importance.
+3. **Does it belong with its siblings?** Components should feel like parts of a unified system.
+4. **Would Gropius approve?** (Half-joking, but useful.)
+
+---
+
+## The Destination
+
+When this system is complete, a designer should be able to describe a page like this:
+
+> "The heading is Futura Bold, asymmetrically placed, with a yellow rule below. The grid is three columns, but the hero image spans two and bleeds to the edge. Cards have 2px black borders with a small red square accent in the corner. The primary button is red on black, square corners. On hover, it inverts."
+
+And a developer should implement it knowing exactly what "red," "yellow," and "blue" mean in this context—because the system defines them precisely.
+
+---
+
+## A Note on Context
+
+Bauhaus suits:
+- Educational platforms where systematic thinking is valued
+- Design tools and creative applications
+- Portfolios that want to signal design literacy
+- Products emphasizing craft and intentionality
+- Any context where geometric clarity enhances comprehension
+
+It may not suit:
+- Brands requiring soft, approachable aesthetics
+- Luxury products expecting ornamental richness
+- Contexts where geometric rigor feels cold or institutional
+
+Know your audience. Bauhaus respects the user by trusting them to appreciate systematic beauty.
+
+---
+
+## Historical Note
+
+The Bauhaus existed from 1919 to 1933, when the Nazis closed it. Its teachers scattered—to America, to Switzerland, to Israel—carrying its ideas into architecture, typography, and design education worldwide. Moholy-Nagy founded the New Bauhaus in Chicago. Albers taught at Yale. Mies van der Rohe shaped the skyline of every modern city.
+
+The school lasted fourteen years. Its influence is now over a century old.
+
+This theme is one small continuation of that legacy: the belief that good design is not luxury, but right.
+
+---
+
+*"The ultimate aim of all creative activity is the building."*
+— Walter Gropius, Bauhaus Manifesto, 1919
+
+This theme is a small building. May it shelter clear thinking.

--- a/packages/ui/docs/destijl_theme/00_VISION.md
+++ b/packages/ui/docs/destijl_theme/00_VISION.md
@@ -1,0 +1,249 @@
+# De Stijl Theme: Design Vision & Roadmap
+
+## Philosophy
+
+### The Essence
+
+De Stijl is reduction to the absolute.
+
+In 1917, a small group of Dutch artists and architects asked a dangerous question: *What if we stripped away everything accidental, personal, and natural, leaving only universal elements?* Their answer was radical: horizontal and vertical lines only. Primary colors only. No curves. No diagonals. No compromise.
+
+Piet Mondrian spent decades refining the same composition—black lines on white, rectangles of red, yellow, blue. Not because he lacked imagination, but because he believed he was approaching something true. Each painting was a proposition: *this is the essential structure of visual harmony*.
+
+This theme applies that proposition to interface design. In a world of gradients, blurs, and organic shapes, De Stijl offers geometric certainty. The grid is not a suggestion—it is the only possibility. The palette is not a choice—it is the complete vocabulary.
+
+The constraint is the point.
+
+### Three Principles
+
+**1. Perpendicular Only**
+
+The most radical constraint: no diagonals, no curves, no organic forms. Every line is horizontal or vertical. Every shape is rectangular. This is not limitation—it is purification. When you cannot rely on the drama of diagonals or the softness of curves, you must find meaning in proportion, placement, and relationship.
+
+**2. Primary Absolutes**
+
+Red, yellow, blue. Black, white, gray. These are not colors among many—they are the complete palette. De Stijl rejected mixed colors as impure, compromised. In practice, we may need to soften this (status states require some flexibility), but the principle holds: when color appears, it should feel absolute, not tentative.
+
+**3. Asymmetric Balance**
+
+De Stijl despised symmetry as static and predictable. True balance comes from dynamic tension—a large blue rectangle countered by a small red one, a thick black line balancing a field of white. The composition should feel alive but stable, like a mobile at rest.
+
+---
+
+## The De Stijl Vocabulary
+
+### What De Stijl Is
+
+- **Perpendicular lines only**: Every border, every division, every structural element is horizontal or vertical
+- **Primary colors as absolutes**: Red, yellow, blue used sparingly but decisively
+- **Non-colors for structure**: Black lines, white grounds, occasional gray
+- **Asymmetric composition**: Balance through dynamic tension, not mirror symmetry
+- **The grid made visible**: Lines are not hidden—they are the aesthetic
+- **Reduction to essentials**: If it can be removed, it should be
+
+### What De Stijl Is Not
+
+- **Mondrian cosplay**: We are not recreating specific paintings—we are applying the principles
+- **Randomly rigid**: Perpendicular constraint is deliberate, not accidental
+- **Cold or mechanical**: The asymmetric balance creates visual energy
+- **Anti-functional**: Constraint serves clarity; clarity serves the user
+- **Merely retro**: These principles are timeless, not nostalgic
+
+---
+
+## The Gap Between Now and Excellence
+
+### What the Token System Provides
+
+The existing architecture aligns well with De Stijl requirements:
+- Three-layer token abstraction enables strict palette control
+- Theme switching supports the constrained vocabulary
+- CSS custom properties allow the visible grid aesthetic
+
+### What De Stijl Requires
+
+**Strict Color Vocabulary**: Current palettes include gradations and intermediates. De Stijl needs exactly: red, yellow, blue, black, white, and (carefully) gray. Status colors must be adapted to work within or alongside this constraint.
+
+**Perpendicular Border System**: Border-radius must be zero everywhere, no exceptions. But more than that—borders become primary design elements, not subtle dividers. Line weight matters enormously.
+
+**Asymmetric Layout Utilities**: Most CSS defaults encourage centered, symmetrical layouts. De Stijl needs utilities for deliberate asymmetric placement.
+
+**Typography Within Constraint**: Sans-serif, geometric, but not competing with the line work. Type should recede slightly, letting the grid dominate.
+
+---
+
+## The Roadmap
+
+### Phase 1: Color Reduction
+
+**Goal**: Establish the absolute palette.
+
+**Key Decisions**:
+- Primary red: #E53935 or a historically accurate De Stijl red
+- Primary yellow: #FDD835 or equivalent
+- Primary blue: #1E88E5 or equivalent
+- Black: True black (#000000)
+- White: True white (#FFFFFF)
+- Gray: One neutral gray for borders/text where pure black is too heavy
+
+**Deliverables**:
+- Primitive color tokens (strictly limited)
+- Semantic mappings using only allowed colors
+- Status color adaptations (success = blue? warning = yellow? danger = red?)
+
+**Success Criteria**: No color in the system falls outside the De Stijl vocabulary. Every hue decision is absolute.
+
+---
+
+### Phase 2: Line System
+
+**Goal**: Make the grid visible and deliberate.
+
+**Key Decisions**:
+- Border widths: Limited set (1px, 2px, 4px, 8px)
+- Border color: Black only (white in dark mode)
+- No border-radius: Zero everywhere, enforced
+- Line as ornament: Borders are aesthetic, not just functional
+
+**Deliverables**:
+- Border weight tokens
+- Utility classes for visible grid lines
+- Components that use lines as primary visual element
+
+**Success Criteria**: The page looks like a Mondrian composition—black lines creating rectangular spaces on white ground.
+
+---
+
+### Phase 3: Typography Integration
+
+**Goal**: Type that respects the perpendicular constraint.
+
+**Key Decisions**:
+- Typeface: Geometric sans-serif (Futura, DIN, or equivalent)
+- Weight: Limited (regular, bold only)
+- Alignment: Flush left typically (ragged right echoes the asymmetry)
+- Type as secondary: Headlines don't dominate; the grid does
+
+**Deliverables**:
+- Font selection and loading
+- Type scale (modest, not dramatic)
+- Guidelines for type within grid
+
+**Success Criteria**: Typography feels integrated, not competing with the line composition.
+
+---
+
+### Phase 4: Asymmetric Composition
+
+**Goal**: Provide tools for deliberate asymmetric layouts.
+
+**Key Decisions**:
+- Grid system: Flexible columns with intentional asymmetric options
+- Offset utilities: Place elements off-center deliberately
+- Balance principles: Documentation on achieving dynamic equilibrium
+
+**Deliverables**:
+- Layout utility classes
+- Composition guidelines with examples
+- Template patterns demonstrating asymmetric balance
+
+**Success Criteria**: Layouts feel balanced but energetic. No lazy centering.
+
+---
+
+### Phase 5: Component Expression
+
+**Goal**: Translate De Stijl principles into components.
+
+**Priority Components**:
+- **Button**: Rectangular, bordered, primary-colored on interaction
+- **Card**: Black-bordered rectangle, interior possibly color-blocked
+- **Divider**: Not subtle—a deliberate thick black line
+- **Badge**: Square or rectangular, primary-colored
+- **Input**: Black-bordered rectangle, no softness
+
+**Success Criteria**: Each component feels like part of a Mondrian composition.
+
+---
+
+### Phase 6: Motion Within Constraint
+
+**Goal**: Animation that respects perpendicular geometry.
+
+**Key Decisions**:
+- Movement: Horizontal and vertical only (no diagonal slides, no curves)
+- Transitions: Hard cuts or slide-in/slide-out
+- Duration: Deliberate, not playful
+
+**Deliverables**:
+- Motion tokens for De Stijl-appropriate animation
+- Guidelines: what motion is permitted
+- Examples of perpendicular animation
+
+**Success Criteria**: Movement reinforces the perpendicular constraint. Elements slide; they do not curve.
+
+---
+
+## Principles for Implementation
+
+### When Adding a Token, Ask:
+
+1. **Is it perpendicular?** Lines, borders, and movements must be horizontal or vertical.
+2. **Is it primary or structural?** Only red, yellow, blue for color; black, white, gray for structure.
+3. **Is it essential?** De Stijl reduces. If it can be removed, it must be.
+4. **Does it balance asymmetrically?** Avoid centered defaults.
+
+### When Building a Component, Ask:
+
+1. **Are all corners square?** No border-radius, ever.
+2. **Is color used absolutely?** When red appears, it should be decisive.
+3. **Does it use lines as design elements?** Borders are not hidden—they are the aesthetic.
+4. **Would it fit in a Mondrian?** A useful heuristic for visual decisions.
+
+---
+
+## The Destination
+
+When this system is complete, a page should feel like a composition—not a layout:
+
+> "The header is a black horizontal line. Below, a large white rectangle holds the main content. To the right, a narrow column in primary yellow contains navigation. The logo is a small red square. The footer is a thick black line with text above it. Every element sits on the grid. Nothing curves."
+
+This is not a page. It is a proposition about visual harmony. De Stijl believed that when we reduce design to its essentials—line, plane, color—we discover universal truth.
+
+Whether that's true is for you to decide. But the theme commits to the experiment.
+
+---
+
+## A Note on Context
+
+De Stijl suits:
+- Data dashboards where grid structure conveys meaning
+- Analytical tools where precision matters
+- Art and design publications that can carry the aesthetic weight
+- Portfolios making a strong design statement
+- Any context where rigorous structure is the message
+
+It may not suit:
+- Soft, approachable consumer brands
+- Contexts requiring organic, natural aesthetics
+- Audiences unfamiliar with abstract design language
+- Situations where the aesthetic might overshadow content
+
+De Stijl is not neutral. It makes a statement. Use it when that statement serves your purpose.
+
+---
+
+## Historical Note
+
+De Stijl (Dutch for "The Style") was founded in 1917 by Theo van Doesburg and lasted until his death in 1931. Its members included Mondrian, architect Gerrit Rietveld (designer of the famous Red Blue Chair), and others who believed that art could approach universal harmony through reduction.
+
+Mondrian left the group in 1925 when van Doesburg introduced diagonals—a betrayal, in Mondrian's view, of the perpendicular principle. The dispute seems absurd until you understand what was at stake: if diagonals are permitted, where does reduction end? The constraint was not arbitrary; it was the whole point.
+
+This theme sides with Mondrian. Perpendicular only.
+
+---
+
+*"The emotion of beauty is always obscured by the appearance of the object. Therefore, the object must be eliminated from the picture."*
+— Piet Mondrian
+
+In interface design, the "object" is the interface itself. The goal is to make structure so clear, so inevitable, that the user sees only content. The grid disappears by becoming everything.

--- a/packages/ui/docs/neoconstructivist_theme/00_VISION.md
+++ b/packages/ui/docs/neoconstructivist_theme/00_VISION.md
@@ -1,0 +1,279 @@
+# Neo-Constructivist / Propaganda Aesthetic Theme: Design Vision & Roadmap
+
+## Philosophy
+
+### The Essence
+
+Neo-Constructivism is rhetoric made visible.
+
+In 1920s Russia, a generation of artists confronted a revolutionary question: *How do you design for revolution?* Their answer was Constructivism—art in the service of social transformation. Every poster, every typeface, every diagonal was a weapon. Alexander Rodchenko's photographs taught the masses to see. El Lissitzky's designs turned manifestos into experiences. The distinction between art and propaganda dissolved.
+
+This theme revives that energy. Not the politics—but the *urgency*. The *directness*. The understanding that design is never neutral. Every interface argues for something. Most interfaces pretend otherwise. Neo-Constructivism drops the pretense.
+
+When you have something to say, say it loud.
+
+### Three Principles
+
+**1. Diagonal = Dynamic**
+
+The Constructivists discovered that diagonal composition creates psychological tension. Horizontal is stable. Vertical is static. But the diagonal is *falling*, *rising*, *moving*. It demands attention. It refuses to settle. In a world of placid rectangular layouts, the diagonal announces: *this matters*.
+
+**2. The Limited Palette Strikes**
+
+Red and black on white (or cream). This is not a limitation—it is a fist. When your palette is this constrained, every color decision is deliberate, rhetorical. Red means: *urgent*. Black means: *serious*. White means: *this is where you look*. There is no room for decoration, only declaration.
+
+**3. Typography as Weapon**
+
+In Constructivist design, type doesn't just carry the message—it *is* the message. Bold condensed headlines. Text that rotates, stacks, breaks the grid. Hierarchy so aggressive it can't be ignored. The goal is not readability in the neutral sense—it's readability in the rhetorical sense: you will read this, because you cannot look away.
+
+---
+
+## The Neo-Constructivist Vocabulary
+
+### What Neo-Constructivism Is
+
+- **Diagonal composition**: Elements that cut across the grid, creating tension
+- **High-contrast palette**: Red, black, white (cream)—possibly gold for emphasis
+- **Bold, condensed typography**: Headlines that punch, not whisper
+- **Photomontage heritage**: Integration of imagery with graphic elements
+- **Rhetorical clarity**: Every element serves the argument
+- **Urgency**: Design that demands attention now
+
+### What Neo-Constructivism Is Not
+
+- **Merely aggressive**: There is method to the intensity; it's not random shouting
+- **Politically specific**: We borrow aesthetics, not ideology
+- **Retro cosplay**: We apply principles to modern interfaces, not recreate Soviet posters
+- **Anti-functional**: Urgency serves communication; confusion does not
+- **Exhausting everywhere**: Save the intensity for moments that deserve it
+
+---
+
+## The Gap Between Now and Excellence
+
+### What the Token System Provides
+
+The existing architecture can support Neo-Constructivism:
+- Three-layer token abstraction enables constrained palettes
+- Theme switching allows for this high-impact alternative
+- Component system can accommodate bold visual treatments
+
+### What Neo-Constructivism Requires
+
+**Constrained Power Palette**: Current colors are functional. Neo-Constructivism needs red that *burns*, black that *anchors*, white that *clears*. The palette is tiny but intense.
+
+**Diagonal Layout System**: Most CSS encourages perpendicular layouts. Diagonals require deliberate implementation—transforms, clip-paths, or SVG-based solutions. This is technically challenging.
+
+**Bold Typography**: Current type stacks are optimized for reading comfort. Neo-Constructivism needs condensed, bold, potentially all-caps options for maximum impact.
+
+**Harsh Transitions**: Current motion is smooth and polite. Neo-Constructivism needs harder transitions—immediate state changes, bold transformations, motion that startles productively.
+
+---
+
+## The Roadmap
+
+### Phase 1: Power Palette
+
+**Goal**: Define colors that command.
+
+**Key Decisions**:
+- Red: Saturated, urgent (possibly historical accuracy: Soviet red #CC0000)
+- Black: True black for maximum contrast
+- White/Cream: Slightly warm for softening without weakening
+- Gold: Optional, for rare emphasis moments
+- No gradients, no transparency (generally)
+
+**Deliverables**:
+- Primitive colors (strictly limited)
+- Semantic mappings for Neo-Constructivist theme
+- Light mode (white/cream ground) and dark mode (black ground with white/red)
+
+**Color Palette**:
+```
+Revolution Red   #CC0000   (urgent, active, impossible to ignore)
+Ink Black        #000000   (grounding, serious, authoritative)
+Paper Cream      #F5F5DC   (softens without weakening)
+Pure White       #FFFFFF   (clean, high contrast on dark)
+Gold Accent      #D4AF37   (rare emphasis, rewards for urgency)
+```
+
+**Success Criteria**: Colors feel like they could appear on a revolutionary poster. Nothing ambiguous.
+
+---
+
+### Phase 2: Diagonal System
+
+**Goal**: Provide tools for breaking the perpendicular grid.
+
+**Key Decisions**:
+- Angle standardization: Define allowed diagonals (15°, 30°, 45°?)
+- Implementation: CSS transforms, clip-paths, SVG
+- Application: Headers, section dividers, decorative elements
+- Discipline: Diagonals for emphasis, not chaos
+
+**Deliverables**:
+- Diagonal utility classes
+- Section divider components with diagonal cuts
+- Guidelines for diagonal usage (when, how much)
+
+**Success Criteria**: Pages can break the grid deliberately, creating dynamic tension without chaos.
+
+---
+
+### Phase 3: Strike Typography
+
+**Goal**: Type that punches.
+
+**Key Decisions**:
+- Display typeface: Bold condensed sans (Oswald, Bebas Neue, Impact-adjacent)
+- Body typeface: Strong sans (not delicate) for readability with presence
+- All-caps treatment: When appropriate (headlines, calls-to-action)
+- Vertical/rotated text: Options for Constructivist layouts
+
+**Deliverables**:
+- Font selection and loading
+- Type scale with dramatic size contrast (small body, large headlines)
+- Rotated text utility classes
+- Stacking/overlapping text options
+
+**Success Criteria**: Headlines feel like they're shouting. Body text feels like a confident voice. The contrast between them is deliberate.
+
+---
+
+### Phase 4: Motion as Emphasis
+
+**Goal**: Animation that strikes, not soothes.
+
+**Key Decisions**:
+- Duration: Short, sharp (100-200ms for emphasis)
+- Easing: Ease-out for arrivals, ease-in for urgency
+- Appropriate effects: Scale, position shift, color inversion
+- Restraint: Save intensity for moments that deserve it
+
+**Deliverables**:
+- Motion tokens with sharp durations
+- Aggressive easing curves
+- Interaction state specifications
+- Guidelines: when to be intense, when to rest
+
+**Success Criteria**: Interactions feel decisive. Hover states command attention. Nothing is polite.
+
+---
+
+### Phase 5: Component Expression
+
+**Goal**: Translate Neo-Constructivist principles into components.
+
+**Priority Components**:
+- **Button**: Bold, often red, angular or with diagonal treatment, aggressive hover
+- **Card**: High-contrast, potentially with diagonal dividers, bold borders
+- **Badge/Tag**: Red on black or reverse, demanding attention
+- **Hero Section**: Full diagonal composition, photomontage-ready
+- **Call-to-Action**: Maximum urgency—large, impossible to miss
+
+**Success Criteria**: Each component feels like part of a poster campaign. Nothing recedes.
+
+---
+
+### Phase 6: Photomontage Integration
+
+**Goal**: Support the Constructivist tradition of combining imagery with graphic elements.
+
+**Deliverables**:
+- Image treatment utilities (high contrast, duotone)
+- Overlay options for text on images
+- Cutout/silhouette styling guidance
+- Guidelines for photomontage composition
+
+**Success Criteria**: Images integrate with graphic elements; they don't just sit next to them.
+
+---
+
+### Phase 7: Campaign Templates
+
+**Goal**: Demonstrate full Neo-Constructivist layouts.
+
+**Deliverables**:
+- Landing page template with diagonal composition
+- Article template for opinion/editorial
+- Call-to-action section patterns
+- Guidelines for full-page design
+
+**Success Criteria**: Templates feel like modern propaganda (in the design sense)—unified, urgent, unmistakable.
+
+---
+
+## Principles for Implementation
+
+### When Adding a Token, Ask:
+
+1. **Does it command?** Every element should feel deliberate, not tentative.
+2. **Is it constrained?** The power comes from limitation. More options = less impact.
+3. **Does it serve the argument?** Neo-Constructivism is rhetorical. Everything makes a case.
+4. **Is it urgent?** If it doesn't feel necessary, it probably isn't.
+
+### When Building a Component, Ask:
+
+1. **Does it break the grid?** At least consider a diagonal treatment.
+2. **Is it bold enough?** Err on the side of too much, then pull back.
+3. **Could it be on a poster?** A useful heuristic for visual impact.
+4. **Does it earn its intensity?** Not everything can shout—save it for what matters.
+
+---
+
+## The Destination
+
+When this system is complete, a page should feel like a speech:
+
+> "The hero cuts diagonally from top-left to bottom-right—white space to red field. The headline is Bebas Neue at 96px, all caps, rotated 15 degrees: 'THIS IS THE MOMENT.' Below, body text in confident black on cream, flush left, ragged right. The primary button is red, full-width on mobile, pulsing slightly on hover. The secondary button is outlined in black, no fill—clearly secondary but still present. An image of hands reaching is silhouetted and placed asymmetrically, overlapping the diagonal cut."
+
+This is not a page. It is an argument. The user is not browsed—they are addressed.
+
+---
+
+## A Note on Context
+
+Neo-Constructivism suits:
+- Opinion and editorial content
+- Political campaigns and activist organizations
+- Calls-to-action that deserve urgency
+- Announcements and launches
+- Brands that want to feel revolutionary
+
+It may not suit:
+- Calm, contemplative content
+- Long-form reading requiring sustained attention
+- Conservative/institutional contexts
+- Users who need gentle guidance
+- Everyday utility interfaces
+
+Neo-Constructivism is a voice raised. Use it when you have something to say—not for everything. A perpetually shouting interface exhausts everyone.
+
+---
+
+## Historical Note
+
+Constructivism emerged in revolutionary Russia (1913–1930s) among artists who believed art should serve social transformation. Alexander Rodchenko, El Lissitzky, and Varvara Stepanova created work that blurred the line between art and propaganda.
+
+After the movement was suppressed in the Soviet Union (Stalin favored Socialist Realism), its visual language migrated westward—influencing Bauhaus, Swiss International Style, and eventually punk graphic design. Shepard Fairey's "Hope" poster for Obama 2008 is direct Neo-Constructivist lineage.
+
+The aesthetic is politically contested. It has been used by leftists and rightists, liberators and authoritarians. The visual language carries revolutionary energy; the politics depends on who deploys it.
+
+This theme borrows the energy, not the ideology. But users should understand: nothing about this aesthetic is neutral. It was designed to persuade. It still does.
+
+---
+
+## Ethical Consideration
+
+Propaganda aesthetics are powerful precisely because they bypass rational evaluation. The diagonal disarms. The red demands. The bold type commands.
+
+With this power comes responsibility. Neo-Constructivism should be used for causes the designer believes in. It should not be used to manipulate, to obscure, to trick. The Constructivists believed they were building a better world. Whether they succeeded is debatable. That they believed it is not.
+
+Use this theme for things worth fighting for.
+
+---
+
+*"The artist constructs a new symbol with his brush. This symbol is not a recognizable form of anything that is already finished, already made, or already existent in the world—it is a symbol of a new world, which is being built upon and which exists by way of the people."*
+— El Lissitzky
+
+This theme is a small tool for building new symbols. Use it to say what needs to be said.

--- a/packages/ui/docs/wabisabi_theme/00_VISION.md
+++ b/packages/ui/docs/wabisabi_theme/00_VISION.md
@@ -1,0 +1,275 @@
+# Japanese Minimalism / Wabi-Sabi Theme: Design Vision & Roadmap
+
+## Philosophy
+
+### The Essence
+
+Wabi-sabi is impermanence made beautiful.
+
+In sixteenth-century Japan, the tea master Sen no Rikyū transformed a simple ritual into a philosophical practice. He replaced ornate Chinese teaware with rough, asymmetrical bowls made by anonymous craftsmen. He built tea houses with humble materials—mud walls, thatched roofs, exposed bamboo. He created beauty from restraint, meaning from emptiness.
+
+Wabi-sabi names this aesthetic: *wabi*, the beauty of simplicity and poverty; *sabi*, the beauty of age and wear. A cracked glaze is more beautiful than a perfect one. A weathered surface tells a story. Empty space is not nothing—it is *ma*, the pregnant pause between things.
+
+This theme carries that ethos into the digital age. In a world of infinite scalability and pixel-perfect precision, wabi-sabi offers a different proposition: *what if we designed for transience, for imperfection, for the human hand?*
+
+The interface should breathe, not shout.
+
+### Three Principles
+
+**1. Ma (間) — The Space Between**
+
+Ma is not empty space—it is active space, charged with meaning. The pause in a conversation. The silence between notes. In interface design, ma is generous whitespace that lets content breathe. It is the courage to leave things out. A button surrounded by space commands more attention than a button crammed with neighbors.
+
+**2. Kanso (簡素) — Simplicity**
+
+Not minimalism as style, but simplicity as substance. Every element earns its place. Nothing decorative. Nothing redundant. But where Western minimalism often feels cold, kanso retains warmth—the warmth of natural materials, of handmade objects, of care taken over simple things.
+
+**3. Fukinsei (不均整) — Asymmetry and Imperfection**
+
+Perfect symmetry is dead. Perfect surfaces are lifeless. Fukinsei embraces the irregular—asymmetric layouts, subtle texture, elements that feel placed by a human hand rather than snapped to a grid. This is not randomness; it is controlled imperfection that creates life.
+
+---
+
+## The Wabi-Sabi Vocabulary
+
+### What Wabi-Sabi Is
+
+- **Generous empty space**: Ma as a design element, not wasted pixels
+- **Muted, natural colors**: Earth tones, stone, clay, paper—colors that could exist in nature
+- **Subtle textures**: Paper grain, slight noise, organic variation
+- **Asymmetric balance**: Placement that feels considered, not computed
+- **Slow transitions**: Movement like breathing, not snapping
+- **Typography as object**: Text with presence, not just information
+
+### What Wabi-Sabi Is Not
+
+- **Minimalist brutalism**: Wabi-sabi has warmth and texture; it is not cold reduction
+- **Deliberate ugliness**: Imperfection is beautiful, not sloppy
+- **Nostalgic pastiche**: We are not recreating paper textures—we are applying principles
+- **Static emptiness**: Ma is active; space has purpose
+- **Anti-functional**: Calm interfaces can be highly usable
+
+---
+
+## The Gap Between Now and Excellence
+
+### What the Token System Provides
+
+The existing architecture can support wabi-sabi:
+- Three-layer token abstraction enables soft, natural palettes
+- Theme switching allows for this contemplative alternative
+- Semantic naming supports the philosophical approach
+
+### What Wabi-Sabi Requires
+
+**Natural Color Palette**: Current colors lean toward web-standard primaries and functional grays. Wabi-sabi needs earth tones—warm whites, clay reds, moss greens, stone grays. Colors that could exist without electricity.
+
+**Texture System**: Digital surfaces are perfectly flat. Wabi-sabi needs subtle texture tokens—paper grain, slight noise, organic imperfection. This is challenging technically but essential aesthetically.
+
+**Generous Spacing**: Current spacing may be functional but conventional. Wabi-sabi needs dramatically generous whitespace options—spacing that feels luxurious, like a meditation hall.
+
+**Slow Motion**: Current transitions are functional and fast. Wabi-sabi needs slow, breath-like motion—long durations, gentle easing, movement that calms rather than urges.
+
+**Asymmetric Layouts**: Most CSS defaults encourage centered, symmetrical layouts. Wabi-sabi needs utilities for deliberate asymmetry that still feels balanced.
+
+---
+
+## The Roadmap
+
+### Phase 1: Color of Nature
+
+**Goal**: Establish a palette that feels like it came from the earth.
+
+**Key Decisions**:
+- Background: Warm white (not blue-white) like handmade paper
+- Text: Soft black (charcoal, not pure #000) like sumi ink
+- Accents: Earth tones—clay, moss, stone, bark
+- No pure primaries: Colors should feel mixed, natural, impure
+
+**Deliverables**:
+- Primitive colors inspired by natural materials
+- Semantic mappings for wabi-sabi theme
+- Light mode (primary) and dark mode (ink on dark paper)
+
+**Color Palette Inspiration**:
+```
+Paper White    #F7F5F0   (warm, not cold)
+Sumi Black     #2D2D2D   (charcoal, not pure black)
+Clay           #B87333   (earth, warmth)
+Moss           #6B7B5F   (organic green, muted)
+Stone          #8B8B8B   (neutral, weathered)
+Bark           #5D4E3C   (deep, grounding)
+Mist           #D5D5D0   (subtle, atmospheric)
+```
+
+**Success Criteria**: The palette feels like materials you could touch—paper, stone, tea, earth.
+
+---
+
+### Phase 2: Ma — Spacing System
+
+**Goal**: Create dramatically generous spacing that creates calm.
+
+**Key Decisions**:
+- Larger base spacing than typical systems
+- Semantic spacing: `ma.sm`, `ma.md`, `ma.lg`, `ma.xl`
+- Composition spacing: Room between sections that feels like pauses
+- Component spacing: Generous internal padding
+
+**Deliverables**:
+- Extended spacing scale (larger increments)
+- Guidelines for when to use generous vs. compact spacing
+- Layout templates demonstrating ma
+
+**Success Criteria**: The page feels spacious, unhurried. Content has room to breathe.
+
+---
+
+### Phase 3: Typography as Presence
+
+**Goal**: Type that feels crafted, not generated.
+
+**Key Decisions**:
+- Typeface: Humanist sans or gentle serif (not geometric, not cold)
+- Weight: Light and regular preferred over bold
+- Spacing: Generous line-height, letter-spacing for headlines
+- Hierarchy: Subtle, not shouting—size differences modest
+
+**Deliverables**:
+- Font selection (something with character, possibly Japanese-influenced Latin type)
+- Type scale (compressed, subtle hierarchy)
+- Line-height and letter-spacing tokens
+
+**Success Criteria**: Text feels written, not displayed. Headlines don't compete for attention.
+
+---
+
+### Phase 4: Texture and Imperfection
+
+**Goal**: Add subtle organic variation to digital surfaces.
+
+**Key Decisions**:
+- Texture approach: CSS noise, subtle gradients, or SVG filters
+- Application: Backgrounds, not foregrounds
+- Subtlety: Barely perceptible, enhances rather than distracts
+- Performance: Lightweight, not computationally expensive
+
+**Deliverables**:
+- Texture utility classes
+- Guidelines for appropriate texture use
+- Performance-tested implementations
+
+**Success Criteria**: Surfaces feel slightly organic—like paper or stone, not glass or plastic.
+
+---
+
+### Phase 5: Slow Motion
+
+**Goal**: Animation that calms rather than urges.
+
+**Key Decisions**:
+- Duration: Longer than typical (500ms–1000ms for emphasis)
+- Easing: Gentle curves, no bounce, no snap
+- Triggers: Subtle, not demanding attention
+- Absence: Motion should be rare, making it meaningful when present
+
+**Deliverables**:
+- Motion tokens with longer durations
+- Easing curves optimized for calm
+- Guidelines: when motion enhances calm, when it disrupts
+
+**Success Criteria**: Transitions feel like slow breaths. Nothing startles.
+
+---
+
+### Phase 6: Component Expression
+
+**Goal**: Translate wabi-sabi principles into the component library.
+
+**Priority Components**:
+- **Button**: Soft borders, muted colors, gentle hover states
+- **Card**: Subtle shadow or border, generous padding, asymmetric placement options
+- **Input**: Understated styling, focus states that don't shout
+- **Blockquote**: Generous spacing, subtle styling, space to breathe
+- **Image treatment**: Soft edges, perhaps slight desaturation
+
+**Success Criteria**: Each component feels handmade, not manufactured. Interfaces feel calm.
+
+---
+
+### Phase 7: Asymmetric Layout
+
+**Goal**: Create tools for deliberate, balanced asymmetry.
+
+**Deliverables**:
+- Layout utilities for off-center placement
+- Guidelines for asymmetric balance
+- Template patterns demonstrating wabi-sabi composition
+
+**Success Criteria**: Layouts feel considered and human, not computed and perfect.
+
+---
+
+## Principles for Implementation
+
+### When Adding a Token, Ask:
+
+1. **Does it feel natural?** Could this color, this spacing, this texture exist in the physical world?
+2. **Does it create calm?** Every element should reduce visual noise, not add to it.
+3. **Is it essential?** Wabi-sabi removes. If it doesn't serve, it goes.
+4. **Does it have warmth?** Even neutrals should feel warm, not cold.
+
+### When Building a Component, Ask:
+
+1. **Would it fit in a tea house?** A useful heuristic for visual restraint.
+2. **Does it breathe?** Spacing should feel generous.
+3. **Is it soft?** Edges, colors, transitions—all should be gentle.
+4. **Does it feel made?** As if someone cared about this small thing.
+
+---
+
+## The Destination
+
+When this system is complete, a page should feel like a meditation:
+
+> "The headline is set in a humanist sans, regular weight, charcoal on warm white. Below it, generous ma—perhaps 120px—before the body text begins. The body is comfortable, long line-height, words that don't feel rushed. A single image sits asymmetrically, slightly off-center, with a soft shadow that suggests it's resting on the page rather than floating above it. The background has the faintest texture, like good paper. Nothing moves unless you hover, and then it moves slowly, like a leaf settling."
+
+This is not a page. It is a place. The reader is not processed—they are welcomed.
+
+---
+
+## A Note on Context
+
+Wabi-sabi suits:
+- Reading apps and long-form content
+- Journaling and personal reflection tools
+- Meditation and wellness applications
+- Personal blogs and portfolios
+- Any context where calm is the goal
+
+It may not suit:
+- High-urgency interfaces (e-commerce, news)
+- Data-dense dashboards requiring quick scanning
+- Brands requiring bold, assertive presence
+- Contexts where users expect fast, snappy feedback
+
+Wabi-sabi assumes the user has time, attention, and willingness to be present. It is a gift for readers who arrive ready to settle in.
+
+---
+
+## Historical Note
+
+Wabi-sabi emerged from Japanese tea ceremony culture, particularly the work of Sen no Rikyū (1522–1591), who elevated simple, rustic aesthetics to high art. The concepts have roots in Buddhist philosophy—particularly the recognition of impermanence (mujō) and the acceptance of suffering and imperfection as aspects of life.
+
+In the twentieth century, wabi-sabi influenced Western design through figures like Charlotte Perriand and later, the work of Apple under Jony Ive (particularly the textured, natural skeuomorphism of early iOS, before the flat design era).
+
+The philosopher Kenya Hara, creative director of MUJI, represents contemporary wabi-sabi thinking in design: "Emptiness is not merely 'nothing.' It is a space that can be filled with anything, with limitless possibilities."
+
+This theme attempts to create that kind of emptiness—not absence, but invitation.
+
+---
+
+*"In the tea ceremony, water representing 'yin' and fire representing 'yang' are used to create harmony."*
+— Sen no Rikyū
+
+This theme seeks harmony between content and space, presence and absence, the screen and the human.


### PR DESCRIPTION
## Summary

- Add `00_VISION.md` documents for **Bauhaus**, **De Stijl**, **Japanese Minimalism (Wabi-Sabi)**, and **Neo-Constructivist / Propaganda Aesthetic** design schools
- Each document follows the established pattern from NYT and Brutalism themes
- Documents include philosophy, core principles, vocabulary definition, gap analysis, phased implementation roadmap, and historical context

## New Files

| Theme | File | Core Principles |
|-------|------|-----------------|
| Bauhaus | `packages/ui/docs/bauhaus_theme/00_VISION.md` | Geometric truth, primary clarity, form follows function |
| De Stijl | `packages/ui/docs/destijl_theme/00_VISION.md` | Perpendicular only, primary absolutes, asymmetric balance |
| Wabi-Sabi | `packages/ui/docs/wabisabi_theme/00_VISION.md` | Ma (空間), kanso (簡素), fukinsei (不均整) |
| Neo-Constructivist | `packages/ui/docs/neoconstructivist_theme/00_VISION.md` | Diagonal = dynamic, limited palette strikes, typography as weapon |

## Test plan

- [ ] Review each vision document for accuracy and completeness
- [ ] Verify documents follow the established pattern from existing themes
- [ ] Check that roadmap phases are actionable and well-defined

🤖 Generated with [Claude Code](https://claude.com/claude-code)