### PR TITLE
feat(blog): Implement Phase 5 Layout & Theme System

### DIFF
--- a/apps/blog/__tests__/theme.test.ts
+++ b/apps/blog/__tests__/theme.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import {
+  type ThemeMode,
+  type ThemeName,
+  THEME_MODE_KEY,
+  THEME_NAME_KEY,
+  DEFAULT_THEME_MODE,
+  DEFAULT_THEME_NAME,
+  getStoredThemeMode,
+  getStoredThemeName,
+  getSystemPreference,
+  setStoredThemeMode,
+  setStoredThemeName,
+  applyThemeMode,
+  applyThemeName,
+  getResolvedThemeMode,
+  getResolvedThemeName,
+  toggleThemeMode,
+} from '../lib/theme';
+
+describe('Theme utilities', () => {
+  // Mock localStorage
+  let localStorageMock: { [key: string]: string };
+
+  beforeEach(() => {
+    localStorageMock = {};
+    vi.stubGlobal('localStorage', {
+      getItem: (key: string) => localStorageMock[key] || null,
+      setItem: (key: string, value: string) => {
+        localStorageMock[key] = value;
+      },
+      removeItem: (key: string) => {
+        delete localStorageMock[key];
+      },
+      clear: () => {
+        localStorageMock = {};
+      },
+    });
+
+    // Mock document
+    vi.stubGlobal('document', {
+      documentElement: {
+        dataset: {} as { mode?: string; theme?: string },
+      },
+    });
+
+    // Mock window.matchMedia
+    vi.stubGlobal('window', {
+      matchMedia: (query: string) => ({
+        matches: query === '(prefers-color-scheme: dark)' ? false : true,
+        media: query,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      }),
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe('Constants', () => {
+    it('has correct storage keys', () => {
+      expect(THEME_MODE_KEY).toBe('theme-mode');
+      expect(THEME_NAME_KEY).toBe('theme-name');
+    });
+
+    it('has correct default values', () => {
+      expect(DEFAULT_THEME_MODE).toBe('light');
+      expect(DEFAULT_THEME_NAME).toBe('nyt');
+    });
+  });
+
+  describe('getStoredThemeMode', () => {
+    it('returns null when no mode is stored', () => {
+      expect(getStoredThemeMode()).toBe(null);
+    });
+
+    it('returns stored light mode', () => {
+      localStorageMock[THEME_MODE_KEY] = 'light';
+      expect(getStoredThemeMode()).toBe('light');
+    });
+
+    it('returns stored dark mode', () => {
+      localStorageMock[THEME_MODE_KEY] = 'dark';
+      expect(getStoredThemeMode()).toBe('dark');
+    });
+
+    it('returns null for invalid stored value', () => {
+      localStorageMock[THEME_MODE_KEY] = 'invalid';
+      expect(getStoredThemeMode()).toBe(null);
+    });
+  });
+
+  describe('getStoredThemeName', () => {
+    it('returns null when no theme is stored', () => {
+      expect(getStoredThemeName()).toBe(null);
+    });
+
+    it('returns stored nyt theme', () => {
+      localStorageMock[THEME_NAME_KEY] = 'nyt';
+      expect(getStoredThemeName()).toBe('nyt');
+    });
+
+    it('returns stored brutalism theme', () => {
+      localStorageMock[THEME_NAME_KEY] = 'brutalism';
+      expect(getStoredThemeName()).toBe('brutalism');
+    });
+
+    it('returns null for invalid stored value', () => {
+      localStorageMock[THEME_NAME_KEY] = 'invalid';
+      expect(getStoredThemeName()).toBe(null);
+    });
+  });
+
+  describe('getSystemPreference', () => {
+    it('returns light when system prefers light', () => {
+      vi.stubGlobal('window', {
+        matchMedia: (query: string) => ({
+          matches: false, // Not dark
+          media: query,
+        }),
+      });
+      expect(getSystemPreference()).toBe('light');
+    });
+
+    it('returns dark when system prefers dark', () => {
+      vi.stubGlobal('window', {
+        matchMedia: (query: string) => ({
+          matches: query === '(prefers-color-scheme: dark)',
+          media: query,
+        }),
+      });
+      expect(getSystemPreference()).toBe('dark');
+    });
+  });
+
+  describe('setStoredThemeMode', () => {
+    it('stores theme mode in localStorage', () => {
+      setStoredThemeMode('dark');
+      expect(localStorageMock[THEME_MODE_KEY]).toBe('dark');
+    });
+  });
+
+  describe('setStoredThemeName', () => {
+    it('stores theme name in localStorage', () => {
+      setStoredThemeName('brutalism');
+      expect(localStorageMock[THEME_NAME_KEY]).toBe('brutalism');
+    });
+  });
+
+  describe('applyThemeMode', () => {
+    it('sets data-mode attribute on document', () => {
+      applyThemeMode('dark');
+      expect(document.documentElement.dataset.mode).toBe('dark');
+    });
+  });
+
+  describe('applyThemeName', () => {
+    it('sets data-theme attribute on document', () => {
+      applyThemeName('brutalism');
+      expect(document.documentElement.dataset.theme).toBe('brutalism');
+    });
+  });
+
+  describe('getResolvedThemeMode', () => {
+    it('returns stored mode if available', () => {
+      localStorageMock[THEME_MODE_KEY] = 'dark';
+      expect(getResolvedThemeMode()).toBe('dark');
+    });
+
+    it('returns system preference if no stored mode', () => {
+      vi.stubGlobal('window', {
+        matchMedia: (query: string) => ({
+          matches: query === '(prefers-color-scheme: dark)',
+          media: query,
+        }),
+      });
+      expect(getResolvedThemeMode()).toBe('dark');
+    });
+  });
+
+  describe('getResolvedThemeName', () => {
+    it('returns stored theme if available', () => {
+      localStorageMock[THEME_NAME_KEY] = 'brutalism';
+      expect(getResolvedThemeName()).toBe('brutalism');
+    });
+
+    it('returns default theme if no stored theme', () => {
+      expect(getResolvedThemeName()).toBe('nyt');
+    });
+  });
+
+  describe('toggleThemeMode', () => {
+    it('toggles from light to dark', () => {
+      localStorageMock[THEME_MODE_KEY] = 'light';
+      const result = toggleThemeMode();
+      expect(result).toBe('dark');
+      expect(localStorageMock[THEME_MODE_KEY]).toBe('dark');
+      expect(document.documentElement.dataset.mode).toBe('dark');
+    });
+
+    it('toggles from dark to light', () => {
+      localStorageMock[THEME_MODE_KEY] = 'dark';
+      const result = toggleThemeMode();
+      expect(result).toBe('light');
+      expect(localStorageMock[THEME_MODE_KEY]).toBe('light');
+      expect(document.documentElement.dataset.mode).toBe('light');
+    });
+  });
+});

--- a/apps/blog/app/layout.tsx
+++ b/apps/blog/app/layout.tsx
@@ -1,6 +1,12 @@
 import type { Metadata } from 'next';
 import '@blog/tokens/css';
 import './globals.css';
+import {
+  SiteHeader,
+  SiteFooter,
+  ThemeProvider,
+  ThemeToggle,
+} from '../components/layout';
 
 export const metadata: Metadata = {
   title: {
@@ -45,8 +51,12 @@ export default function RootLayout({ children }: RootLayoutProps) {
           }}
         />
       </head>
-      <body className="min-h-screen bg-ground-primary text-figure-primary antialiased">
-        {children}
+      <body className="flex min-h-screen flex-col bg-ground-primary text-figure-primary antialiased">
+        <ThemeProvider>
+          <SiteHeader actions={<ThemeToggle />} />
+          <main className="flex-1">{children}</main>
+          <SiteFooter />
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/apps/blog/components/layout/SiteFooter.stories.tsx
+++ b/apps/blog/components/layout/SiteFooter.stories.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { SiteFooter } from './SiteFooter';
+
+const meta: Meta<typeof SiteFooter> = {
+  title: 'Blog / Layout / SiteFooter',
+  component: SiteFooter,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof SiteFooter>;
+
+export const Default: Story = {
+  args: {},
+};
+
+export const CustomCopyright: Story = {
+  args: {
+    copyright: '© 2024 John Doe. All rights reserved.',
+  },
+};
+
+// GitHub icon component for stories
+const GitHubIcon = () => (
+  <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
+    <path
+      fillRule="evenodd"
+      d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"
+      clipRule="evenodd"
+    />
+  </svg>
+);
+
+// Twitter/X icon component for stories
+const TwitterIcon = () => (
+  <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
+    <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+  </svg>
+);
+
+// LinkedIn icon component for stories
+const LinkedInIcon = () => (
+  <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
+    <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+  </svg>
+);
+
+export const WithSocialLinks: Story = {
+  args: {
+    socialLinks: [
+      { href: 'https://github.com', label: 'GitHub', icon: <GitHubIcon /> },
+      { href: 'https://twitter.com', label: 'Twitter', icon: <TwitterIcon /> },
+      { href: 'https://linkedin.com', label: 'LinkedIn', icon: <LinkedInIcon /> },
+    ],
+  },
+};
+
+export const FullFooter: Story = {
+  args: {
+    copyright: '© 2024 Essays. Built with Next.js and love.',
+    socialLinks: [
+      { href: 'https://github.com', label: 'GitHub', icon: <GitHubIcon /> },
+      { href: 'https://twitter.com', label: 'Twitter', icon: <TwitterIcon /> },
+    ],
+  },
+};

--- a/apps/blog/components/layout/SiteFooter.tsx
+++ b/apps/blog/components/layout/SiteFooter.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import * as React from 'react';
+import Link from 'next/link';
+import { cn, Separator } from '@blog/ui';
+
+export interface SocialLink {
+  href: string;
+  label: string;
+  icon: React.ReactNode;
+}
+
+export interface SiteFooterProps {
+  /** Copyright text */
+  copyright?: string;
+  /** Social media links */
+  socialLinks?: SocialLink[];
+  /** Additional class names */
+  className?: string;
+}
+
+const currentYear = new Date().getFullYear();
+
+export function SiteFooter({
+  copyright = `© ${currentYear} All rights reserved.`,
+  socialLinks,
+  className,
+}: SiteFooterProps) {
+  return (
+    <footer className={cn('border-t border-border bg-ground-primary', className)}>
+      <div className="container mx-auto px-4 py-8 md:px-6">
+        <div className="flex flex-col items-center gap-4 md:flex-row md:justify-between">
+          {/* Copyright */}
+          <p className="text-body-sm text-figure-muted">{copyright}</p>
+
+          {/* Social links */}
+          {socialLinks && socialLinks.length > 0 && (
+            <div className="flex items-center gap-4">
+              {socialLinks.map((link) => (
+                <Link
+                  key={link.href}
+                  href={link.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={cn(
+                    'text-figure-muted hover:text-figure-primary',
+                    'transition-hover'
+                  )}
+                  aria-label={link.label}
+                >
+                  {link.icon}
+                </Link>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Optional: Navigation links in footer */}
+        <Separator spacing="md" variant="muted" className="mt-6 mb-4" />
+        <nav
+          className="flex flex-wrap justify-center gap-4 md:gap-6"
+          aria-label="Footer navigation"
+        >
+          <Link
+            href="/essays"
+            className="text-body-sm text-figure-muted hover:text-figure-primary transition-hover"
+          >
+            Essays
+          </Link>
+          <Link
+            href="/about"
+            className="text-body-sm text-figure-muted hover:text-figure-primary transition-hover"
+          >
+            About
+          </Link>
+        </nav>
+      </div>
+    </footer>
+  );
+}

--- a/apps/blog/components/layout/SiteHeader.stories.tsx
+++ b/apps/blog/components/layout/SiteHeader.stories.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { SiteHeader } from './SiteHeader';
+import { ThemeProvider } from './ThemeProvider';
+import { ThemeToggle } from './ThemeToggle';
+
+const meta: Meta<typeof SiteHeader> = {
+  title: 'Blog / Layout / SiteHeader',
+  component: SiteHeader,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  decorators: [
+    (Story) => (
+      <ThemeProvider>
+        <Story />
+      </ThemeProvider>
+    ),
+  ],
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof SiteHeader>;
+
+export const Default: Story = {
+  args: {
+    siteName: 'Essays',
+  },
+};
+
+export const WithThemeToggle: Story = {
+  args: {
+    siteName: 'Essays',
+    actions: <ThemeToggle />,
+  },
+};
+
+export const CustomSiteName: Story = {
+  args: {
+    siteName: 'My Blog',
+    actions: <ThemeToggle />,
+  },
+};
+
+export const WithCustomNavigation: Story = {
+  args: {
+    siteName: 'Essays',
+    navigation: (
+      <nav className="flex items-center gap-6">
+        <a href="#" className="text-body text-figure-secondary hover:text-figure-primary">
+          Home
+        </a>
+        <a href="#" className="text-body text-figure-secondary hover:text-figure-primary">
+          Articles
+        </a>
+        <a href="#" className="text-body text-figure-secondary hover:text-figure-primary">
+          Projects
+        </a>
+        <a href="#" className="text-body text-figure-secondary hover:text-figure-primary">
+          Contact
+        </a>
+      </nav>
+    ),
+    actions: <ThemeToggle />,
+  },
+};

--- a/apps/blog/components/layout/SiteHeader.tsx
+++ b/apps/blog/components/layout/SiteHeader.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import * as React from 'react';
+import Link from 'next/link';
+import { cn } from '@blog/ui';
+import { SiteNav } from './SiteNav';
+
+export interface SiteHeaderProps {
+  /** Site name/logo text */
+  siteName?: string;
+  /** Optional slot for navigation (defaults to SiteNav) */
+  navigation?: React.ReactNode;
+  /** Optional slot for actions (e.g., theme toggle) */
+  actions?: React.ReactNode;
+  /** Additional class names */
+  className?: string;
+}
+
+export function SiteHeader({
+  siteName = 'Essays',
+  navigation,
+  actions,
+  className,
+}: SiteHeaderProps) {
+  return (
+    <header
+      className={cn(
+        'sticky top-0 z-40 w-full',
+        'bg-ground-primary/95 backdrop-blur supports-[backdrop-filter]:bg-ground-primary/80',
+        'border-b border-border',
+        className
+      )}
+    >
+      <div className="container mx-auto flex h-16 items-center justify-between px-4 md:px-6">
+        {/* Logo / Site name */}
+        <Link
+          href="/"
+          className={cn(
+            'flex items-center gap-2',
+            'text-heading-sm font-semibold tracking-tight',
+            'text-figure-primary hover:text-link-hover transition-hover'
+          )}
+        >
+          {siteName}
+        </Link>
+
+        {/* Navigation - hidden on mobile, shown on md+ */}
+        <div className="hidden md:flex md:items-center md:gap-6">
+          {navigation ?? <SiteNav />}
+        </div>
+
+        {/* Actions slot (theme toggle, etc.) */}
+        <div className="flex items-center gap-2">
+          {actions}
+          {/* Mobile menu button - placeholder for Phase 8 */}
+          <button
+            type="button"
+            className={cn(
+              'md:hidden',
+              'inline-flex items-center justify-center',
+              'h-10 w-10 rounded-md',
+              'text-figure-secondary hover:text-figure-primary hover:bg-action-secondary',
+              'transition-hover'
+            )}
+            aria-label="Open menu"
+            aria-expanded="false"
+          >
+            <svg
+              className="h-5 w-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth="1.5"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M3.75 6.75h16.5M3.75 12h16.5M3.75 17.25h16.5"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/apps/blog/components/layout/SiteNav.stories.tsx
+++ b/apps/blog/components/layout/SiteNav.stories.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { SiteNav, type NavLink } from './SiteNav';
+
+const meta: Meta<typeof SiteNav> = {
+  title: 'Blog / Layout / SiteNav',
+  component: SiteNav,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof SiteNav>;
+
+export const Default: Story = {
+  args: {},
+};
+
+export const CustomLinks: Story = {
+  args: {
+    links: [
+      { href: '/blog', label: 'Blog' },
+      { href: '/projects', label: 'Projects' },
+      { href: '/about', label: 'About' },
+      { href: '/contact', label: 'Contact' },
+    ],
+  },
+};
+
+export const SingleLink: Story = {
+  args: {
+    links: [{ href: '/essays', label: 'All Essays' }],
+  },
+};
+
+export const ManyLinks: Story = {
+  args: {
+    links: [
+      { href: '/essays', label: 'Essays' },
+      { href: '/guides', label: 'Guides' },
+      { href: '/tutorials', label: 'Tutorials' },
+      { href: '/reviews', label: 'Reviews' },
+      { href: '/about', label: 'About' },
+    ],
+  },
+};

--- a/apps/blog/components/layout/SiteNav.tsx
+++ b/apps/blog/components/layout/SiteNav.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import * as React from 'react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { cn } from '@blog/ui';
+
+export interface NavLink {
+  href: string;
+  label: string;
+}
+
+export interface SiteNavProps {
+  links?: NavLink[];
+  className?: string;
+}
+
+const defaultLinks: NavLink[] = [
+  { href: '/essays', label: 'Essays' },
+  { href: '/about', label: 'About' },
+];
+
+export function SiteNav({ links = defaultLinks, className }: SiteNavProps) {
+  const pathname = usePathname();
+
+  return (
+    <nav className={cn('flex items-center gap-6', className)} aria-label="Main navigation">
+      {links.map((link) => {
+        const isActive = pathname === link.href || pathname.startsWith(`${link.href}/`);
+        return (
+          <Link
+            key={link.href}
+            href={link.href}
+            className={cn(
+              'text-body transition-hover',
+              'hover:text-link-hover',
+              isActive
+                ? 'text-figure-primary font-medium'
+                : 'text-figure-secondary'
+            )}
+            aria-current={isActive ? 'page' : undefined}
+          >
+            {link.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/apps/blog/components/layout/ThemeProvider.tsx
+++ b/apps/blog/components/layout/ThemeProvider.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import * as React from 'react';
+import {
+  type ThemeMode,
+  type ThemeName,
+  getResolvedThemeMode,
+  getResolvedThemeName,
+  setStoredThemeMode,
+  setStoredThemeName,
+  applyThemeMode,
+  applyThemeName,
+  getSystemPreference,
+  DEFAULT_THEME_MODE,
+  DEFAULT_THEME_NAME,
+} from '@/lib/theme';
+
+interface ThemeContextValue {
+  mode: ThemeMode;
+  themeName: ThemeName;
+  setMode: (mode: ThemeMode) => void;
+  setThemeName: (name: ThemeName) => void;
+  toggleMode: () => void;
+}
+
+const ThemeContext = React.createContext<ThemeContextValue | undefined>(
+  undefined
+);
+
+export interface ThemeProviderProps {
+  children: React.ReactNode;
+  /** Default mode to use before hydration */
+  defaultMode?: ThemeMode;
+  /** Default theme name to use */
+  defaultThemeName?: ThemeName;
+}
+
+export function ThemeProvider({
+  children,
+  defaultMode = DEFAULT_THEME_MODE,
+  defaultThemeName = DEFAULT_THEME_NAME,
+}: ThemeProviderProps) {
+  // Initialize with default to avoid hydration mismatch
+  // The actual value will be set in useEffect after mount
+  const [mode, setModeState] = React.useState<ThemeMode>(defaultMode);
+  const [themeName, setThemeNameState] =
+    React.useState<ThemeName>(defaultThemeName);
+  const [mounted, setMounted] = React.useState(false);
+
+  // On mount, read the actual values from localStorage/system preference
+  React.useEffect(() => {
+    setMounted(true);
+    const resolvedMode = getResolvedThemeMode();
+    const resolvedThemeName = getResolvedThemeName();
+    setModeState(resolvedMode);
+    setThemeNameState(resolvedThemeName);
+    applyThemeMode(resolvedMode);
+    applyThemeName(resolvedThemeName);
+  }, []);
+
+  // Listen for system preference changes
+  React.useEffect(() => {
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+
+    const handleChange = () => {
+      // Only update if no stored preference
+      if (!localStorage.getItem('theme-mode')) {
+        const systemMode = getSystemPreference();
+        setModeState(systemMode);
+        applyThemeMode(systemMode);
+      }
+    };
+
+    mediaQuery.addEventListener('change', handleChange);
+    return () => mediaQuery.removeEventListener('change', handleChange);
+  }, []);
+
+  const setMode = React.useCallback((newMode: ThemeMode) => {
+    setModeState(newMode);
+    setStoredThemeMode(newMode);
+    applyThemeMode(newMode);
+  }, []);
+
+  const setThemeName = React.useCallback((newName: ThemeName) => {
+    setThemeNameState(newName);
+    setStoredThemeName(newName);
+    applyThemeName(newName);
+  }, []);
+
+  const toggleMode = React.useCallback(() => {
+    setMode(mode === 'light' ? 'dark' : 'light');
+  }, [mode, setMode]);
+
+  const value = React.useMemo(
+    () => ({
+      mode,
+      themeName,
+      setMode,
+      setThemeName,
+      toggleMode,
+    }),
+    [mode, themeName, setMode, setThemeName, toggleMode]
+  );
+
+  return (
+    <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+  );
+}
+
+export function useTheme(): ThemeContextValue {
+  const context = React.useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+}
+
+/**
+ * Hook that returns true once the component has mounted.
+ * Useful for avoiding hydration mismatches with theme-dependent UI.
+ */
+export function useThemeMounted(): boolean {
+  const [mounted, setMounted] = React.useState(false);
+  React.useEffect(() => {
+    setMounted(true);
+  }, []);
+  return mounted;
+}

--- a/apps/blog/components/layout/ThemeToggle.stories.tsx
+++ b/apps/blog/components/layout/ThemeToggle.stories.tsx
@@ -1,0 +1,74 @@
+import * as React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { ThemeToggle } from './ThemeToggle';
+import { ThemeProvider } from './ThemeProvider';
+
+const meta: Meta<typeof ThemeToggle> = {
+  title: 'Blog / Layout / ThemeToggle',
+  component: ThemeToggle,
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    (Story) => (
+      <ThemeProvider>
+        <div className="p-8">
+          <Story />
+        </div>
+      </ThemeProvider>
+    ),
+  ],
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof ThemeToggle>;
+
+export const Default: Story = {
+  args: {},
+};
+
+export const WithCustomClass: Story = {
+  args: {
+    className: 'border border-border rounded-full',
+  },
+};
+
+export const InContext: Story = {
+  decorators: [
+    (Story) => (
+      <ThemeProvider>
+        <div className="flex items-center gap-4 p-4 bg-ground-secondary rounded-lg">
+          <span className="text-body text-figure-secondary">Toggle theme:</span>
+          <Story />
+        </div>
+      </ThemeProvider>
+    ),
+  ],
+};
+
+export const InHeader: Story = {
+  decorators: [
+    (Story) => (
+      <ThemeProvider>
+        <header className="flex items-center justify-between w-full max-w-4xl p-4 border-b border-border bg-ground-primary">
+          <span className="text-heading-sm font-semibold">Essays</span>
+          <div className="flex items-center gap-4">
+            <nav className="flex items-center gap-6">
+              <a href="#" className="text-body text-figure-secondary hover:text-figure-primary">
+                Essays
+              </a>
+              <a href="#" className="text-body text-figure-secondary hover:text-figure-primary">
+                About
+              </a>
+            </nav>
+            <Story />
+          </div>
+        </header>
+      </ThemeProvider>
+    ),
+  ],
+  parameters: {
+    layout: 'fullscreen',
+  },
+};

--- a/apps/blog/components/layout/ThemeToggle.tsx
+++ b/apps/blog/components/layout/ThemeToggle.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import * as React from 'react';
+import { Button } from '@blog/ui';
+import { Tooltip } from '@blog/ui';
+import { useTheme, useThemeMounted } from './ThemeProvider';
+
+// Sun icon for light mode
+const SunIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="20"
+    height="20"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <circle cx="12" cy="12" r="4" />
+    <path d="M12 2v2" />
+    <path d="M12 20v2" />
+    <path d="m4.93 4.93 1.41 1.41" />
+    <path d="m17.66 17.66 1.41 1.41" />
+    <path d="M2 12h2" />
+    <path d="M20 12h2" />
+    <path d="m6.34 17.66-1.41 1.41" />
+    <path d="m19.07 4.93-1.41 1.41" />
+  </svg>
+);
+
+// Moon icon for dark mode
+const MoonIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="20"
+    height="20"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z" />
+  </svg>
+);
+
+export interface ThemeToggleProps {
+  /** Additional CSS classes */
+  className?: string;
+}
+
+export function ThemeToggle({ className }: ThemeToggleProps) {
+  const { mode, toggleMode } = useTheme();
+  const mounted = useThemeMounted();
+
+  // Render a placeholder with the same dimensions to avoid layout shift
+  // This also prevents hydration mismatch since we don't know the theme on server
+  if (!mounted) {
+    return (
+      <Button
+        variant="ghost"
+        size="sm"
+        className={className}
+        aria-label="Toggle theme"
+        disabled
+      >
+        <span className="w-5 h-5" />
+      </Button>
+    );
+  }
+
+  const isDark = mode === 'dark';
+
+  return (
+    <Tooltip content={isDark ? 'Switch to light mode' : 'Switch to dark mode'}>
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={toggleMode}
+        className={className}
+        aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+      >
+        {isDark ? <SunIcon /> : <MoonIcon />}
+      </Button>
+    </Tooltip>
+  );
+}

--- a/apps/blog/components/layout/index.ts
+++ b/apps/blog/components/layout/index.ts
@@ -1,0 +1,10 @@
+export { SiteHeader, type SiteHeaderProps } from './SiteHeader';
+export { SiteNav, type SiteNavProps, type NavLink } from './SiteNav';
+export { SiteFooter, type SiteFooterProps, type SocialLink } from './SiteFooter';
+export {
+  ThemeProvider,
+  useTheme,
+  useThemeMounted,
+  type ThemeProviderProps,
+} from './ThemeProvider';
+export { ThemeToggle, type ThemeToggleProps } from './ThemeToggle';

--- a/apps/blog/lib/index.ts
+++ b/apps/blog/lib/index.ts
@@ -22,3 +22,22 @@ export {
   type CompileMDXOptions,
   type MDXComponents,
 } from './mdx';
+
+export {
+  type ThemeMode,
+  type ThemeName,
+  THEME_MODE_KEY,
+  THEME_NAME_KEY,
+  DEFAULT_THEME_MODE,
+  DEFAULT_THEME_NAME,
+  getStoredThemeMode,
+  getStoredThemeName,
+  getSystemPreference,
+  setStoredThemeMode,
+  setStoredThemeName,
+  applyThemeMode,
+  applyThemeName,
+  getResolvedThemeMode,
+  getResolvedThemeName,
+  toggleThemeMode,
+} from './theme';

--- a/apps/blog/lib/theme.ts
+++ b/apps/blog/lib/theme.ts
@@ -1,0 +1,123 @@
+/**
+ * Theme utilities for the blog application
+ */
+
+export type ThemeMode = 'light' | 'dark';
+export type ThemeName = 'nyt' | 'brutalism';
+
+export const THEME_MODE_KEY = 'theme-mode';
+export const THEME_NAME_KEY = 'theme-name';
+
+export const DEFAULT_THEME_MODE: ThemeMode = 'light';
+export const DEFAULT_THEME_NAME: ThemeName = 'nyt';
+
+/**
+ * Get the stored theme mode from localStorage
+ */
+export function getStoredThemeMode(): ThemeMode | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const stored = localStorage.getItem(THEME_MODE_KEY);
+    if (stored === 'light' || stored === 'dark') {
+      return stored;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get the stored theme name from localStorage
+ */
+export function getStoredThemeName(): ThemeName | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const stored = localStorage.getItem(THEME_NAME_KEY);
+    if (stored === 'nyt' || stored === 'brutalism') {
+      return stored;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get the system preferred color scheme
+ */
+export function getSystemPreference(): ThemeMode {
+  if (typeof window === 'undefined') return DEFAULT_THEME_MODE;
+  return window.matchMedia('(prefers-color-scheme: dark)').matches
+    ? 'dark'
+    : 'light';
+}
+
+/**
+ * Store the theme mode in localStorage
+ */
+export function setStoredThemeMode(mode: ThemeMode): void {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(THEME_MODE_KEY, mode);
+  } catch {
+    // Ignore storage errors
+  }
+}
+
+/**
+ * Store the theme name in localStorage
+ */
+export function setStoredThemeName(name: ThemeName): void {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(THEME_NAME_KEY, name);
+  } catch {
+    // Ignore storage errors
+  }
+}
+
+/**
+ * Apply the theme mode to the document
+ */
+export function applyThemeMode(mode: ThemeMode): void {
+  if (typeof document === 'undefined') return;
+  document.documentElement.dataset.mode = mode;
+}
+
+/**
+ * Apply the theme name to the document
+ */
+export function applyThemeName(name: ThemeName): void {
+  if (typeof document === 'undefined') return;
+  document.documentElement.dataset.theme = name;
+}
+
+/**
+ * Get the resolved theme mode (stored > system > default)
+ */
+export function getResolvedThemeMode(): ThemeMode {
+  const stored = getStoredThemeMode();
+  if (stored) return stored;
+  return getSystemPreference();
+}
+
+/**
+ * Get the resolved theme name (stored > default)
+ */
+export function getResolvedThemeName(): ThemeName {
+  const stored = getStoredThemeName();
+  if (stored) return stored;
+  return DEFAULT_THEME_NAME;
+}
+
+/**
+ * Toggle the theme mode between light and dark
+ */
+export function toggleThemeMode(): ThemeMode {
+  const current = getResolvedThemeMode();
+  const next = current === 'light' ? 'dark' : 'light';
+  setStoredThemeMode(next);
+  applyThemeMode(next);
+  return next;
+}

--- a/apps/blog/next.config.js
+++ b/apps/blog/next.config.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   // Transpile workspace packages
@@ -13,6 +15,21 @@ const nextConfig = {
   images: {
     // For static export, images need to be unoptimized
     unoptimized: process.env.NODE_ENV === 'production',
+  },
+
+  // Webpack configuration to resolve @ui/* path alias from @blog/ui package
+  webpack: (config, { isServer }) => {
+    config.resolve.alias['@ui'] = path.resolve(__dirname, '../../packages/ui/src');
+
+    // Externalize problematic modules during SSR
+    if (isServer) {
+      // react-syntax-highlighter has issues with SSR, mark as external
+      config.externals = [...(config.externals || []), {
+        'react-syntax-highlighter': 'react-syntax-highlighter',
+      }];
+    }
+
+    return config;
   },
 };
 

--- a/apps/blog/tsconfig.json
+++ b/apps/blog/tsconfig.json
@@ -3,9 +3,8 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@/*": [
-        "./*"
-      ]
+      "@/*": ["./*"],
+      "@ui/*": ["../../packages/ui/src/*"]
     },
     "plugins": [
       {

--- a/apps/blog/vitest.config.ts
+++ b/apps/blog/vitest.config.ts
@@ -20,6 +20,8 @@ export default defineConfig({
       '@': path.resolve(__dirname, '.'),
       // Mock CSS imports from @blog/tokens
       '@blog/tokens/css': path.resolve(__dirname, './__tests__/mocks/tokens-css.ts'),
+      // Resolve @ui alias for @blog/ui package
+      '@ui': path.resolve(__dirname, '../../packages/ui/src'),
     },
   },
 });

--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -3,8 +3,10 @@ import path from 'path';
 
 const config: StorybookConfig = {
   stories: [
-    // Co-located stories from packages/ui
+    // Co-located stories from packages/ui (Foundations & Components)
     '../../../packages/ui/src/**/*.stories.@(js|jsx|mjs|ts|tsx)',
+    // Co-located stories from apps/blog (Blog components)
+    '../../../apps/blog/components/**/*.stories.@(js|jsx|mjs|ts|tsx)',
     // Local stories
     '../stories/**/*.stories.@(js|jsx|mjs|ts|tsx)',
   ],
@@ -24,9 +26,22 @@ const config: StorybookConfig = {
     if (config.resolve) {
       config.resolve.alias = {
         ...config.resolve.alias,
+        // UI package alias
         '@ui': path.resolve(__dirname, '../../../packages/ui/src'),
+        // Blog app alias (for @/ imports in blog components)
+        '@': path.resolve(__dirname, '../../../apps/blog'),
+        // Mock Next.js modules for Storybook
+        'next/navigation': path.resolve(__dirname, '../mocks/next-navigation.ts'),
+        'next/link': path.resolve(__dirname, '../mocks/next-link.tsx'),
       };
     }
+
+    // Define process.env for Next.js compatibility
+    config.define = {
+      ...config.define,
+      'process.env': {},
+    };
+
     return config;
   },
 };

--- a/apps/storybook/mocks/next-link.tsx
+++ b/apps/storybook/mocks/next-link.tsx
@@ -1,0 +1,25 @@
+/**
+ * Mock for next/link component in Storybook
+ */
+import * as React from 'react';
+
+interface LinkProps {
+  href: string;
+  children: React.ReactNode;
+  className?: string;
+  [key: string]: unknown;
+}
+
+const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
+  ({ href, children, ...props }, ref) => {
+    return (
+      <a ref={ref} href={href} {...props}>
+        {children}
+      </a>
+    );
+  }
+);
+
+Link.displayName = 'Link';
+
+export default Link;

--- a/apps/storybook/mocks/next-navigation.ts
+++ b/apps/storybook/mocks/next-navigation.ts
@@ -1,0 +1,17 @@
+/**
+ * Mock for next/navigation hooks in Storybook
+ */
+
+export const usePathname = () => '/';
+export const useRouter = () => ({
+  push: () => {},
+  replace: () => {},
+  back: () => {},
+  forward: () => {},
+  refresh: () => {},
+  prefetch: () => {},
+});
+export const useSearchParams = () => new URLSearchParams();
+export const useParams = () => ({});
+export const notFound = () => {};
+export const redirect = () => {};

--- a/packages/ui/src/components/Accordion/Accordion.tsx
+++ b/packages/ui/src/components/Accordion/Accordion.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { cn } from '@ui/lib/utils';
 

--- a/packages/ui/src/components/Avatar/Avatar.tsx
+++ b/packages/ui/src/components/Avatar/Avatar.tsx
@@ -92,7 +92,7 @@ const Avatar = React.forwardRef<HTMLDivElement, AvatarProps>(
               'font-medium text-figure-secondary',
               (loading || imageLoading) && 'animate-pulse'
             )}
-            aria-hidden={showImage}
+            aria-hidden={showImage ? 'true' : undefined}
           >
             {children || initials || (
               <svg

--- a/packages/ui/src/components/CodeBlock/CodeBlock.tsx
+++ b/packages/ui/src/components/CodeBlock/CodeBlock.tsx
@@ -1,22 +1,25 @@
+'use client';
+
 import * as React from 'react';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { cn } from '@ui/lib/utils';
 
 // Custom theme based on our design tokens
-const customTheme = {
+// Using 'as const' to make the literal types work with react-syntax-highlighter
+const customTheme: Record<string, React.CSSProperties> = {
   'code[class*="language-"]': {
     color: 'var(--color-text-primary)',
     background: 'none',
     fontFamily: 'var(--font-code)',
     fontSize: '0.875rem',
     lineHeight: '1.75',
-    textAlign: 'left',
-    whiteSpace: 'pre',
+    textAlign: 'left' as const,
+    whiteSpace: 'pre' as const,
     wordSpacing: 'normal',
-    wordBreak: 'normal',
-    wordWrap: 'normal',
+    wordBreak: 'normal' as const,
+    wordWrap: 'normal' as const,
     tabSize: 2,
-    hyphens: 'none',
+    hyphens: 'none' as const,
   },
   'pre[class*="language-"]': {
     color: 'var(--color-text-primary)',
@@ -24,16 +27,16 @@ const customTheme = {
     fontFamily: 'var(--font-code)',
     fontSize: '0.875rem',
     lineHeight: '1.75',
-    textAlign: 'left',
-    whiteSpace: 'pre',
+    textAlign: 'left' as const,
+    whiteSpace: 'pre' as const,
     wordSpacing: 'normal',
-    wordBreak: 'normal',
-    wordWrap: 'normal',
+    wordBreak: 'normal' as const,
+    wordWrap: 'normal' as const,
     tabSize: 2,
-    hyphens: 'none',
+    hyphens: 'none' as const,
     padding: 0,
     margin: 0,
-    overflow: 'auto',
+    overflow: 'auto' as const,
   },
   comment: {
     color: 'var(--color-text-muted)',

--- a/packages/ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/ui/src/components/Dropdown/Dropdown.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@ui/lib/utils';

--- a/packages/ui/src/components/Modal/Modal.tsx
+++ b/packages/ui/src/components/Modal/Modal.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@ui/lib/utils';

--- a/packages/ui/src/components/Separator/Separator.tsx
+++ b/packages/ui/src/components/Separator/Separator.tsx
@@ -93,11 +93,14 @@ const Separator = React.forwardRef<HTMLDivElement, SeparatorProps>(
       );
     }
 
+    // Ensure orientation is not null for aria-orientation
+    const ariaOrientation = orientation === 'horizontal' || orientation === 'vertical' ? orientation : undefined;
+
     return (
       <div
         ref={ref}
         role={decorative ? 'none' : 'separator'}
-        aria-orientation={decorative ? undefined : orientation}
+        aria-orientation={decorative ? undefined : ariaOrientation}
         className={cn(separatorVariants({ orientation, variant, spacing, className }))}
         {...props}
       />

--- a/packages/ui/src/components/Tabs/Tabs.tsx
+++ b/packages/ui/src/components/Tabs/Tabs.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@ui/lib/utils';

--- a/packages/ui/src/components/Toast/Toast.tsx
+++ b/packages/ui/src/components/Toast/Toast.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@ui/lib/utils';

--- a/packages/ui/src/components/Tooltip/Tooltip.tsx
+++ b/packages/ui/src/components/Tooltip/Tooltip.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@ui/lib/utils';

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 // Components
 export { Button, buttonVariants, type ButtonProps } from '@ui/components/Button';
 export {

--- a/plan/ARCHITECTURE.md
+++ b/plan/ARCHITECTURE.md
@@ -218,9 +218,11 @@ Primitives (raw values)  →  Semantic (meaning)  →  Themes (variations)
 - [x] Phase 2: Token Architecture
 - [x] Phase 3: UI Package (22+ components)
 - [x] Phase 4: Blog App Foundation
+- [x] Phase 5A: Site Layout Components (SiteHeader, SiteFooter, SiteNav)
+- [x] Phase 5B: Theme System (ThemeProvider, ThemeToggle, lib/theme.ts)
+- [x] Storybook integration for blog components (with Playwright tests)
 
 ### Current
-- [ ] Phase 5: Layout & Theme
 - [ ] Phase 6: Essay Core
 
 ### Future

--- a/plan/IMPLEMENTATION_PLAN.md
+++ b/plan/IMPLEMENTATION_PLAN.md
@@ -14,7 +14,7 @@ This document outlines the step-by-step implementation plan for rebuilding the b
 |-------|-------|--------------|--------------|--------------|
 | 1-3 | Foundation | ✅ Complete | ✅ Complete | - |
 | 4 | Blog App Foundation | ✅ Complete | ✅ Complete | Phase 3 |
-| **5** | Layout & Theme | Site layout | Theme system | Phase 4 |
+| 5 | Layout & Theme | ✅ Complete | ✅ Complete | Phase 4 |
 | **6** | Essay Core | Essay page & layout | Content components | Phase 5 |
 | **7** | Essay Index & Home | List & filters | Home page | Phase 6 |
 | **8** | About & Polish | About page | Mobile & a11y | Phase 7 |
@@ -111,57 +111,65 @@ apps/blog/
 
 ---
 
-## Phase 5: Layout & Theme
+## Phase 5: Layout & Theme ✅
 
 **Goal:** Site header, footer, navigation, and theme switching.
 
-### Workstream 5A: Site Layout Components
+### Workstream 5A: Site Layout Components ✅
 
-**Files to create:**
+**Files created:**
 ```
 apps/blog/components/
 └── layout/
     ├── SiteHeader.tsx
+    ├── SiteHeader.stories.tsx
     ├── SiteFooter.tsx
+    ├── SiteFooter.stories.tsx
     ├── SiteNav.tsx
+    ├── SiteNav.stories.tsx
     └── index.ts
 ```
 
 **Tasks:**
-- [ ] Create `SiteHeader` with:
+- [x] Create `SiteHeader` with:
   - Logo/site name (link to home)
   - Navigation slot
   - Actions slot (for theme toggle)
-- [ ] Create `SiteNav` with links: Essays, About
-- [ ] Create `SiteFooter` with copyright, optional social links
-- [ ] Update `app/layout.tsx` to use layout components
-- [ ] Basic responsive styles (mobile hamburger deferred to Phase 8)
+- [x] Create `SiteNav` with links: Essays, About
+- [x] Create `SiteFooter` with copyright, optional social links
+- [x] Update `app/layout.tsx` to use layout components
+- [x] Basic responsive styles (mobile hamburger deferred to Phase 8)
+- [x] Add Storybook stories for all layout components
+- [x] Add Playwright tests for blog component stories (8 tests)
 
-**Uses from @blog/ui:** Button, Separator
+**Uses from @blog/ui:** Button, Separator, cn utility
 
-### Workstream 5B: Theme System
+### Workstream 5B: Theme System ✅
 
-**Files to create:**
+**Files created:**
 ```
 apps/blog/
 ├── components/
 │   └── layout/
 │       ├── ThemeToggle.tsx
+│       ├── ThemeToggle.stories.tsx
 │       └── ThemeProvider.tsx
-└── lib/
-    └── theme.ts
+├── lib/
+│   └── theme.ts
+└── __tests__/
+    └── theme.test.ts
 ```
 
 **Tasks:**
-- [ ] Create `ThemeProvider` context:
+- [x] Create `ThemeProvider` context:
   - Read system preference
   - Read localStorage preference
   - Provide toggle function
   - Set `data-mode` on `<html>`
-- [ ] Create `ThemeToggle` component (sun/moon icon button)
-- [ ] Create `lib/theme.ts` with helpers
-- [ ] Integrate into `SiteHeader`
-- [ ] Handle SSR (avoid hydration mismatch with suppressHydrationWarning or script)
+- [x] Create `ThemeToggle` component (sun/moon icon button)
+- [x] Create `lib/theme.ts` with helpers
+- [x] Integrate into `SiteHeader`
+- [x] Handle SSR (avoid hydration mismatch with suppressHydrationWarning or script)
 
 **Uses from @blog/ui:** Button, Tooltip
 
@@ -507,11 +515,15 @@ Phase 4 (Complete)
 - [x] `getAllEssays()` returns data
 - [x] TypeScript types enforce schema
 
-### Phase 5
-- [ ] Header/footer render on all pages
-- [ ] Navigation links work
-- [ ] Theme toggle persists preference
-- [ ] No hydration errors
+### Phase 5 ✅ (Complete)
+- [x] Header/footer render on all pages
+- [x] Navigation links work
+- [x] Theme toggle persists preference
+- [x] No hydration errors
+- [x] Unit tests pass (22 theme tests)
+- [x] Storybook stories for all layout components (Blog / Layout / *)
+- [x] Playwright tests pass (32 total: 8 foundations + 16 brutalism + 8 blog)
+- [x] Next.js mocks configured for Storybook (next/navigation, next/link)
 
 ### Phase 6
 - [ ] Essay page renders MDX content

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -59,6 +59,13 @@ export default defineConfig({
       use: { ...devices['Desktop Chrome'] },
     },
 
+    // Blog components tests
+    {
+      name: 'blog',
+      testDir: './tests/blog',
+      use: { ...devices['Desktop Chrome'] },
+    },
+
     // Cross-browser testing (run selectively)
     {
       name: 'webkit',

--- a/tests/blog/layout-components.spec.ts
+++ b/tests/blog/layout-components.spec.ts
@@ -1,0 +1,137 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Blog Layout Components Tests
+ *
+ * Verifies that blog-specific layout components render correctly in Storybook.
+ */
+
+test.describe('Blog: Layout Components', () => {
+  test.describe('SiteHeader', () => {
+    test('default story renders correctly', async ({ page }) => {
+      await page.goto(
+        '/iframe.html?id=blog-layout-siteheader--default&viewMode=story'
+      );
+
+      // Verify header renders
+      const header = page.locator('header');
+      await expect(header).toBeVisible();
+
+      // Verify site name link is displayed (the first "Essays" is the site name link)
+      const siteNameLink = page.locator('header a[href="/"]');
+      await expect(siteNameLink).toBeVisible();
+      await expect(siteNameLink).toContainText('Essays');
+    });
+
+    test('with theme toggle renders correctly', async ({ page }) => {
+      await page.goto(
+        '/iframe.html?id=blog-layout-siteheader--with-theme-toggle&viewMode=story'
+      );
+
+      // Verify header renders
+      const header = page.locator('header');
+      await expect(header).toBeVisible();
+
+      // Verify theme toggle button exists (look for aria-label containing "mode")
+      const themeToggle = page.locator(
+        'button[aria-label*="mode"], button[aria-label="Toggle theme"]'
+      );
+      await expect(themeToggle.first()).toBeVisible();
+    });
+  });
+
+  test.describe('SiteFooter', () => {
+    test('default story renders correctly', async ({ page }) => {
+      await page.goto(
+        '/iframe.html?id=blog-layout-sitefooter--default&viewMode=story'
+      );
+
+      // Verify footer renders
+      const footer = page.locator('footer');
+      await expect(footer).toBeVisible();
+    });
+
+    test('with social links renders icons', async ({ page }) => {
+      await page.goto(
+        '/iframe.html?id=blog-layout-sitefooter--with-social-links&viewMode=story'
+      );
+
+      // Verify footer renders
+      const footer = page.locator('footer');
+      await expect(footer).toBeVisible();
+
+      // Verify social links are present (SVG icons)
+      const socialIcons = footer.locator('svg');
+      await expect(socialIcons).toHaveCount(3); // GitHub, Twitter, LinkedIn
+    });
+  });
+
+  test.describe('SiteNav', () => {
+    test('default story renders correctly', async ({ page }) => {
+      await page.goto(
+        '/iframe.html?id=blog-layout-sitenav--default&viewMode=story'
+      );
+
+      // Verify nav renders
+      const nav = page.locator('nav');
+      await expect(nav).toBeVisible();
+    });
+
+    test('custom links story shows all links', async ({ page }) => {
+      await page.goto(
+        '/iframe.html?id=blog-layout-sitenav--custom-links&viewMode=story'
+      );
+
+      // Verify nav renders
+      const nav = page.locator('nav');
+      await expect(nav).toBeVisible();
+
+      // Verify custom links are present
+      await expect(page.locator('text=Blog')).toBeVisible();
+      await expect(page.locator('text=Projects')).toBeVisible();
+      await expect(page.locator('text=About')).toBeVisible();
+      await expect(page.locator('text=Contact')).toBeVisible();
+    });
+  });
+
+  test.describe('ThemeToggle', () => {
+    test('default story renders correctly', async ({ page }) => {
+      await page.goto(
+        '/iframe.html?id=blog-layout-themetoggle--default&viewMode=story'
+      );
+
+      // Wait for the component to mount (ThemeToggle has a mounting state)
+      await page.waitForTimeout(500);
+
+      // Verify toggle button renders - look for the theme toggle by aria-label
+      const button = page.locator(
+        'button[aria-label*="mode"], button[aria-label="Toggle theme"]'
+      );
+      await expect(button.first()).toBeVisible();
+
+      // Verify it has an icon
+      const icon = button.first().locator('svg');
+      await expect(icon).toBeVisible();
+    });
+
+    test('toggle changes theme', async ({ page }) => {
+      await page.goto(
+        '/iframe.html?id=blog-layout-themetoggle--default&viewMode=story'
+      );
+
+      // Wait for the component to mount
+      await page.waitForTimeout(500);
+
+      const button = page.locator(
+        'button[aria-label*="mode"], button[aria-label="Toggle theme"]'
+      );
+      await expect(button.first()).toBeVisible();
+
+      // Click to toggle theme
+      await button.first().click();
+
+      // The button should still be visible after toggle (we're testing it doesn't crash)
+      await expect(button.first()).toBeVisible();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Implements Phase 5 of the blog redesign: Layout & Theme system
- Adds site layout components (SiteHeader, SiteFooter, SiteNav) with Storybook stories
- Adds theme system with ThemeProvider context, ThemeToggle component, and theme utilities
- Configures Storybook to support blog components with Next.js mocks
- Adds 8 Playwright tests for blog component stories

## Changes

### Phase 5A: Site Layout Components
- `SiteHeader` - Logo/site name, navigation slot, actions slot for theme toggle
- `SiteFooter` - Copyright, optional social links (GitHub, Twitter, LinkedIn)
- `SiteNav` - Navigation links with active state highlighting using `usePathname`
- Updated `app/layout.tsx` to integrate all layout components

### Phase 5B: Theme System
- `ThemeProvider` - React context for theme mode (light/dark)
  - Reads system preference via `matchMedia`
  - Persists to localStorage
  - Sets `data-mode` attribute on `<html>`
  - SSR-safe with `useThemeMounted` hook
- `ThemeToggle` - Button with sun/moon icons, wrapped in Tooltip
- `lib/theme.ts` - Utility functions for theme management

### Storybook Integration
- Extended `main.ts` to include blog component stories
- Added Next.js mocks (`next/navigation`, `next/link`) for Storybook compatibility
- All stories use "Blog / Layout / *" naming convention

### TypeScript Fixes
- Fixed `aria-hidden` type error in Avatar.tsx
- Fixed CSS property type errors in CodeBlock.tsx (added `as const` assertions)
- Fixed `aria-orientation` type error in Separator.tsx
- Added `'use client'` directive to UI package index

## Test Plan

- [x] Unit tests pass (22 theme tests in `apps/blog/__tests__/theme.test.ts`)
- [x] Storybook builds successfully
- [x] All 32 Playwright tests pass:
  - 8 foundations tests
  - 16 brutalism theme tests
  - 8 blog component tests (new)
- [x] Theme toggle persists preference across page reloads
- [x] No hydration errors in browser console
- [x] Layout renders correctly at all breakpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)