### PR TITLE
feat(blog): Add Table of Contents to EssayLayout

### DIFF
--- a/apps/blog/__tests__/mdx-helpers.test.ts
+++ b/apps/blog/__tests__/mdx-helpers.test.ts
@@ -3,7 +3,7 @@ import { extractHeadings, stripFrontmatter } from '@/lib/mdx';
 
 describe('MDX Helper Functions', () => {
   describe('extractHeadings', () => {
-    it('extracts headings with correct levels', () => {
+    it('extracts h2 and h3 headings by default', () => {
       const content = `
 # Heading 1
 Some text
@@ -13,17 +13,35 @@ More text
 `;
       const headings = extractHeadings(content);
 
-      expect(headings).toHaveLength(3);
-      expect(headings[0]).toEqual({ level: 1, text: 'Heading 1', id: 'heading-1' });
-      expect(headings[1]).toEqual({ level: 2, text: 'Heading 2', id: 'heading-2' });
-      expect(headings[2]).toEqual({ level: 3, text: 'Heading 3', id: 'heading-3' });
+      // Default filters to h2-h3 only (excludes h1)
+      expect(headings).toHaveLength(2);
+      expect(headings[0]).toEqual({ level: 2, title: 'Heading 2', id: 'heading-2' });
+      expect(headings[1]).toEqual({ level: 3, title: 'Heading 3', id: 'heading-3' });
+    });
+
+    it('respects minLevel and maxLevel options', () => {
+      const content = `
+# H1
+## H2
+### H3
+#### H4
+`;
+      // Include all levels
+      const allHeadings = extractHeadings(content, { minLevel: 1, maxLevel: 6 });
+      expect(allHeadings).toHaveLength(4);
+      expect(allHeadings.map((h) => h.level)).toEqual([1, 2, 3, 4]);
+
+      // Only h2
+      const h2Only = extractHeadings(content, { minLevel: 2, maxLevel: 2 });
+      expect(h2Only).toHaveLength(1);
+      expect(h2Only[0].level).toBe(2);
     });
 
     it('handles special characters in headings', () => {
       const content = `## What's New in 2024?`;
       const headings = extractHeadings(content);
 
-      expect(headings[0].text).toBe("What's New in 2024?");
+      expect(headings[0].title).toBe("What's New in 2024?");
       expect(headings[0].id).toBe('whats-new-in-2024');
     });
 
@@ -34,7 +52,7 @@ More text
       expect(headings).toEqual([]);
     });
 
-    it('handles all heading levels', () => {
+    it('handles all heading levels when configured', () => {
       const content = `
 # H1
 ## H2
@@ -43,7 +61,7 @@ More text
 ##### H5
 ###### H6
 `;
-      const headings = extractHeadings(content);
+      const headings = extractHeadings(content, { minLevel: 1, maxLevel: 6 });
 
       expect(headings).toHaveLength(6);
       expect(headings.map((h) => h.level)).toEqual([1, 2, 3, 4, 5, 6]);

--- a/apps/blog/app/essays/[slug]/page.tsx
+++ b/apps/blog/app/essays/[slug]/page.tsx
@@ -71,11 +71,12 @@ export default async function EssayPage({ params }: EssayPageProps) {
     notFound();
   }
 
-  const { title, description, date, type, topics, readingTime, content } =
+  const { title, description, date, type, topics, readingTime, content, toc } =
     essay;
 
   return (
     <EssayLayout
+      toc={toc}
       header={
         <EssayHeader
           type={type}

--- a/apps/blog/app/periodics/[slug]/page.tsx
+++ b/apps/blog/app/periodics/[slug]/page.tsx
@@ -72,11 +72,12 @@ export default async function PeriodicPage({ params }: PeriodicPageProps) {
     notFound();
   }
 
-  const { title, description, date, issue, type, topics, readingTime, content } =
+  const { title, description, date, issue, type, topics, readingTime, content, toc } =
     periodic;
 
   return (
     <EssayLayout
+      toc={toc}
       header={
         <PeriodicHeader
           issue={issue}

--- a/apps/blog/app/references/[slug]/page.tsx
+++ b/apps/blog/app/references/[slug]/page.tsx
@@ -73,11 +73,12 @@ export default async function ReferencePage({ params }: ReferencePageProps) {
     notFound();
   }
 
-  const { title, description, date, updated, category, topics, itemCount, readingTime, content } =
+  const { title, description, date, updated, category, topics, itemCount, readingTime, content, toc } =
     reference;
 
   return (
     <EssayLayout
+      toc={toc}
       header={
         <ReferenceHeader
           category={category}

--- a/apps/blog/app/zh/essays/[slug]/page.tsx
+++ b/apps/blog/app/zh/essays/[slug]/page.tsx
@@ -77,11 +77,12 @@ export default async function ZhEssayPage({ params }: ZhEssayPageProps) {
     notFound();
   }
 
-  const { title, description, date, type, topics, readingTime, content } =
+  const { title, description, date, type, topics, readingTime, content, toc } =
     essay;
 
   return (
     <EssayLayout
+      toc={toc}
       header={
         <EssayHeader
           type={type}

--- a/apps/blog/app/zh/periodics/[slug]/page.tsx
+++ b/apps/blog/app/zh/periodics/[slug]/page.tsx
@@ -72,11 +72,12 @@ export default async function ZhPeriodicPage({ params }: PeriodicPageProps) {
     notFound();
   }
 
-  const { title, description, date, issue, type, topics, readingTime, content } =
+  const { title, description, date, issue, type, topics, readingTime, content, toc } =
     periodic;
 
   return (
     <EssayLayout
+      toc={toc}
       header={
         <PeriodicHeader
           issue={issue}

--- a/apps/blog/app/zh/references/[slug]/page.tsx
+++ b/apps/blog/app/zh/references/[slug]/page.tsx
@@ -73,11 +73,12 @@ export default async function ZhReferencePage({ params }: ReferencePageProps) {
     notFound();
   }
 
-  const { title, description, date, updated, category, topics, itemCount, readingTime, content } =
+  const { title, description, date, updated, category, topics, itemCount, readingTime, content, toc } =
     reference;
 
   return (
     <EssayLayout
+      toc={toc}
       header={
         <ReferenceHeader
           category={category}

--- a/apps/blog/components/essay/EssayLayout.stories.tsx
+++ b/apps/blog/components/essay/EssayLayout.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
-import { EssayLayout } from './EssayLayout';
+import { EssayLayout, TocItem } from './EssayLayout';
 import { EssayHeader } from './EssayHeader';
 import { Note } from '../content/Note';
 import { Reference } from '../content/Reference';
@@ -204,6 +204,126 @@ export const WithMultipleNotes: Story = {
     ),
   },
 };
+
+/**
+ * Demonstrates the Table of Contents feature with a minimal sticky sidebar on desktop.
+ * On tablet/mobile, the ToC is hidden to prioritize content.
+ */
+const tocItems: TocItem[] = [
+  { id: 'introduction', title: 'Introduction', level: 2 },
+  { id: 'the-key-innovation-self-attention', title: 'The Key Innovation: Self-Attention', level: 2 },
+  { id: 'parallel-processing', title: 'Parallel Processing', level: 3 },
+  { id: 'architecture-overview', title: 'Architecture Overview', level: 2 },
+  { id: 'the-encoder', title: 'The Encoder', level: 3 },
+  { id: 'the-decoder', title: 'The Decoder', level: 3 },
+  { id: 'conclusion', title: 'Conclusion', level: 2 },
+];
+
+const tocContentWithIds = (
+  <>
+    <h2 id="introduction">Introduction</h2>
+    <p>
+      The transformer architecture changed everything in machine learning. Before
+      transformers, we relied heavily on recurrent neural networks (RNNs) and
+      convolutional neural networks (CNNs) for sequence-to-sequence tasks.
+    </p>
+
+    <p>
+      In 2017, the paper &quot;Attention Is All You Need&quot; introduced a novel
+      architecture that would revolutionize the field.
+      <Note>
+        This refers to the seminal paper by Vaswani et al., published at NeurIPS
+        2017. The paper has been cited over 100,000 times.
+      </Note>
+    </p>
+
+    <h2 id="the-key-innovation-self-attention">The Key Innovation: Self-Attention</h2>
+
+    <p>
+      The core innovation of the transformer is the self-attention mechanism.
+      Unlike RNNs, which process sequences one element at a time, self-attention
+      allows the model to look at all positions in the input sequence
+      simultaneously.
+      <Note>
+        This parallel processing is what makes transformers so efficient to
+        train on modern GPUs.
+      </Note>
+    </p>
+
+    <h3 id="parallel-processing">Parallel Processing</h3>
+
+    <p>
+      This has profound implications for how we build language models today. The
+      ability to capture long-range dependencies efficiently is what enables
+      models like GPT-4 and Claude to maintain coherent conversations over
+      thousands of tokens.
+    </p>
+
+    <h2 id="architecture-overview">Architecture Overview</h2>
+
+    <p>
+      A transformer consists of an encoder and a decoder, though many modern
+      applications use only one of these components. GPT models, for example,
+      use only the decoder portion.
+    </p>
+
+    <h3 id="the-encoder">The Encoder</h3>
+
+    <p>
+      The encoder processes the input sequence and produces a representation
+      that captures the meaning of the input. It consists of multiple identical
+      layers, each containing multi-head self-attention and feed-forward networks.
+    </p>
+
+    <h3 id="the-decoder">The Decoder</h3>
+
+    <p>
+      The decoder generates the output sequence one token at a time. In addition
+      to self-attention, it includes cross-attention layers that attend to the
+      encoder&apos;s output.
+    </p>
+
+    <p>
+      The key components of each layer are:
+    </p>
+
+    <ul>
+      <li>Multi-head self-attention</li>
+      <li>Feed-forward neural networks</li>
+      <li>Layer normalization</li>
+      <li>Residual connections</li>
+    </ul>
+
+    <h2 id="conclusion">Conclusion</h2>
+
+    <p>
+      Understanding transformers is essential for anyone working in modern
+      machine learning. They form the backbone of virtually all state-of-the-art
+      language models and are increasingly being applied to other domains like
+      vision and audio.
+    </p>
+  </>
+);
+
+export const WithTableOfContents: Story = {
+  args: {
+    header: sampleHeader,
+    children: tocContentWithIds,
+    toc: tocItems,
+  },
+  parameters: {
+    viewport: {
+      defaultViewport: 'desktop',
+    },
+    docs: {
+      story: {
+        inline: false,
+        iframeHeight: 600,
+      },
+    },
+  },
+};
+
 
 /**
  * Tests that ReferenceProvider is properly integrated into EssayLayout.

--- a/apps/blog/components/essay/EssayLayout.tsx
+++ b/apps/blog/components/essay/EssayLayout.tsx
@@ -8,75 +8,182 @@ import { ReferenceProvider } from '../content/ReferenceContext';
 // Import essay typography styles that use CSS custom properties
 import '@/styles/essay.css';
 
+export interface TocItem {
+  /** Unique identifier (typically the heading id) */
+  id: string;
+  /** Display text for the ToC entry */
+  title: string;
+  /** Heading level (2 = h2, 3 = h3, etc.) */
+  level: number;
+}
+
 export interface EssayLayoutProps {
   /** Essay header content (title, metadata, etc.) */
   header?: React.ReactNode;
   /** Main essay content */
   children: React.ReactNode;
+  /** Table of contents items */
+  toc?: TocItem[];
   /** Additional CSS classes for the layout container */
   className?: string;
 }
 
 /**
- * EssayLayout - Centered content with right margin for sidenotes
+ * EssayLayout - Centered content with ToC on left, sidenotes on right
  *
  * Layout approach (Tufte CSS-inspired):
- * - Main content is max-width constrained and left-aligned
+ * - Main content is max-width constrained and centered
+ * - Left side has space for Table of Contents (via padding)
  * - Right side has space for sidenotes (via padding)
  * - Sidenotes use float + negative margin to flow into the right space
  *
  * Responsive:
- * - Desktop (≥1024px): Content with sidenote margin on right
+ * - Desktop (≥1280px): ToC on left, content centered, sidenotes on right
+ * - Tablet (1024-1279px): Content with sidenotes, no ToC visible
  * - Mobile (<1024px): Single column, sidenotes expand inline
  *
  * The layout wraps content in NoteProvider and ReferenceProvider for
  * sidenote numbering and citation management.
  */
-export function EssayLayout({ header, children, className }: EssayLayoutProps) {
+export function EssayLayout({ header, children, toc, className }: EssayLayoutProps) {
+  const [activeId, setActiveId] = React.useState<string | null>(null);
+
+  // Track active heading via Intersection Observer
+  React.useEffect(() => {
+    if (!toc || toc.length === 0) return;
+
+    const headingIds = toc.map((item) => item.id);
+    const headingElements = headingIds
+      .map((id) => document.getElementById(id))
+      .filter(Boolean) as HTMLElement[];
+
+    if (headingElements.length === 0) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        // Find the first visible heading
+        const visibleEntries = entries.filter((entry) => entry.isIntersecting);
+        if (visibleEntries.length > 0) {
+          setActiveId(visibleEntries[0].target.id);
+        }
+      },
+      {
+        rootMargin: '-80px 0px -80% 0px',
+        threshold: 0,
+      }
+    );
+
+    headingElements.forEach((el) => observer.observe(el));
+
+    return () => observer.disconnect();
+  }, [toc]);
+
+  const handleTocClick = (id: string) => {
+    const element = document.getElementById(id);
+    if (element) {
+      element.scrollIntoView({ behavior: 'smooth' });
+    }
+  };
+
   return (
     <NoteProvider>
       <ReferenceProvider>
-        <article
+        {/* Wrapper for grid layout on desktop */}
+        <div
           className={cn(
-            'essay-layout',
-            // Mobile: single column with padding
+            'essay-layout-wrapper',
+            // Mobile/Tablet: single column
             'px-4 py-8 md:px-6 md:py-12',
-            // Desktop: centered layout with right margin space for sidenotes
-            // The right padding creates space for floated sidenotes
-            'lg:max-w-[1100px] lg:mx-auto lg:px-8',
-            // Right padding provides the margin space for sidenotes
-            'lg:pr-[340px]',
+            // Desktop (xl): CSS Grid with ToC | Content | Sidenotes
+            'xl:grid xl:grid-cols-[200px_1fr_340px] xl:gap-8',
+            'xl:max-w-[1400px] xl:mx-auto xl:px-8',
             className
           )}
         >
-          {/* Header */}
-          {header && (
-            <header
-              className={cn(
-                'essay-header-container',
-                'mb-8 lg:mb-12',
-                'max-w-prose'
-              )}
-            >
-              {header}
-            </header>
-          )}
-
-          {/* Main content with max-width for readability */}
-          {/* Typography styles for headings, paragraphs, etc. come from essay.css */}
-          <div
+          {/* Desktop ToC - sticky left sidebar */}
+          <aside
             className={cn(
-              'essay-content',
-              'max-w-prose',
-              // Base typography
-              'text-body text-figure-primary',
-              // Vertical rhythm
-              '[&>*]:mb-6 [&>*:last-child]:mb-0'
+              'hidden xl:block',
+              'relative'
             )}
           >
-            {children}
-          </div>
-        </article>
+            <nav
+              className={cn(
+                'sticky top-24',
+                'pt-12' // Align with content top
+              )}
+              aria-label="Table of contents"
+            >
+              {toc && toc.length > 0 && (
+                <ul className="space-y-2">
+                  {toc.map((item) => (
+                    <li key={item.id}>
+                      <button
+                        type="button"
+                        onClick={() => handleTocClick(item.id)}
+                        className={cn(
+                          'block w-full text-left',
+                          'text-caption leading-snug',
+                          'transition-colors duration-150',
+                          item.level === 3 && 'pl-3',
+                          item.level === 4 && 'pl-6',
+                          activeId === item.id
+                            ? 'text-figure-primary font-medium'
+                            : 'text-figure-muted hover:text-figure-primary'
+                        )}
+                      >
+                        {item.title}
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </nav>
+          </aside>
+
+          {/* Main content column */}
+          <article
+            className={cn(
+              'essay-layout',
+              // Tablet (lg): add right padding for sidenotes
+              'lg:pr-[340px]',
+              // Desktop (xl): no padding needed, grid handles it
+              'xl:pr-0'
+            )}
+          >
+            {/* Header */}
+            {header && (
+              <header
+                className={cn(
+                  'essay-header-container',
+                  'mb-8 lg:mb-12',
+                  'max-w-prose'
+                )}
+              >
+                {header}
+              </header>
+            )}
+
+            {/* Main content with max-width for readability */}
+            {/* Typography styles for headings, paragraphs, etc. come from essay.css */}
+            <div
+              className={cn(
+                'essay-content',
+                'max-w-prose',
+                // Base typography
+                'text-body text-figure-primary',
+                // Vertical rhythm
+                '[&>*]:mb-6 [&>*:last-child]:mb-0'
+              )}
+            >
+              {children}
+            </div>
+          </article>
+
+          {/* Right column placeholder for sidenotes (they float into this space) */}
+          {/* pointer-events-none allows hero content to be clickable when it spans full width */}
+          <aside className="hidden xl:block pointer-events-none" aria-hidden="true" />
+        </div>
       </ReferenceProvider>
     </NoteProvider>
   );

--- a/apps/blog/components/essay/index.ts
+++ b/apps/blog/components/essay/index.ts
@@ -1,4 +1,4 @@
-export { EssayLayout, type EssayLayoutProps } from './EssayLayout';
+export { EssayLayout, type EssayLayoutProps, type TocItem } from './EssayLayout';
 export { EssayHeader, type EssayHeaderProps } from './EssayHeader';
 export { EssayCard, type EssayCardProps } from './EssayCard';
 export { EssayList, type EssayListProps } from './EssayList';

--- a/apps/blog/lib/essays.ts
+++ b/apps/blog/lib/essays.ts
@@ -16,6 +16,7 @@ import {
   type Topic,
   type Language,
 } from '@/types/content';
+import { extractHeadings } from './mdx';
 
 /** Directory where essay MDX files are stored */
 const ESSAYS_DIRECTORY = path.join(process.cwd(), 'content', 'essays');
@@ -103,12 +104,15 @@ export function getEssayBySlug(slug: string): Essay | null {
   try {
     const frontmatter = validateFrontmatter(data);
     const stats = readingTime(content);
+    // Extract table of contents from h2 and h3 headings
+    const toc = extractHeadings(content, { minLevel: 2, maxLevel: 3 });
 
     return {
       slug,
       ...frontmatter,
       content,
       readingTime: Math.ceil(stats.minutes),
+      toc,
     };
   } catch (error) {
     console.error(`Error parsing essay ${slug}:`, error);

--- a/apps/blog/lib/mdx-options.ts
+++ b/apps/blog/lib/mdx-options.ts
@@ -1,12 +1,14 @@
 import remarkGfm from 'remark-gfm';
+import rehypeSlug from 'rehype-slug';
 
 /**
  * Shared MDX options for next-mdx-remote/rsc
  *
  * Includes:
  * - remark-gfm: GitHub Flavored Markdown (tables, strikethrough, etc.)
+ * - rehype-slug: Adds id attributes to headings (for ToC linking)
  */
 export const mdxOptions = {
   remarkPlugins: [remarkGfm],
-  rehypePlugins: [],
+  rehypePlugins: [rehypeSlug],
 };

--- a/apps/blog/lib/mdx.ts
+++ b/apps/blog/lib/mdx.ts
@@ -7,6 +7,7 @@
 import { serialize } from 'next-mdx-remote/serialize';
 import type { MDXRemoteSerializeResult } from 'next-mdx-remote';
 import type { ComponentType } from 'react';
+import GithubSlugger from 'github-slugger';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type RemarkRehypePlugin = [any, any?] | any;
@@ -86,25 +87,68 @@ export function getMDXComponents(
 }
 
 /**
+ * Table of contents item (matches EssayLayout.TocItem)
+ */
+export interface TocItem {
+  /** Unique identifier (the heading slug) */
+  id: string;
+  /** Display text for the ToC entry */
+  title: string;
+  /** Heading level (2 = h2, 3 = h3, etc.) */
+  level: number;
+}
+
+/**
+ * Options for extracting headings
+ */
+export interface ExtractHeadingsOptions {
+  /** Minimum heading level to include (default: 2) */
+  minLevel?: number;
+  /** Maximum heading level to include (default: 3) */
+  maxLevel?: number;
+}
+
+/**
+ * Generate a slug from heading text
+ *
+ * Uses github-slugger to match the behavior of rehype-slug for consistent IDs.
+ * Each call to extractHeadings creates a new slugger instance to ensure
+ * consistent slug generation within a single document.
+ */
+export function generateHeadingSlug(text: string, slugger: GithubSlugger): string {
+  return slugger.slug(text);
+}
+
+/**
  * Extract headings from MDX content for table of contents
+ *
+ * @param content - Raw MDX content string
+ * @param options - Filtering options for heading levels
+ * @returns Array of TocItem for use with EssayLayout
  */
 export function extractHeadings(
-  content: string
-): Array<{ level: number; text: string; id: string }> {
+  content: string,
+  options: ExtractHeadingsOptions = {}
+): TocItem[] {
+  const { minLevel = 2, maxLevel = 3 } = options;
   const headingRegex = /^(#{1,6})\s+(.+)$/gm;
-  const headings: Array<{ level: number; text: string; id: string }> = [];
+  const headings: TocItem[] = [];
+  // Create a new slugger instance for each document to match rehype-slug behavior
+  const slugger = new GithubSlugger();
   let match;
 
   while ((match = headingRegex.exec(content)) !== null) {
     const level = match[1].length;
-    const text = match[2].trim();
-    // Generate slug-like ID
-    const id = text
-      .toLowerCase()
-      .replace(/[^\w\s-]/g, '')
-      .replace(/\s+/g, '-');
 
-    headings.push({ level, text, id });
+    // Filter by level range
+    if (level < minLevel || level > maxLevel) {
+      continue;
+    }
+
+    const title = match[2].trim();
+    const id = generateHeadingSlug(title, slugger);
+
+    headings.push({ id, title, level });
   }
 
   return headings;

--- a/apps/blog/lib/periodics.ts
+++ b/apps/blog/lib/periodics.ts
@@ -17,6 +17,7 @@ import {
   type Topic,
   type Language,
 } from '@/types/content';
+import { extractHeadings } from './mdx';
 
 /** Directory where periodic MDX files are stored */
 const PERIODICS_DIRECTORY = path.join(process.cwd(), 'content', 'periodics');
@@ -108,12 +109,15 @@ export function getPeriodicBySlug(slug: string): Periodic | null {
   try {
     const frontmatter = validatePeriodicFrontmatter(data);
     const stats = readingTime(content);
+    // Extract table of contents from h2 and h3 headings
+    const toc = extractHeadings(content, { minLevel: 2, maxLevel: 3 });
 
     return {
       slug,
       ...frontmatter,
       content,
       readingTime: Math.ceil(stats.minutes),
+      toc,
     };
   } catch (error) {
     console.error(`Error parsing periodic ${slug}:`, error);

--- a/apps/blog/lib/references.ts
+++ b/apps/blog/lib/references.ts
@@ -17,6 +17,7 @@ import {
   type Topic,
   type Language,
 } from '@/types/content';
+import { extractHeadings } from './mdx';
 
 /** Directory where reference MDX files are stored */
 const REFERENCES_DIRECTORY = path.join(process.cwd(), 'content', 'references');
@@ -108,12 +109,15 @@ export function getReferenceBySlug(slug: string): Reference | null {
   try {
     const frontmatter = validateReferenceFrontmatter(data);
     const stats = readingTime(content);
+    // Extract table of contents from h2 and h3 headings
+    const toc = extractHeadings(content, { minLevel: 2, maxLevel: 3 });
 
     return {
       slug,
       ...frontmatter,
       content,
       readingTime: Math.ceil(stats.minutes),
+      toc,
     };
   } catch (error) {
     console.error(`Error parsing reference ${slug}:`, error);

--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -22,6 +22,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "reading-time": "^1.5.0",
+    "rehype-slug": "^6.0.0",
     "remark-gfm": "^3.0.0",
     "tailwind-merge": "^2.6.0"
   },
@@ -35,6 +36,7 @@
     "@vitejs/plugin-react": "^4.0.0",
     "autoprefixer": "^10.4.0",
     "eslint-config-next": "^14.0.0",
+    "github-slugger": "^2.0.0",
     "jsdom": "^24.0.0",
     "postcss": "^8.4.0",
     "tailwindcss": "^3.4.0",

--- a/apps/blog/types/content.ts
+++ b/apps/blog/types/content.ts
@@ -81,11 +81,25 @@ export interface EssayMeta {
 }
 
 /**
+ * Table of contents item for essay navigation
+ */
+export interface TocItem {
+  /** Unique identifier (the heading slug) */
+  id: string;
+  /** Display text for the ToC entry */
+  title: string;
+  /** Heading level (2 = h2, 3 = h3, etc.) */
+  level: number;
+}
+
+/**
  * Full essay with content
  */
 export interface Essay extends EssayMeta {
   /** Raw MDX content */
   content: string;
+  /** Table of contents extracted from headings */
+  toc: TocItem[];
 }
 
 // ============================================================================
@@ -126,6 +140,8 @@ export interface PeriodicMeta {
 export interface Periodic extends PeriodicMeta {
   /** Raw MDX content */
   content: string;
+  /** Table of contents extracted from headings */
+  toc: TocItem[];
 }
 
 /**
@@ -191,6 +207,8 @@ export interface ReferenceMeta {
 export interface Reference extends ReferenceMeta {
   /** Raw MDX content */
   content: string;
+  /** Table of contents extracted from headings */
+  toc: TocItem[];
 }
 
 /**

--- a/apps/storybook/.storybook/preview.tsx
+++ b/apps/storybook/.storybook/preview.tsx
@@ -21,6 +21,30 @@ const preview: Preview = {
         { name: 'dark', value: '#09090b' },
       ],
     },
+    viewport: {
+      viewports: {
+        mobile1: {
+          name: 'Mobile (320px)',
+          styles: { width: '320px', height: '568px' },
+        },
+        mobile2: {
+          name: 'Mobile (375px)',
+          styles: { width: '375px', height: '667px' },
+        },
+        tablet: {
+          name: 'Tablet (768px)',
+          styles: { width: '768px', height: '1024px' },
+        },
+        laptop: {
+          name: 'Laptop (1024px)',
+          styles: { width: '1024px', height: '768px' },
+        },
+        desktop: {
+          name: 'Desktop (1440px)',
+          styles: { width: '1440px', height: '900px' },
+        },
+      },
+    },
   },
   globalTypes: {
     theme: {

--- a/tests/blog/essay-components.spec.ts
+++ b/tests/blog/essay-components.spec.ts
@@ -198,9 +198,9 @@ test.describe('Blog: Essay Components', () => {
       expect(texts[1]).toBe('2');
     });
 
-    test('layout has proper structure with right margin space on desktop', async ({ page }) => {
-      // Set desktop viewport
-      await page.setViewportSize({ width: 1280, height: 800 });
+    test('layout has proper structure with right margin space on tablet', async ({ page }) => {
+      // Set tablet viewport (lg breakpoint, before xl grid kicks in)
+      await page.setViewportSize({ width: 1024, height: 800 });
 
       await page.goto(
         '/iframe.html?id=blog-essay-essaylayout--default&viewMode=story'
@@ -208,7 +208,7 @@ test.describe('Blog: Essay Components', () => {
 
       await page.waitForSelector('.essay-layout', { timeout: 10000 });
 
-      // Verify layout has right padding for sidenote margin space
+      // Verify layout has right padding for sidenote margin space on tablet
       const article = page.locator('article.essay-layout');
       await expect(article).toHaveClass(/lg:pr-\[340px\]/);
     });
@@ -339,6 +339,207 @@ test.describe('Blog: Essay Components', () => {
       expect(refTexts).toContain('[1]');
       expect(refTexts).toContain('[2]');
       expect(refTexts).toContain('[3]');
+    });
+  });
+
+  test.describe('EssayLayout Table of Contents', () => {
+    test('ToC is hidden on mobile/tablet viewports', async ({ page }) => {
+      // Test mobile viewport
+      await page.setViewportSize({ width: 375, height: 667 });
+
+      await page.goto(
+        '/iframe.html?id=blog-essay-essaylayout--with-table-of-contents&viewMode=story'
+      );
+
+      await page.waitForSelector('.essay-layout', { timeout: 10000 });
+
+      // ToC nav should not be visible on mobile
+      const tocNav = page.locator('nav[aria-label="Table of contents"]');
+      await expect(tocNav).not.toBeVisible();
+    });
+
+    test('ToC is hidden on tablet viewport (1024px)', async ({ page }) => {
+      // Test tablet viewport (below xl breakpoint of 1280px)
+      await page.setViewportSize({ width: 1024, height: 768 });
+
+      await page.goto(
+        '/iframe.html?id=blog-essay-essaylayout--with-table-of-contents&viewMode=story'
+      );
+
+      await page.waitForSelector('.essay-layout', { timeout: 10000 });
+
+      // ToC nav should not be visible on tablet
+      const tocNav = page.locator('nav[aria-label="Table of contents"]');
+      await expect(tocNav).not.toBeVisible();
+    });
+
+    test('ToC is visible on desktop viewport (xl: 1280px+)', async ({ page }) => {
+      // Set desktop viewport (xl breakpoint)
+      await page.setViewportSize({ width: 1440, height: 900 });
+
+      await page.goto(
+        '/iframe.html?id=blog-essay-essaylayout--with-table-of-contents&viewMode=story'
+      );
+
+      await page.waitForSelector('.essay-layout', { timeout: 10000 });
+
+      // ToC nav should be visible on desktop
+      const tocNav = page.locator('nav[aria-label="Table of contents"]');
+      await expect(tocNav).toBeVisible();
+    });
+
+    test('ToC displays all heading items from toc prop', async ({ page }) => {
+      await page.setViewportSize({ width: 1440, height: 900 });
+
+      await page.goto(
+        '/iframe.html?id=blog-essay-essaylayout--with-table-of-contents&viewMode=story'
+      );
+
+      await page.waitForSelector('.essay-layout', { timeout: 10000 });
+
+      const tocNav = page.locator('nav[aria-label="Table of contents"]');
+
+      // Verify all ToC items are present
+      await expect(tocNav.getByText('Introduction')).toBeVisible();
+      await expect(tocNav.getByText('The Key Innovation: Self-Attention')).toBeVisible();
+      await expect(tocNav.getByText('Parallel Processing')).toBeVisible();
+      await expect(tocNav.getByText('Architecture Overview')).toBeVisible();
+      await expect(tocNav.getByText('The Encoder')).toBeVisible();
+      await expect(tocNav.getByText('The Decoder')).toBeVisible();
+      await expect(tocNav.getByText('Conclusion')).toBeVisible();
+    });
+
+    test('ToC is in a separate column from content (not overlapping)', async ({ page }) => {
+      await page.setViewportSize({ width: 1440, height: 900 });
+
+      await page.goto(
+        '/iframe.html?id=blog-essay-essaylayout--with-table-of-contents&viewMode=story'
+      );
+
+      await page.waitForSelector('.essay-layout', { timeout: 10000 });
+
+      // Get bounding boxes of ToC and content
+      const tocNav = page.locator('nav[aria-label="Table of contents"]');
+      const essayHeader = page.locator('.essay-header-container');
+
+      const tocBox = await tocNav.boundingBox();
+      const headerBox = await essayHeader.boundingBox();
+
+      expect(tocBox).not.toBeNull();
+      expect(headerBox).not.toBeNull();
+
+      if (tocBox && headerBox) {
+        // ToC should be entirely to the left of the header
+        // ToC right edge should be less than or equal to header left edge
+        expect(tocBox.x + tocBox.width).toBeLessThanOrEqual(headerBox.x);
+      }
+    });
+
+    test('ToC uses CSS Grid layout on desktop', async ({ page }) => {
+      await page.setViewportSize({ width: 1440, height: 900 });
+
+      await page.goto(
+        '/iframe.html?id=blog-essay-essaylayout--with-table-of-contents&viewMode=story'
+      );
+
+      await page.waitForSelector('.essay-layout', { timeout: 10000 });
+
+      // The wrapper should use CSS Grid on desktop
+      const wrapper = page.locator('.essay-layout-wrapper');
+      const display = await wrapper.evaluate((el) =>
+        window.getComputedStyle(el).display
+      );
+
+      expect(display).toBe('grid');
+    });
+
+    test('ToC is sticky when scrolling', async ({ page }) => {
+      await page.setViewportSize({ width: 1440, height: 900 });
+
+      await page.goto(
+        '/iframe.html?id=blog-essay-essaylayout--with-table-of-contents&viewMode=story'
+      );
+
+      await page.waitForSelector('.essay-layout', { timeout: 10000 });
+
+      const tocNav = page.locator('nav[aria-label="Table of contents"]');
+
+      // Verify ToC has sticky positioning
+      const position = await tocNav.evaluate((el) =>
+        window.getComputedStyle(el).position
+      );
+      expect(position).toBe('sticky');
+    });
+
+    test('ToC items have proper indentation for nested headings', async ({ page }) => {
+      await page.setViewportSize({ width: 1440, height: 900 });
+
+      await page.goto(
+        '/iframe.html?id=blog-essay-essaylayout--with-table-of-contents&viewMode=story'
+      );
+
+      await page.waitForSelector('.essay-layout', { timeout: 10000 });
+
+      const tocNav = page.locator('nav[aria-label="Table of contents"]');
+
+      // h2 items should not have left padding (or have pl-0)
+      const h2Button = tocNav.getByText('Introduction');
+      const h2PaddingLeft = await h2Button.evaluate((el) =>
+        window.getComputedStyle(el).paddingLeft
+      );
+
+      // h3 items should have left padding (pl-3 = 0.75rem = 12px)
+      const h3Button = tocNav.getByText('Parallel Processing');
+      const h3PaddingLeft = await h3Button.evaluate((el) =>
+        window.getComputedStyle(el).paddingLeft
+      );
+
+      // h3 should have more padding than h2
+      const h2Padding = parseFloat(h2PaddingLeft);
+      const h3Padding = parseFloat(h3PaddingLeft);
+      expect(h3Padding).toBeGreaterThan(h2Padding);
+    });
+
+    test('clicking ToC item scrolls to heading', async ({ page }) => {
+      await page.setViewportSize({ width: 1440, height: 900 });
+
+      await page.goto(
+        '/iframe.html?id=blog-essay-essaylayout--with-table-of-contents&viewMode=story'
+      );
+
+      await page.waitForSelector('.essay-layout', { timeout: 10000 });
+
+      // Get initial scroll position
+      const initialScroll = await page.evaluate(() => window.scrollY);
+
+      // Click on "Conclusion" in ToC
+      const tocNav = page.locator('nav[aria-label="Table of contents"]');
+      await tocNav.getByText('Conclusion').click();
+
+      // Wait for smooth scroll to complete
+      await page.waitForTimeout(500);
+
+      // Verify scroll position changed (scrolled down to conclusion)
+      const finalScroll = await page.evaluate(() => window.scrollY);
+      expect(finalScroll).toBeGreaterThan(initialScroll);
+    });
+
+    test('layout without toc prop does not show ToC sidebar', async ({ page }) => {
+      await page.setViewportSize({ width: 1440, height: 900 });
+
+      await page.goto(
+        '/iframe.html?id=blog-essay-essaylayout--default&viewMode=story'
+      );
+
+      await page.waitForSelector('.essay-layout', { timeout: 10000 });
+
+      // ToC nav should not exist when no toc prop is provided
+      const tocNav = page.locator('nav[aria-label="Table of contents"]');
+      const tocContent = page.locator('nav[aria-label="Table of contents"] ul');
+
+      // The nav element might exist but be empty
+      const itemCount = await tocContent.locator('li').count();
+      expect(itemCount).toBe(0);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Add a minimal left sidebar Table of Contents (ToC) for essays, references, and periodics
- Use CSS Grid layout on desktop with three columns: ToC | Content | Sidenotes
- Auto-extract headings (h2, h3) from MDX content using github-slugger to match rehype-slug IDs
- Add Intersection Observer for active heading tracking with visual highlight
- Add comprehensive Playwright tests for ToC behavior

## Changes

### Layout (`EssayLayout.tsx`)
- Add `TocItem` interface and `toc` prop
- Implement CSS Grid layout on xl breakpoint: `grid-cols-[200px_1fr_340px]`
- Add sticky ToC sidebar with active heading highlight
- Support responsive behavior (ToC hidden on tablet/mobile)

### MDX Processing
- Add `rehype-slug` plugin for automatic heading ID generation
- Update `extractHeadings()` to use `github-slugger` for consistent slug generation
- Add `toc` field to Essay, Reference, and Periodic types

### Page Components
- Update all 6 page components to pass `toc` prop to EssayLayout

### Tests
- Add 10 Playwright tests for ToC functionality:
  - Visibility at different viewport sizes
  - Grid layout verification
  - Sticky positioning
  - Click-to-scroll behavior
  - Heading indentation

## Test plan

- [x] Unit tests pass (`npx vitest run`)
- [x] Playwright tests pass (`npx playwright test --project=blog`)
- [ ] Manual testing in Storybook at desktop viewport
- [ ] Manual testing on actual essay/reference pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)