### PR TITLE
feat(blog): Implement Phase 10 static export for GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,56 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build
+        run: pnpm build
+
+      - name: Add .nojekyll
+        run: touch apps/blog/out/.nojekyll
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: apps/blog/out
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,16 +6,14 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 concurrency:
   group: "pages"
   cancel-in-progress: false
 
 jobs:
-  build:
+  build-and-deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -36,21 +34,17 @@ jobs:
       - name: Build
         run: pnpm build
 
-      - name: Add .nojekyll
-        run: touch apps/blog/out/.nojekyll
+      - name: Prepare docs folder
+        run: |
+          rm -rf docs
+          cp -r apps/blog/out docs
+          touch docs/.nojekyll
+          echo "www.feitong.phd" > docs/CNAME
 
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: apps/blog/out
-
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+      - name: Commit and push to docs
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add docs
+          git diff --staged --quiet || git commit -m "chore: Update docs folder from build"
+          git push

--- a/apps/blog/app/essays/page.tsx
+++ b/apps/blog/app/essays/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next';
-import { EssaysIndexPage, parseTypeParam, parseTopicsParam } from '@/components/pages';
+import { EssaysIndexPage } from '@/components/pages';
 
 export const metadata: Metadata = {
   title: 'Essays',
@@ -13,20 +13,6 @@ export const metadata: Metadata = {
   },
 };
 
