### PR TITLE
fix(blog): Use focus-visible for topic filter button focus ring

### DIFF
--- a/apps/blog/components/essay/EssayFilters.tsx
+++ b/apps/blog/components/essay/EssayFilters.tsx
@@ -158,7 +158,7 @@ export function EssayFilters({
                 key={value}
                 onClick={() => handleTopicToggle(value)}
                 aria-pressed={isSelected}
-                className="essay-filters-topic-btn focus:outline-none focus:ring-2 focus:ring-action-primary focus:ring-offset-2 rounded-full"
+                className="essay-filters-topic-btn focus:outline-none focus-visible:ring-2 focus-visible:ring-action-primary focus-visible:ring-offset-2 rounded-full"
                 data-topic={value}
                 data-selected={isSelected}
               >


### PR DESCRIPTION
## Summary
- Change `focus:ring-*` to `focus-visible:ring-*` on topic filter buttons
- Focus ring now only appears on keyboard navigation, not mouse clicks
- Removes distracting blue circle that appeared when clicking topic badges

## Test plan
- [ ] Click on topic badges (Technical, AI, Product, Career) - no blue ring should appear
- [ ] Tab to topic badges using keyboard - blue focus ring should appear for accessibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)