-interface EssaysPageProps {
-  searchParams: Promise<{ type?: string; topics?: string }>;
-}
-
-export default async function EssaysPage({ searchParams }: EssaysPageProps) {
-  const params = await searchParams;
-  const selectedType = parseTypeParam(params.type);
-  const selectedTopics = parseTopicsParam(params.topics);
-
-  return (
-    <EssaysIndexPage
-      language="en"
-      selectedType={selectedType}
-      selectedTopics={selectedTopics}
-    />
-  );
+export default function EssaysPage() {
+  return <EssaysIndexPage language="en" />;
 }

--- a/apps/blog/app/zh/essays/page.tsx
+++ b/apps/blog/app/zh/essays/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next';
-import { EssaysIndexPage, parseTypeParam, parseTopicsParam } from '@/components/pages';
+import { EssaysIndexPage } from '@/components/pages';
 
 export const metadata: Metadata = {
   title: '文章',
@@ -12,20 +12,6 @@ export const metadata: Metadata = {
   },
 };
 
-interface ZhEssaysPageProps {
-  searchParams: Promise<{ type?: string; topics?: string }>;
-}
-
-export default async function ZhEssaysPage({ searchParams }: ZhEssaysPageProps) {
-  const params = await searchParams;
-  const selectedType = parseTypeParam(params.type);
-  const selectedTopics = parseTopicsParam(params.topics);
-
-  return (
-    <EssaysIndexPage
-      language="zh"
-      selectedType={selectedType}
-      selectedTopics={selectedTopics}
-    />
-  );
+export default function ZhEssaysPage() {
+  return <EssaysIndexPage language="zh" />;
 }

--- a/apps/blog/components/pages/EssaysIndexPage.tsx
+++ b/apps/blog/components/pages/EssaysIndexPage.tsx
@@ -1,35 +1,10 @@
-import { Suspense } from 'react';
 import { getAllEssays } from '@/lib/essays';
-import { ESSAY_TYPES, TOPICS } from '@/lib/constants';
-import { EssayFilters, EssayFiltersSkeleton, EssayList } from '@/components/essay';
-import { translate, formatResultsCount, type Language } from '@/lib/i18n';
-import type { EssayType, Topic } from '@/types/content';
+import { translate, type Language } from '@/lib/i18n';
+import { EssaysPageContent } from './EssaysPageContent';
 
 export interface EssaysIndexPageProps {
   /** Language for the page content */
   language?: Language;
-  /** Selected type filter from URL params */
-  selectedType?: EssayType | null;
-  /** Selected topics filter from URL params */
-  selectedTopics?: Topic[];
-}
-
-/**
- * Parse and validate type parameter
- */
-export function parseTypeParam(type?: string): EssayType | null {
-  if (!type) return null;
-  return ESSAY_TYPES.includes(type as EssayType) ? (type as EssayType) : null;
-}
-
-/**
- * Parse and validate topics parameter
- */
-export function parseTopicsParam(topics?: string): Topic[] {
-  if (!topics) return [];
-  return topics
-    .split(',')
-    .filter((t): t is Topic => TOPICS.includes(t as Topic));
 }
 
 /**
@@ -37,40 +12,20 @@ export function parseTopicsParam(topics?: string): Topic[] {
  *
  * Displays all essays with type and topic filters.
  * Used by both `/essays` (English) and `/zh/essays` (Chinese) routes.
+ *
+ * This is a server component that fetches all essays at build time
+ * and delegates filtering to the client-side EssaysPageContent component.
  */
-export function EssaysIndexPage({
-  language = 'en',
-  selectedType = null,
-  selectedTopics = [],
-}: EssaysIndexPageProps) {
+export function EssaysIndexPage({ language = 'en' }: EssaysIndexPageProps) {
   const basePath = language === 'zh' ? '/zh/essays' : '/essays';
   const t = (key: Parameters<typeof translate>[1]) => translate(language, key);
 
-  // Get all essays for this language (exclude drafts)
+  // Get all essays for this language at build time
   const allEssays = getAllEssays({ language, includeDrafts: false });
-
-  // Filter essays based on selected filters
-  let filteredEssays = allEssays;
-
-  if (selectedType) {
-    filteredEssays = filteredEssays.filter(
-      (essay) => essay.type === selectedType
-    );
-  }
-
-  if (selectedTopics.length > 0) {
-    filteredEssays = filteredEssays.filter((essay) =>
-      selectedTopics.some((topic) => essay.topics.includes(topic))
-    );
-  }
-
-  const hasActiveFilters = selectedType !== null || selectedTopics.length > 0;
-  const resultsText = formatResultsCount(language, filteredEssays.length);
-  const matchingText = t('essays.matchingFilters');
 
   return (
     <main className="mx-auto max-w-5xl px-inset-lg py-12">
-      {/* Page header */}
+      {/* Page header - static content */}
       <header className="mb-8">
         <h1 className="text-display font-serif text-figure-primary mb-2">
           {t('nav.essays')}
@@ -80,29 +35,11 @@ export function EssaysIndexPage({
         </p>
       </header>
 
-      {/* Filters */}
-      <Suspense fallback={<EssayFiltersSkeleton className="mb-8" />}>
-        <EssayFilters
-          selectedType={selectedType}
-          selectedTopics={selectedTopics}
-          className="mb-8"
-          language={language}
-        />
-      </Suspense>
-
-      {/* Results count */}
-      <div className="mb-6 text-body-sm text-figure-muted">
-        {resultsText}
-        {hasActiveFilters && <span> {matchingText}</span>}
-      </div>
-
-      {/* Essay list */}
-      <EssayList
-        essays={filteredEssays}
-        layout="list"
-        emptyMessage={t('essays.emptyFiltered')}
-        basePath={basePath}
+      {/* Client-side filtering */}
+      <EssaysPageContent
+        essays={allEssays}
         language={language}
+        basePath={basePath}
       />
     </main>
   );

--- a/apps/blog/components/pages/EssaysPageContent.tsx
+++ b/apps/blog/components/pages/EssaysPageContent.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { Suspense, useMemo } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { EssayFilters, EssayFiltersSkeleton, EssayList } from '@/components/essay';
+import { ESSAY_TYPES, TOPICS } from '@/lib/constants';
+import { formatResultsCount, translate, type Language } from '@/lib/i18n';
+import type { EssayMeta, EssayType, Topic } from '@/types/content';
+
+/**
+ * Parse and validate type parameter
+ */
+function parseTypeParam(type: string | null): EssayType | null {
+  if (!type) return null;
+  return ESSAY_TYPES.includes(type as EssayType) ? (type as EssayType) : null;
+}
+
+/**
+ * Parse and validate topics parameter
+ */
+function parseTopicsParam(topics: string | null): Topic[] {
+  if (!topics) return [];
+  return topics
+    .split(',')
+    .filter((t): t is Topic => TOPICS.includes(t as Topic));
+}
+
+export interface EssaysPageContentProps {
+  /** All essays to filter from */
+  essays: EssayMeta[];
+  /** Language for localization */
+  language: Language;
+  /** Base path for essay links */
+  basePath: string;
+}
+
+/**
+ * Inner component that reads URL params and filters essays
+ */
+function EssaysContentInner({ essays, language, basePath }: EssaysPageContentProps) {
+  const searchParams = useSearchParams();
+  const t = (key: Parameters<typeof translate>[1]) => translate(language, key);
+
+  // Parse filter state from URL
+  const selectedType = parseTypeParam(searchParams.get('type'));
+  const selectedTopics = parseTopicsParam(searchParams.get('topics'));
+
+  // Filter essays based on URL params
+  const filteredEssays = useMemo(() => {
+    let result = essays;
+
+    if (selectedType) {
+      result = result.filter((essay) => essay.type === selectedType);
+    }
+
+    if (selectedTopics.length > 0) {
+      result = result.filter((essay) =>
+        selectedTopics.some((topic) => essay.topics.includes(topic))
+      );
+    }
+
+    return result;
+  }, [essays, selectedType, selectedTopics]);
+
+  const hasActiveFilters = selectedType !== null || selectedTopics.length > 0;
+  const resultsText = formatResultsCount(language, filteredEssays.length);
+  const matchingText = t('essays.matchingFilters');
+
+  return (
+    <>
+      <EssayFilters
+        selectedType={selectedType}
+        selectedTopics={selectedTopics}
+        className="mb-8"
+        language={language}
+      />
+
+      <div className="mb-6 text-body-sm text-figure-muted">
+        {resultsText}
+        {hasActiveFilters && <span> {matchingText}</span>}
+      </div>
+
+      <EssayList
+        essays={filteredEssays}
+        layout="list"
+        emptyMessage={t('essays.emptyFiltered')}
+        basePath={basePath}
+        language={language}
+      />
+    </>
+  );
+}
+
+/**
+ * Loading skeleton shown while useSearchParams hydrates
+ */
+function EssaysLoadingSkeleton() {
+  return (
+    <div className="space-y-4">
+      <EssayFiltersSkeleton className="mb-8" />
+      <div className="mb-6">
+        <div className="h-4 w-24 bg-ground-secondary rounded animate-pulse" />
+      </div>
+      <div className="space-y-4">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="h-32 bg-ground-secondary rounded-lg animate-pulse" />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Client component for essays page content with filtering
+ *
+ * Wraps the content in Suspense to handle useSearchParams during SSR/static export.
+ * This is required because useSearchParams() needs client-side hydration.
+ */
+export function EssaysPageContent(props: EssaysPageContentProps) {
+  return (
+    <Suspense fallback={<EssaysLoadingSkeleton />}>
+      <EssaysContentInner {...props} />
+    </Suspense>
+  );
+}

--- a/apps/blog/components/pages/index.ts
+++ b/apps/blog/components/pages/index.ts
@@ -1,8 +1,11 @@
 export { HomePage } from './HomePage';
 export type { HomePageProps } from './HomePage';
 
-export { EssaysIndexPage, parseTypeParam, parseTopicsParam } from './EssaysIndexPage';
+export { EssaysIndexPage } from './EssaysIndexPage';
 export type { EssaysIndexPageProps } from './EssaysIndexPage';
+
+export { EssaysPageContent } from './EssaysPageContent';
+export type { EssaysPageContentProps } from './EssaysPageContent';
 
 export { AboutPage } from './AboutPage';
 export type { AboutPageProps } from './AboutPage';

--- a/apps/blog/next.config.js
+++ b/apps/blog/next.config.js
@@ -2,6 +2,15 @@ const path = require('path');
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  // Enable static export for GitHub Pages
+  output: 'export',
+
+  // Output directory for static files
+  distDir: 'out',
+
+  // Add trailing slashes for GitHub Pages compatibility
+  trailingSlash: true,
+
   // Transpile workspace packages
   transpilePackages: ['@blog/ui', '@blog/tokens'],
 
@@ -13,8 +22,8 @@ const nextConfig = {
 
   // Image optimization configuration
   images: {
-    // For static export, images need to be unoptimized
-    unoptimized: process.env.NODE_ENV === 'production',
+    // Static export requires unoptimized images
+    unoptimized: true,
   },
 
   // Webpack configuration to resolve @ui/* path alias from @blog/ui package

--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -9,7 +9,8 @@
     "lint": "next lint",
     "test": "vitest",
     "test:run": "vitest run",
-    "clean": "rm -rf .next out"
+    "clean": "rm -rf .next out",
+    "serve:static": "npx serve out"
   },
   "dependencies": {
     "@blog/tokens": "workspace:*",

--- a/plan/STATIC_EXPORT.md
+++ b/plan/STATIC_EXPORT.md
@@ -10,363 +10,235 @@ This document outlines the plan to convert the blog to a fully static-generated 
 
 ## Current State
 
-| Route | Status | Issue |
-|-------|--------|-------|
-| `/` | ○ Static | None |
-| `/essays/[slug]` | ● SSG | None (has `generateStaticParams`) |
-| `/essays` | ƒ Dynamic | Uses `searchParams` prop |
+Build output shows:
 
-The `/essays` page is dynamic because it reads URL search params on the server. This blocks static export.
+```
+Route (app)                              Size     First Load JS
+┌ ○ /                                    144 B           360 kB
+├ ○ /_not-found                          871 B          88.2 kB
+├ ○ /about                               145 B           360 kB
+├ ƒ /essays                              144 B           360 kB    ← PROBLEM
+├ ● /essays/[slug]                       145 B           352 kB
+├ ○ /zh                                  145 B           360 kB
+├ ○ /zh/about                            144 B           360 kB
+├ ƒ /zh/essays                           145 B           360 kB    ← PROBLEM
+└ ● /zh/essays/[slug]                    145 B           352 kB
 
-### Current Architecture Analysis
+○  (Static)   prerendered as static content
+●  (SSG)      prerendered as static HTML (uses getStaticProps)
+ƒ  (Dynamic)  server-rendered on demand
+```
 
-**`/essays/page.tsx`:**
-- Server component that accepts `searchParams: Promise<{ type?: string; topics?: string }>`
-- Awaits params and filters essays server-side
-- Wraps `EssayFilters` in Suspense with `EssayFiltersSkeleton` fallback
+**Problem:** `/essays` and `/zh/essays` are dynamic because they use `searchParams` prop in the page component.
 
-**`EssayFilters` component:**
-- Already a client component (`'use client'`)
-- Already uses `useSearchParams()` internally for URL state management
-- Accepts `selectedType` and `selectedTopics` props for initial/current state
-- Handles URL updates via `router.push()`
+### Root Cause
 
-**Key insight:** `EssayFilters` already handles client-side URL state. The server component just needs to stop reading `searchParams` and delegate filtering to the client.
+Both essay index pages (`app/essays/page.tsx` and `app/zh/essays/page.tsx`) accept `searchParams` as a prop:
+
+```tsx
+interface EssaysPageProps {
+  searchParams: Promise<{ type?: string; topics?: string }>;
+}
+
+export default async function EssaysPage({ searchParams }: EssaysPageProps) {
+  const params = await searchParams;
+  // ... uses params for server-side filtering
+}
+```
+
+This forces Next.js to render these pages dynamically since `searchParams` is only known at request time.
 
 ---
 
 ## Solution: Client-Side Filtering
 
-Move filtering logic from server to client. The page fetches all essays at build time; filtering happens in the browser.
+Move filter state management entirely to the client. The server renders all essays; the client handles URL params and filtering.
+
+### Key Insight
+
+`EssayFilters` is already a client component that:
+- Uses `useSearchParams()` to read URL state
+- Uses `router.push()` to update URL
+- Has all necessary data attributes for testing (`data-type`, `data-topic`, `data-selected`)
+
+The filtering logic in `EssaysIndexPage` just needs to move to a client component wrapper.
 
 ### Architecture
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
 │ /essays/page.tsx (Server Component)                         │
+│ - Exports metadata only                                     │
+│ - Renders EssaysIndexPage with language prop                │
+│ - NO searchParams                                           │
+└─────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│ EssaysIndexPage (Server Component)                          │
 │ - Fetches ALL essays at build time                          │
 │ - Passes data to client component                           │
-│ - No searchParams access                                    │
-│ - No Suspense wrapper (moved to client)                     │
+│ - NO filtering (moved to client)                            │
 └─────────────────────────────────────────────────────────────┘
                               │
                               ▼
 ┌─────────────────────────────────────────────────────────────┐
-│ EssaysPageClient.tsx (Client Component)                     │
+│ EssaysPageContent (New Client Component)                    │
 │ - Reads URL via useSearchParams()                           │
 │ - Filters essays in useMemo                                 │
-│ - Passes state to EssayFilters (for consistency)            │
-│ - Wrapped in Suspense boundary                              │
-└─────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────┐
-│ EssayFilters + EssayList (existing components)              │
-│ - EssayFilters: receives props, manages URL updates         │
-│ - EssayList: pure presentation                              │
+│ - Renders EssayFilters + EssayList                          │
+│ - Wrapped in Suspense for SSR compatibility                 │
 └─────────────────────────────────────────────────────────────┘
 ```
-
-### Benefits
-
-- Full static export compatibility
-- Instant client-side filtering (no server round-trip)
-- URL state preserved (shareable filter links)
-- Progressive enhancement friendly
 
 ---
 
 ## Implementation Tasks
 
-### Task 1: Create Client Component for Essays Page
+### Task 1: Create Client Component for Essay Filtering
 
-**File:** `apps/blog/app/essays/EssaysPageClient.tsx`
+**File:** `apps/blog/components/pages/EssaysPageContent.tsx`
 
-```tsx
-'use client';
+Create a client component that:
+1. Accepts all essays as props
+2. Reads filter state from URL via `useSearchParams()`
+3. Filters essays client-side
+4. Renders `EssayFilters` and `EssayList`
 
-import { useSearchParams } from 'next/navigation';
-import { useMemo, Suspense } from 'react';
-import { EssayFilters, EssayFiltersSkeleton, EssayList } from '@/components/essay';
-import { ESSAY_TYPES, TOPICS } from '@/lib/constants';
-import type { EssayMeta, EssayType, Topic } from '@/types/content';
+Key considerations:
+- Wrap `useSearchParams()` usage in Suspense boundary (required for static export)
+- Reuse existing `EssayFiltersSkeleton` for loading state
+- Import validation helpers from existing code (`ESSAY_TYPES`, `TOPICS`)
 
-/**
- * Parse and validate type parameter
- */
-function parseTypeParam(type: string | null): EssayType | null {
-  if (!type) return null;
-  return ESSAY_TYPES.includes(type as EssayType) ? (type as EssayType) : null;
-}
+### Task 2: Update EssaysIndexPage
 
-/**
- * Parse and validate topics parameter
- */
-function parseTopicsParam(topics: string | null): Topic[] {
-  if (!topics) return [];
-  return topics
-    .split(',')
-    .filter((t): t is Topic => TOPICS.includes(t as Topic));
-}
+**File:** `apps/blog/components/pages/EssaysIndexPage.tsx`
 
-/**
- * Inner component that uses useSearchParams
- * Separated to allow Suspense boundary around useSearchParams usage
- */
-function EssaysContent({ essays }: { essays: EssayMeta[] }) {
-  const searchParams = useSearchParams();
+Changes:
+- Remove `selectedType` and `selectedTopics` props
+- Remove server-side filtering logic
+- Pass all essays to new client component
+- Keep page header (static content)
 
-  const selectedType = parseTypeParam(searchParams.get('type'));
-  const selectedTopics = parseTopicsParam(searchParams.get('topics'));
+### Task 3: Simplify Page Components
 
-  const filteredEssays = useMemo(() => {
-    let result = essays;
+**Files:**
+- `apps/blog/app/essays/page.tsx`
+- `apps/blog/app/zh/essays/page.tsx`
 
-    if (selectedType) {
-      result = result.filter((essay) => essay.type === selectedType);
-    }
+Changes:
+- Remove `searchParams` prop from both pages
+- Simplify to just render `EssaysIndexPage` with language
 
-    if (selectedTopics.length > 0) {
-      result = result.filter((essay) =>
-        selectedTopics.some((topic) => essay.topics.includes(topic))
-      );
-    }
-
-    return result;
-  }, [essays, selectedType, selectedTopics]);
-
-  return (
-    <>
-      <EssayFilters
-        selectedType={selectedType}
-        selectedTopics={selectedTopics}
-        className="mb-8"
-      />
-
-      <div className="mb-6 text-body-sm text-figure-muted">
-        {filteredEssays.length} {filteredEssays.length === 1 ? 'essay' : 'essays'}
-        {(selectedType || selectedTopics.length > 0) && <span> matching filters</span>}
-      </div>
-
-      <EssayList
-        essays={filteredEssays}
-        layout="list"
-        emptyMessage="No essays match the selected filters. Try adjusting your filters."
-      />
-    </>
-  );
-}
-
-/**
- * Loading skeleton for Suspense fallback
- * Reuses existing EssayFiltersSkeleton and adds list skeleton
- */
-function EssaysLoadingSkeleton() {
-  return (
-    <div className="space-y-4">
-      {/* Filter skeleton - reuse existing component */}
-      <EssayFiltersSkeleton className="mb-8" />
-
-      {/* Results count skeleton */}
-      <div className="mb-6">
-        <div className="h-4 w-24 bg-ground-secondary rounded animate-pulse" />
-      </div>
-
-      {/* List skeleton */}
-      <div className="space-y-4">
-        {[1, 2, 3].map((i) => (
-          <div key={i} className="h-32 bg-ground-secondary rounded-lg animate-pulse" />
-        ))}
-      </div>
-    </div>
-  );
-}
-
-/**
- * Exported client component with Suspense boundary
- *
- * useSearchParams() requires a Suspense boundary in static export mode
- * to handle the initial client-side hydration.
- */
-export interface EssaysPageClientProps {
-  essays: EssayMeta[];
-}
-
-export function EssaysPageClient({ essays }: EssaysPageClientProps) {
-  return (
-    <Suspense fallback={<EssaysLoadingSkeleton />}>
-      <EssaysContent essays={essays} />
-    </Suspense>
-  );
-}
-```
-
-**Note:** This reuses the existing `EssayFiltersSkeleton` component and imports constants from `@/lib/constants` instead of hardcoding valid types/topics.
-
-### Task 2: Update Essays Page (Server Component)
-
-**File:** `apps/blog/app/essays/page.tsx`
-
-```tsx
-import type { Metadata } from 'next';
-import { getAllEssays } from '@/lib/essays';
-import { EssaysPageClient } from './EssaysPageClient';
-
-export const metadata: Metadata = {
-  title: 'Essays',
-  description: 'Essays on technology, AI, product thinking, and career development.',
-};
-
-/**
- * Essays index page - displays all essays with client-side filtering
- *
- * This is a static page. All essays are fetched at build time and passed
- * to a client component that handles filtering based on URL params.
- *
- * Changes from previous implementation:
- * - Removed searchParams prop (was making page dynamic)
- * - Removed server-side filtering (now handled client-side)
- * - Removed Suspense wrapper (now in EssaysPageClient)
- */
-export default function EssaysPage() {
-  // Fetch all essays at build time
-  const allEssays = getAllEssays();
-
-  return (
-    <main className="mx-auto max-w-5xl px-inset-lg py-12">
-      <header className="mb-8">
-        <h1 className="text-display font-serif text-figure-primary mb-2">
-          Essays
-        </h1>
-        <p className="text-body-lg text-figure-secondary">
-          Thoughts on technology, AI, product thinking, and career development.
-        </p>
-      </header>
-
-      <EssaysPageClient essays={allEssays} />
-    </main>
-  );
-}
-```
-
-**Key changes from current implementation:**
-- Removed `searchParams` from props interface
-- Removed `parseTypeParam()` and `parseTopicsParam()` (moved to client)
-- Removed server-side filtering logic
-- Removed `Suspense` wrapper around `EssayFilters` (now in client component)
-- Removed `EssayFiltersSkeleton` import (now in client component)
-
-### Task 3: Update Next.js Config for Static Export
+### Task 4: Update Next.js Config
 
 **File:** `apps/blog/next.config.js`
 
+Add static export configuration:
+
 ```js
-const path = require('path');
-
-/** @type {import('next').NextConfig} */
 const nextConfig = {
-  // Enable static export
   output: 'export',
-
-  // Output directory (use 'docs' for GitHub Pages, or 'out' for other hosts)
   distDir: 'out',
-
-  // Add trailing slashes for static file compatibility
   trailingSlash: true,
-
-  // Transpile workspace packages
-  transpilePackages: ['@blog/ui', '@blog/tokens'],
-
-  reactStrictMode: true,
-  poweredByHeader: false,
-
-  // Images must be unoptimized for static export (unconditionally)
   images: {
-    unoptimized: true,
+    unoptimized: true,  // Always true for static export
   },
-
-  webpack: (config, { isServer }) => {
-    config.resolve.alias['@ui'] = path.resolve(__dirname, '../../packages/ui/src');
-
-    if (isServer) {
-      config.externals = [...(config.externals || []), {
-        'react-syntax-highlighter': 'react-syntax-highlighter',
-      }];
-    }
-
-    return config;
-  },
+  // ... existing config
 };
-
-module.exports = nextConfig;
 ```
 
-**Changes from current config:**
-- Added `output: 'export'`
-- Added `distDir: 'out'`
-- Added `trailingSlash: true`
-- Changed `images.unoptimized` from conditional to always `true`
+### Task 5: Add Build Scripts
 
-### Task 4: Add Build Scripts
+**File:** `apps/blog/package.json`
 
-**File:** `apps/blog/package.json` (update scripts section)
+Add/update scripts:
 
 ```json
 {
   "scripts": {
-    "dev": "next dev",
     "build": "next build",
-    "start": "next start",
-    "lint": "next lint",
-    "test": "vitest",
-    "test:run": "vitest run",
-    "clean": "rm -rf .next out",
-    "serve:static": "npx serve out"
+    "serve:static": "npx serve out",
+    "clean": "rm -rf .next out"
   }
 }
 ```
 
-**Changes:**
-- Added `serve:static` script for local testing of static export
-- Kept existing scripts intact
-
-### Task 5: Add Static Export Utilities
+### Task 6: Create Post-Export Script
 
 **File:** `apps/blog/scripts/post-export.js`
 
-```js
-#!/usr/bin/env node
+Creates `.nojekyll` file for GitHub Pages compatibility.
 
-/**
- * Post-export script for GitHub Pages compatibility
- *
- * Run after `next build` to add necessary files for GitHub Pages
- */
+### Task 7: Create GitHub Actions Workflow
 
-const fs = require('fs');
-const path = require('path');
+**File:** `.github/workflows/deploy.yml`
 
-const outDir = path.join(__dirname, '../out');
+Workflow that:
+1. Checks out code
+2. Sets up pnpm (auto-detects version from `packageManager` field)
+3. Installs dependencies
+4. Builds project
+5. Adds `.nojekyll`
+6. Deploys to GitHub Pages via `actions/deploy-pages@v4`
 
-// Add .nojekyll to prevent GitHub from processing with Jekyll
-const nojekyllPath = path.join(outDir, '.nojekyll');
-if (!fs.existsSync(nojekyllPath)) {
-  fs.writeFileSync(nojekyllPath, '');
-  console.log('Created .nojekyll');
-}
+---
 
-// Add CNAME for custom domain (if using one)
-// Uncomment and update if you have a custom domain
-// const cnamePath = path.join(outDir, 'CNAME');
-// fs.writeFileSync(cnamePath, 'yourdomain.com');
-// console.log('Created CNAME');
+## Validation Checklist
 
-console.log('Post-export complete!');
+After implementation, verify:
+
+### Build Output
+- [ ] `pnpm --filter @blog/blog build` succeeds
+- [ ] All routes show `○` or `●` (no `ƒ`)
+- [ ] Static files generated in `apps/blog/out/`
+
+### File Structure
+- [ ] `out/essays/index.html` exists
+- [ ] `out/zh/essays/index.html` exists
+- [ ] `out/essays/[slug]/index.html` for each essay
+
+### Local Testing
+- [ ] `npx serve apps/blog/out` serves the site
+- [ ] All pages load without errors
+- [ ] Filtering works client-side
+
+### Filter Functionality
+- [ ] Type filter updates URL (`?type=guide`)
+- [ ] Topic filter updates URL (`?topics=technical,ai`)
+- [ ] Combined filters work (`?type=guide&topics=technical`)
+- [ ] Clear filters resets URL
+- [ ] Direct navigation to filtered URL works
+- [ ] Refresh preserves filter state
+
+### Both Languages
+- [ ] `/essays/` works with filters
+- [ ] `/zh/essays/` works with filters
+- [ ] Language toggle still works
+
+---
+
+## Expected Build Output After Changes
+
+```
+Route (app)                              Size     First Load JS
+┌ ○ /                                    XXX B           XXX kB
+├ ○ /_not-found                          XXX B           XXX kB
+├ ○ /about                               XXX B           XXX kB
+├ ○ /essays                              XXX B           XXX kB  ← Changed from ƒ to ○
+├ ● /essays/[slug]                       XXX B           XXX kB
+├ ○ /zh                                  XXX B           XXX kB
+├ ○ /zh/about                            XXX B           XXX kB
+├ ○ /zh/essays                           XXX B           XXX kB  ← Changed from ƒ to ○
+└ ● /zh/essays/[slug]                    XXX B           XXX kB
+
+○  (Static)   prerendered as static content
+●  (SSG)      prerendered as static HTML (uses getStaticProps)
 ```
 
-### Task 6: Update GitHub Actions
+---
 
-**File:** `.github/workflows/deploy.yml` (create or update)
+## GitHub Actions Workflow
 
 ```yaml
 name: Deploy to GitHub Pages
@@ -394,7 +266,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        # Auto-detects version from packageManager field in package.json (pnpm@9.15.0)
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -406,7 +277,7 @@ jobs:
         run: pnpm install
 
       - name: Build
-        run: pnpm --filter @blog/blog build
+        run: pnpm build
 
       - name: Add .nojekyll
         run: touch apps/blog/out/.nojekyll
@@ -428,210 +299,36 @@ jobs:
         uses: actions/deploy-pages@v4
 ```
 
-**Changes from original plan:**
-- Updated `pnpm/action-setup` to `v4` (auto-detects version from `packageManager` field)
-- Removed hardcoded `version: 8` (your repo uses pnpm 9.15.0)
-
-### Task 7: Add E2E Validation Test
-
-**File:** `tests/blog/essays-static.spec.ts`
-
-```ts
-import { test, expect } from '@playwright/test';
-
-/**
- * Essays Page Static Export Tests
- *
- * Validates that the essays page works correctly with static export:
- * - Page loads and renders
- * - Client-side filtering works
- * - URL state is preserved
- * - Direct navigation to filtered URLs works
- */
-test.describe('Blog: Essays Page (Static Export)', () => {
-  test('essays page loads and displays content', async ({ page }) => {
-    await page.goto('/essays/');
-
-    // Verify page header
-    await expect(page.locator('h1')).toHaveText('Essays');
-
-    // Verify filters are present
-    await expect(page.locator('.essay-filters')).toBeVisible();
-
-    // Verify essay list is present
-    await expect(page.locator('[role="list"]')).toBeVisible();
-  });
-
-  test('type filter updates URL and filters essays', async ({ page }) => {
-    await page.goto('/essays/');
-
-    // Click on "Guide" type filter
-    await page.click('[data-type="guide"]');
-
-    // Verify URL updated
-    await expect(page).toHaveURL(/type=guide/);
-
-    // Verify filter is selected
-    await expect(page.locator('[data-type="guide"][data-selected="true"]')).toBeVisible();
-  });
-
-  test('topic filter updates URL and filters essays', async ({ page }) => {
-    await page.goto('/essays/');
-
-    // Click on "Technical" topic filter
-    await page.click('[data-topic="technical"]');
-
-    // Verify URL updated
-    await expect(page).toHaveURL(/topics=technical/);
-
-    // Verify filter is selected
-    await expect(page.locator('[data-topic="technical"][data-selected="true"]')).toBeVisible();
-  });
-
-  test('direct navigation to filtered URL works', async ({ page }) => {
-    // Navigate directly to a filtered URL
-    await page.goto('/essays/?type=guide&topics=technical');
-
-    // Verify filters are pre-selected
-    await expect(page.locator('[data-type="guide"][data-selected="true"]')).toBeVisible();
-    await expect(page.locator('[data-topic="technical"][data-selected="true"]')).toBeVisible();
-  });
-
-  test('clear filters resets URL', async ({ page }) => {
-    await page.goto('/essays/?type=guide&topics=technical');
-
-    // Click clear filters button
-    await page.click('.essay-filters-clear-btn');
-
-    // Verify URL is clean
-    await expect(page).toHaveURL(/\/essays\/$/);
-
-    // Verify "All" type is selected
-    await expect(page.locator('[data-type="all"][data-selected="true"]')).toBeVisible();
-  });
-
-  test('filter state persists on page refresh', async ({ page }) => {
-    await page.goto('/essays/');
-
-    // Apply filter
-    await page.click('[data-type="deep-dive"]');
-    await expect(page).toHaveURL(/type=deep-dive/);
-
-    // Refresh page
-    await page.reload();
-
-    // Verify filter is still selected
-    await expect(page.locator('[data-type="deep-dive"][data-selected="true"]')).toBeVisible();
-  });
-
-  test('multiple topic filters work together', async ({ page }) => {
-    await page.goto('/essays/');
-
-    // Select multiple topics
-    await page.click('[data-topic="technical"]');
-    await page.click('[data-topic="ai"]');
-
-    // Verify URL contains both topics
-    await expect(page).toHaveURL(/topics=technical.*ai|topics=ai.*technical/);
-
-    // Verify both are selected
-    await expect(page.locator('[data-topic="technical"][data-selected="true"]')).toBeVisible();
-    await expect(page.locator('[data-topic="ai"][data-selected="true"]')).toBeVisible();
-  });
-});
-```
-
----
-
-## Validation Checklist
-
-After implementation, verify:
-
-- [ ] `pnpm --filter @blog/blog build` succeeds
-- [ ] Build output shows all routes as `○` or `●` (no `ƒ`)
-- [ ] Static files generated in `apps/blog/out/`
-- [ ] `/essays/` directory contains `index.html`
-- [ ] `/essays/[slug]/` directories contain `index.html` for each essay
-- [ ] Local test with `npx serve apps/blog/out` works
-- [ ] Filtering works in browser (client-side)
-- [ ] URL updates when filters change
-- [ ] Direct link to filtered URL works (e.g., `/essays/?type=guide`)
-- [ ] Refresh preserves filter state
-- [ ] E2E tests pass: `pnpm test:e2e tests/blog/essays-static.spec.ts`
-
----
-
-## Expected Build Output
-
-```
-Route (app)                              Size     First Load JS
-┌ ○ /                                    X kB         XXX kB
-├ ○ /_not-found                          X kB         XXX kB
-├ ○ /essays                              X kB         XXX kB  ← Changed from ƒ to ○
-└ ● /essays/[slug]                       X kB         XXX kB
-    ├ /essays/test-essay
-    └ /essays/...
-
-○  (Static)   prerendered as static content
-●  (SSG)      prerendered as static HTML (uses getStaticProps)
-```
-
 ---
 
 ## Troubleshooting
 
-### Common Issues
+### Build fails with "Page couldn't be rendered statically"
+- Ensure no `searchParams`, `headers()`, or `cookies()` in server components
+- Check that `useSearchParams()` is wrapped in Suspense
 
-**1. Build fails with "Page ... couldn't be rendered statically"**
-- Ensure no `searchParams` or `headers()` or `cookies()` usage in server components
-- Check that all dynamic data fetching happens at build time
+### Hydration mismatch with useSearchParams
+- Client component using `useSearchParams()` must be wrapped in `<Suspense>`
+- This handles the initial SSR where search params are unknown
 
-**2. useSearchParams causes hydration mismatch**
-- Ensure `useSearchParams()` is wrapped in a Suspense boundary
-- The client component should handle the initial undefined state gracefully
-
-**3. Images not loading in static export**
-- Ensure `images.unoptimized: true` in next.config.js
-- Use relative paths or configure `basePath` if deploying to subpath
-
-**4. 404 on direct navigation to routes**
+### 404 on direct navigation
 - Ensure `trailingSlash: true` in next.config.js
-- GitHub Pages requires trailing slashes for directory-based routing
+- GitHub Pages requires trailing slashes for directory routing
+
+### Images not loading
+- Ensure `images.unoptimized: true`
+- Use relative paths for images
 
 ---
 
-## Future Considerations
+## Future Enhancements
 
-### Adding Dynamic Features Later
-
-If you need server features in the future:
-
-1. Remove `output: 'export'` from next.config.js
-2. Deploy to Vercel/Netlify instead of GitHub Pages
-3. Existing code will work without changes
-
-### Recommended Static-Compatible Enhancements
-
-| Feature | Implementation |
-|---------|---------------|
-| Full-text search | [Pagefind](https://pagefind.app/) - runs at build time, searches client-side |
-| Comments | [Giscus](https://giscus.app/) - GitHub Discussions backed |
+| Feature | Static-Compatible Solution |
+|---------|---------------------------|
+| Full-text search | [Pagefind](https://pagefind.app/) |
+| Comments | [Giscus](https://giscus.app/) |
 | Analytics | [Plausible](https://plausible.io/) or [Umami](https://umami.is/) |
 | Newsletter | [Buttondown](https://buttondown.email/) embed |
-| View counts | [Supabase](https://supabase.com/) with client-side fetch |
-
-### Base Path (if needed)
-
-If deploying to a subpath (e.g., `username.github.io/blog/`):
-
-```js
-// next.config.js
-const nextConfig = {
-  output: 'export',
-  basePath: '/blog',
-  // ...
-};
-```
 
 ---
 


### PR DESCRIPTION
## Summary

- Convert `/essays` and `/zh/essays` from dynamic to static routes by moving filtering to client-side
- Add static export configuration (`output: 'export'`, `trailingSlash: true`)
- Add GitHub Actions workflow for automated deployment to GitHub Pages
- Fix language redirect bug where header showed different language than content

## Changes

| File | Change |
|------|--------|
| `EssaysPageContent.tsx` | New client component for filtering |
| `EssaysIndexPage.tsx` | Simplified - delegates filtering to client |
| `app/essays/page.tsx` | Removed `searchParams` prop |
| `app/zh/essays/page.tsx` | Removed `searchParams` prop |
| `next.config.js` | Added `output: 'export'`, `trailingSlash`, `distDir` |
| `lib/i18n/context.tsx` | Added redirect on initial load for language preference |
| `package.json` | Added `serve:static` script |
| `.github/workflows/deploy.yml` | New GitHub Actions workflow |
| `plan/STATIC_EXPORT.md` | Updated with implementation details |

## Build Output

All routes now static:
```
┌ ○ /
├ ○ /about
├ ○ /essays              ← was ƒ (dynamic)
├ ● /essays/[slug]
├ ○ /zh
├ ○ /zh/about
├ ○ /zh/essays           ← was ƒ (dynamic)
└ ● /zh/essays/[slug]
```

## Test plan

- [x] `pnpm build` succeeds with all static routes
- [x] All 117 unit tests pass
- [x] Static files generated in `apps/blog/out/`
- [x] Local testing with `serve` works
- [x] Language preference redirect works correctly
- [ ] Deploy to GitHub Pages and verify all routes work

## After merge

Configure GitHub Pages in repo settings:
- Go to Settings → Pages
- Source: **GitHub Actions**

🤖 Generated with [Claude Code](https://claude.com/claude-code)