### PR TITLE
refactor(ui): Make TableOfContents theme-aware with navigation tokens

### DIFF
--- a/apps/blog/components/essay/EssayLayout.tsx
+++ b/apps/blog/components/essay/EssayLayout.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 import { cn } from '@/lib/utils';
+import { TableOfContents, type TocItem as SharedTocItem } from '@blog/ui';
 import { NoteProvider } from '../content/NoteContext';
 import { ReferenceProvider } from '../content/ReferenceContext';
 
@@ -107,38 +108,21 @@ export function EssayLayout({ header, children, toc, className }: EssayLayoutPro
               'relative'
             )}
           >
-            <nav
-              className={cn(
-                'sticky top-24',
-                'pt-12' // Align with content top
-              )}
-              aria-label="Table of contents"
-            >
-              {toc && toc.length > 0 && (
-                <ul className="space-y-2">
-                  {toc.map((item) => (
-                    <li key={item.id}>
-                      <button
-                        type="button"
-                        onClick={() => handleTocClick(item.id)}
-                        className={cn(
-                          'block w-full text-left',
-                          'text-caption leading-snug',
-                          'transition-colors duration-150',
-                          item.level === 3 && 'pl-3',
-                          item.level === 4 && 'pl-6',
-                          activeId === item.id
-                            ? 'text-figure-primary font-medium'
-                            : 'text-figure-muted hover:text-figure-primary'
-                        )}
-                      >
-                        {item.title}
-                      </button>
-                    </li>
-                  ))}
-                </ul>
-              )}
-            </nav>
+            {toc && toc.length > 0 && (
+              <TableOfContents
+                items={toc.map((item) => ({
+                  id: item.id,
+                  title: item.title,
+                  // Map level: EssayLayout uses 2/3/4, TableOfContents uses 1/2/3
+                  level: Math.min(Math.max(item.level - 1, 1), 3) as 1 | 2 | 3,
+                }))}
+                activeId={activeId || undefined}
+                onItemClick={handleTocClick}
+                position="sticky"
+                showTitle={false}
+                className="top-24 pt-12"
+              />
+            )}
           </aside>
 
           {/* Main content column */}

--- a/packages/config/tailwind.config.js
+++ b/packages/config/tailwind.config.js
@@ -102,6 +102,19 @@ const colors = {
     'seq-4': 'var(--color-data-sequential-4)',
     'seq-5': 'var(--color-data-sequential-5)',
   },
+  // Navigation component colors
+  toc: {
+    border: 'var(--navigation-toc-border-color)',
+    item: {
+      bg: 'var(--navigation-toc-item-bg)',
+      text: 'var(--navigation-toc-item-text)',
+    },
+    active: {
+      bg: 'var(--navigation-toc-active-bg)',
+      text: 'var(--navigation-toc-active-text)',
+      border: 'var(--navigation-toc-active-border)',
+    },
+  },
 };
 
 /**
@@ -200,6 +213,7 @@ const borders = {
   borderWidth: {
     DEFAULT: 'var(--border-width-default)',
     thick: 'var(--border-width-thick)',
+    toc: 'var(--navigation-toc-border-width)',
   },
 };
 

--- a/packages/tokens/src/semantic/navigation.json
+++ b/packages/tokens/src/semantic/navigation.json
@@ -1,0 +1,19 @@
+{
+  "navigation": {
+    "toc": {
+      "border": {
+        "width": { "value": "{border.width.default}" },
+        "color": { "value": "{color.border.muted}" }
+      },
+      "item": {
+        "bg": { "value": "transparent" },
+        "text": { "value": "{color.text.secondary}" }
+      },
+      "active": {
+        "bg": { "value": "{color.bg.secondary}" },
+        "text": { "value": "{color.accent.primary}" },
+        "border": { "value": "{color.accent.primary}" }
+      }
+    }
+  }
+}

--- a/packages/tokens/src/themes/brutalism/dark.json
+++ b/packages/tokens/src/themes/brutalism/dark.json
@@ -190,5 +190,22 @@
   "focus": {
     "ring-width": { "value": "3px" },
     "ring-offset": { "value": "3px" }
+  },
+  "navigation": {
+    "toc": {
+      "border": {
+        "width": { "value": "{border.width.thick}" },
+        "color": { "value": "{color.border.strong}" }
+      },
+      "item": {
+        "bg": { "value": "transparent" },
+        "text": { "value": "{color.text.secondary}" }
+      },
+      "active": {
+        "bg": { "value": "{color.bg.inverse}" },
+        "text": { "value": "{color.text.inverse}" },
+        "border": { "value": "{color.accent.primary}" }
+      }
+    }
   }
 }

--- a/packages/tokens/src/themes/brutalism/light.json
+++ b/packages/tokens/src/themes/brutalism/light.json
@@ -190,5 +190,22 @@
   "focus": {
     "ring-width": { "value": "3px" },
     "ring-offset": { "value": "3px" }
+  },
+  "navigation": {
+    "toc": {
+      "border": {
+        "width": { "value": "{border.width.thick}" },
+        "color": { "value": "{color.border.strong}" }
+      },
+      "item": {
+        "bg": { "value": "transparent" },
+        "text": { "value": "{color.text.secondary}" }
+      },
+      "active": {
+        "bg": { "value": "{color.bg.inverse}" },
+        "text": { "value": "{color.text.inverse}" },
+        "border": { "value": "{color.accent.primary}" }
+      }
+    }
   }
 }

--- a/packages/tokens/src/themes/chinese-aesthetic/dark.json
+++ b/packages/tokens/src/themes/chinese-aesthetic/dark.json
@@ -250,5 +250,22 @@
     "handscroll": { "value": "{primitive.aspect.handscroll}" },
     "hanging": { "value": "{primitive.aspect.hanging}" },
     "album": { "value": "{primitive.aspect.album}" }
+  },
+  "navigation": {
+    "toc": {
+      "border": {
+        "width": { "value": "0" },
+        "color": { "value": "transparent" }
+      },
+      "item": {
+        "bg": { "value": "transparent" },
+        "text": { "value": "{primitive.color.chinese.ink.wash}" }
+      },
+      "active": {
+        "bg": { "value": "{primitive.color.chinese.ink.dense}" },
+        "text": { "value": "{primitive.color.chinese.seal.red-light}" },
+        "border": { "value": "{primitive.color.chinese.seal.red-light}" }
+      }
+    }
   }
 }

--- a/packages/tokens/src/themes/chinese-aesthetic/light.json
+++ b/packages/tokens/src/themes/chinese-aesthetic/light.json
@@ -250,5 +250,22 @@
     "handscroll": { "value": "{primitive.aspect.handscroll}" },
     "hanging": { "value": "{primitive.aspect.hanging}" },
     "album": { "value": "{primitive.aspect.album}" }
+  },
+  "navigation": {
+    "toc": {
+      "border": {
+        "width": { "value": "0" },
+        "color": { "value": "transparent" }
+      },
+      "item": {
+        "bg": { "value": "transparent" },
+        "text": { "value": "{primitive.color.chinese.ink.medium}" }
+      },
+      "active": {
+        "bg": { "value": "{primitive.color.chinese.paper.xuan}" },
+        "text": { "value": "{primitive.color.chinese.seal.red}" },
+        "border": { "value": "{primitive.color.chinese.seal.red}" }
+      }
+    }
   }
 }

--- a/packages/ui/src/components/TableOfContents/TableOfContents.stories.tsx
+++ b/packages/ui/src/components/TableOfContents/TableOfContents.stories.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { TableOfContents, useActiveHeading, type TocItem } from './TableOfContents';
 
 const meta: Meta<typeof TableOfContents> = {
-  title: 'Components/Themes/Chinese Aesthetic/TableOfContents',
+  title: 'Components/Navigation/TableOfContents',
   component: TableOfContents,
   tags: ['autodocs'],
   parameters: {
@@ -11,7 +11,12 @@ const meta: Meta<typeof TableOfContents> = {
     docs: {
       description: {
         component: `
-Table of Contents (目录) - Article navigation component for the Chinese Aesthetic theme.
+Table of Contents - Theme-aware article navigation component.
+
+Automatically adapts to the current theme:
+- **NYT**: Thin left border, classic newspaper style
+- **Chinese Aesthetic**: No border, seal-stamp markers
+- **Brutalism**: Thick border, inverted active state
 
 ## Features
 - Vertical list with hierarchical indentation
@@ -20,15 +25,16 @@ Table of Contents (目录) - Article navigation component for the Chinese Aesthe
 - Multiple marker styles: dot, seal, line
 - Optional sticky/fixed positioning
 - useActiveHeading hook for scroll-based tracking
+- Theme-aware styling via navigation tokens
 
 ## Usage
 \`\`\`tsx
-import { TableOfContents, useActiveHeading } from '@ui/components/TableOfContents';
+import { TableOfContents, useActiveHeading } from '@blog/ui';
 
 const items = [
-  { id: 'intro', title: '引言', level: 1 },
-  { id: 'chapter-1', title: '第一章', level: 1 },
-  { id: 'section-1-1', title: '第一节', level: 2 },
+  { id: 'intro', title: 'Introduction', level: 1 },
+  { id: 'chapter-1', title: 'Chapter 1', level: 1 },
+  { id: 'section-1-1', title: 'Section 1.1', level: 2 },
 ];
 
 function ArticleToc() {

--- a/packages/ui/src/components/TableOfContents/TableOfContents.tsx
+++ b/packages/ui/src/components/TableOfContents/TableOfContents.tsx
@@ -6,13 +6,17 @@ const tableOfContentsVariants = cva(
   [
     'flex flex-col',
     'transition-all duration-normal',
+    // Use navigation tokens for border (theme-aware)
+    '[border-left-width:var(--navigation-toc-border-width)]',
+    '[border-left-color:var(--navigation-toc-border-color)]',
+    '[border-left-style:solid]',
   ],
   {
     variants: {
       variant: {
-        default: 'space-y-2',
-        scroll: 'space-y-3 border-l-2 border-ground-secondary pl-4',
-        compact: 'space-y-1',
+        default: 'space-y-2 pl-4',
+        scroll: 'space-y-3 pl-4',
+        compact: 'space-y-1 pl-4',
       },
       position: {
         inline: '',
@@ -35,16 +39,19 @@ const tocItemVariants = cva(
     'cursor-pointer',
     'hover:bg-ground-secondary',
     'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary',
+    // Use navigation tokens for item colors (theme-aware)
+    '[color:var(--navigation-toc-item-text)]',
   ],
   {
     variants: {
       level: {
-        1: 'font-medium text-text-primary',
-        2: 'pl-4 text-text-secondary',
-        3: 'pl-8 text-text-muted text-caption',
+        1: 'font-medium',
+        2: 'pl-4',
+        3: 'pl-8 text-caption',
       },
       active: {
-        true: 'bg-ground-secondary text-accent-primary font-medium',
+        // Use navigation tokens for active state (theme-aware)
+        true: '[background-color:var(--navigation-toc-active-bg)] [color:var(--navigation-toc-active-text)] font-medium',
         false: '',
       },
     },
@@ -95,7 +102,7 @@ const TableOfContents = React.forwardRef<HTMLElement, TableOfContentsProps>(
       label = '目录',
       showTitle = true,
       smoothScroll = true,
-      markerStyle = 'dot',
+      markerStyle = 'line',
       ...props
     },
     ref
@@ -119,7 +126,7 @@ const TableOfContents = React.forwardRef<HTMLElement, TableOfContentsProps>(
           return (
             <span
               className="inline-block w-1.5 h-1.5 rounded-full mr-2"
-              style={{ backgroundColor: 'var(--color-accent-primary)' }}
+              style={{ backgroundColor: 'var(--navigation-toc-active-border)' }}
               aria-hidden="true"
             />
           );
@@ -127,7 +134,7 @@ const TableOfContents = React.forwardRef<HTMLElement, TableOfContentsProps>(
           return (
             <span
               className="inline-block w-2 h-2 rounded-sm mr-2"
-              style={{ backgroundColor: 'var(--color-accent-primary)' }}
+              style={{ backgroundColor: 'var(--navigation-toc-active-border)' }}
               aria-hidden="true"
             />
           );
@@ -135,7 +142,7 @@ const TableOfContents = React.forwardRef<HTMLElement, TableOfContentsProps>(
           return (
             <span
               className="absolute left-0 top-0 bottom-0 w-0.5"
-              style={{ backgroundColor: 'var(--color-accent-primary)' }}
+              style={{ backgroundColor: 'var(--navigation-toc-active-border)' }}
               aria-hidden="true"
             />
           );

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -108,12 +108,7 @@ export {
 export { Byline, bylineVariants, type BylineProps, type Author } from '@ui/components/Byline';
 export { CodeBlock, InlineCode, type CodeBlockProps, type InlineCodeProps } from '@ui/components/CodeBlock';
 
-// Chinese Aesthetic Theme Components
-export { SealStamp, sealStampVariants, type SealStampProps } from '@ui/components/SealStamp';
-export { BrushDivider, brushDividerVariants, type BrushDividerProps } from '@ui/components/BrushDivider';
-export { MarginNote, marginNoteVariants, type MarginNoteProps } from '@ui/components/MarginNote';
-export { MoonGate, moonGateVariants, type MoonGateProps } from '@ui/components/MoonGate';
-export { ScrollLandscape, scrollLandscapeVariants, type ScrollLandscapeProps } from '@ui/components/ScrollLandscape';
+// Navigation Components
 export {
   TableOfContents,
   tableOfContentsVariants,
@@ -122,6 +117,13 @@ export {
   type TableOfContentsProps,
   type TocItem,
 } from '@ui/components/TableOfContents';
+
+// Chinese Aesthetic Theme Components
+export { SealStamp, sealStampVariants, type SealStampProps } from '@ui/components/SealStamp';
+export { BrushDivider, brushDividerVariants, type BrushDividerProps } from '@ui/components/BrushDivider';
+export { MarginNote, marginNoteVariants, type MarginNoteProps } from '@ui/components/MarginNote';
+export { MoonGate, moonGateVariants, type MoonGateProps } from '@ui/components/MoonGate';
+export { ScrollLandscape, scrollLandscapeVariants, type ScrollLandscapeProps } from '@ui/components/ScrollLandscape';
 export {
   SeasonSelector,
   seasonSelectorVariants,

--- a/tests/components/navigation.spec.ts
+++ b/tests/components/navigation.spec.ts
@@ -1,0 +1,317 @@
+import { test, expect } from '@playwright/test';
+import {
+  navigateToStoryWithTheme,
+  getComputedStyleProperty,
+  parsePixelValue,
+  parseColor,
+  getCSSVariable,
+} from '../utils';
+
+/**
+ * Navigation Component Tests
+ *
+ * Tests that TableOfContents correctly adapts to different themes
+ * using navigation semantic tokens.
+ *
+ * Theme visual differences:
+ * - NYT: Thin 1px left border, serif font, classic newspaper style
+ * - Chinese Aesthetic: No border, seal markers available
+ * - Brutalism: Thick 4px border, inverted active state, monospace font
+ */
+
+test.describe('TableOfContents: Cross-Theme Tests', () => {
+  test.describe('Border Width by Theme', () => {
+    test('NYT theme has 1px border (classic newspaper)', async ({ page }) => {
+      const iframe = await navigateToStoryWithTheme(
+        page,
+        'components-navigation-tableofcontents--default',
+        'nyt',
+        'light'
+      );
+
+      await iframe.locator('body').waitFor({ state: 'visible' });
+      await page.waitForTimeout(500);
+
+      const toc = iframe.locator('nav').first();
+      const borderWidth = await getComputedStyleProperty(toc, 'border-left-width');
+      expect(parsePixelValue(borderWidth)).toBe(1);
+    });
+
+    test('Chinese Aesthetic theme has no border', async ({ page }) => {
+      const iframe = await navigateToStoryWithTheme(
+        page,
+        'components-navigation-tableofcontents--default',
+        'chinese-aesthetic',
+        'light'
+      );
+
+      await iframe.locator('body').waitFor({ state: 'visible' });
+      await page.waitForTimeout(500);
+
+      const toc = iframe.locator('nav').first();
+      const borderWidth = await getComputedStyleProperty(toc, 'border-left-width');
+      expect(parsePixelValue(borderWidth)).toBe(0);
+    });
+
+    test('Brutalism theme has 4px border (thick geometric)', async ({ page }) => {
+      const iframe = await navigateToStoryWithTheme(
+        page,
+        'components-navigation-tableofcontents--default',
+        'brutalism',
+        'light'
+      );
+
+      await iframe.locator('body').waitFor({ state: 'visible' });
+      await page.waitForTimeout(500);
+
+      const toc = iframe.locator('nav').first();
+      const borderWidth = await getComputedStyleProperty(toc, 'border-left-width');
+      expect(parsePixelValue(borderWidth)).toBe(4);
+    });
+  });
+
+  test.describe('Active State Styling by Theme', () => {
+    test('NYT: active item uses accent color text on secondary bg', async ({ page }) => {
+      const iframe = await navigateToStoryWithTheme(
+        page,
+        'components-navigation-tableofcontents--default',
+        'nyt',
+        'light'
+      );
+
+      await iframe.locator('body').waitFor({ state: 'visible' });
+      await page.waitForTimeout(500);
+
+      const activeItem = iframe.locator('[aria-current="location"]');
+      await expect(activeItem).toBeVisible();
+
+      const textColor = await getComputedStyleProperty(activeItem, 'color');
+      const parsedColor = parseColor(textColor);
+
+      // NYT accent is blue
+      expect(parsedColor).not.toBeNull();
+      expect(parsedColor!.b).toBeGreaterThan(100);
+    });
+
+    test('Chinese Aesthetic: active item uses seal red accent', async ({ page }) => {
+      const iframe = await navigateToStoryWithTheme(
+        page,
+        'components-navigation-tableofcontents--default',
+        'chinese-aesthetic',
+        'light'
+      );
+
+      await iframe.locator('body').waitFor({ state: 'visible' });
+      await page.waitForTimeout(500);
+
+      const activeItem = iframe.locator('[aria-current="location"]');
+      await expect(activeItem).toBeVisible();
+
+      const textColor = await getComputedStyleProperty(activeItem, 'color');
+      const parsedColor = parseColor(textColor);
+
+      // Chinese aesthetic accent is seal red
+      expect(parsedColor).not.toBeNull();
+      expect(parsedColor!.r).toBeGreaterThan(150);
+    });
+
+    test('Brutalism: active item has inverted colors (white on black)', async ({ page }) => {
+      const iframe = await navigateToStoryWithTheme(
+        page,
+        'components-navigation-tableofcontents--default',
+        'brutalism',
+        'light'
+      );
+
+      await iframe.locator('body').waitFor({ state: 'visible' });
+      await page.waitForTimeout(500);
+
+      const activeItem = iframe.locator('[aria-current="location"]');
+      await expect(activeItem).toBeVisible();
+
+      const bgColor = await getComputedStyleProperty(activeItem, 'background-color');
+      const textColor = await getComputedStyleProperty(activeItem, 'color');
+
+      const bgParsed = parseColor(bgColor);
+      const textParsed = parseColor(textColor);
+
+      // Background should be dark/black
+      expect(bgParsed).not.toBeNull();
+      expect(bgParsed!.r).toBeLessThan(50);
+
+      // Text should be light/white
+      expect(textParsed).not.toBeNull();
+      expect(textParsed!.r).toBeGreaterThan(200);
+    });
+  });
+
+  test.describe('Navigation Tokens', () => {
+    test('navigation tokens are defined for NYT', async ({ page }) => {
+      const iframe = await navigateToStoryWithTheme(
+        page,
+        'components-navigation-tableofcontents--default',
+        'nyt',
+        'light'
+      );
+
+      await iframe.locator('body').waitFor({ state: 'visible' });
+
+      const borderWidth = await getCSSVariable(iframe, '--navigation-toc-border-width');
+      const borderColor = await getCSSVariable(iframe, '--navigation-toc-border-color');
+      const activeText = await getCSSVariable(iframe, '--navigation-toc-active-text');
+
+      expect(borderWidth).toBeTruthy();
+      expect(borderColor).toBeTruthy();
+      expect(activeText).toBeTruthy();
+    });
+
+    test('navigation tokens are defined for Chinese Aesthetic', async ({ page }) => {
+      const iframe = await navigateToStoryWithTheme(
+        page,
+        'components-navigation-tableofcontents--default',
+        'chinese-aesthetic',
+        'light'
+      );
+
+      await iframe.locator('body').waitFor({ state: 'visible' });
+
+      const borderWidth = await getCSSVariable(iframe, '--navigation-toc-border-width');
+      const activeBorder = await getCSSVariable(iframe, '--navigation-toc-active-border');
+
+      expect(borderWidth).toBe('0');
+      expect(activeBorder).toBeTruthy();
+    });
+
+    test('navigation tokens are defined for Brutalism', async ({ page }) => {
+      const iframe = await navigateToStoryWithTheme(
+        page,
+        'components-navigation-tableofcontents--default',
+        'brutalism',
+        'light'
+      );
+
+      await iframe.locator('body').waitFor({ state: 'visible' });
+
+      const borderWidth = await getCSSVariable(iframe, '--navigation-toc-border-width');
+      const activeBg = await getCSSVariable(iframe, '--navigation-toc-active-bg');
+      const activeText = await getCSSVariable(iframe, '--navigation-toc-active-text');
+
+      expect(parsePixelValue(borderWidth)).toBe(4);
+      expect(activeBg).toBeTruthy();
+      expect(activeText).toBeTruthy();
+    });
+  });
+
+  test.describe('Common Functionality', () => {
+    const themes = ['nyt', 'chinese-aesthetic', 'brutalism'] as const;
+
+    for (const theme of themes) {
+      test(`${theme}: renders navigation landmark`, async ({ page }) => {
+        const iframe = await navigateToStoryWithTheme(
+          page,
+          'components-navigation-tableofcontents--default',
+          theme,
+          'light'
+        );
+
+        await iframe.locator('body').waitFor({ state: 'visible' });
+        await page.waitForTimeout(500);
+
+        const nav = iframe.locator('nav');
+        await expect(nav).toBeVisible();
+      });
+
+      test(`${theme}: active item has aria-current`, async ({ page }) => {
+        const iframe = await navigateToStoryWithTheme(
+          page,
+          'components-navigation-tableofcontents--default',
+          theme,
+          'light'
+        );
+
+        await iframe.locator('body').waitFor({ state: 'visible' });
+        await page.waitForTimeout(500);
+
+        const activeItem = iframe.locator('[aria-current="location"]');
+        await expect(activeItem).toBeVisible();
+      });
+
+      test(`${theme}: links are focusable`, async ({ page }) => {
+        const iframe = await navigateToStoryWithTheme(
+          page,
+          'components-navigation-tableofcontents--default',
+          theme,
+          'light'
+        );
+
+        await iframe.locator('body').waitFor({ state: 'visible' });
+        await page.waitForTimeout(500);
+
+        const link = iframe.locator('nav a').first();
+        await link.focus();
+
+        const isFocused = await link.evaluate((el) => document.activeElement === el);
+        expect(isFocused).toBe(true);
+      });
+    }
+  });
+
+  test.describe('Marker Styles', () => {
+    test('dot marker renders correctly across themes', async ({ page }) => {
+      const iframe = await navigateToStoryWithTheme(
+        page,
+        'components-navigation-tableofcontents--dot-marker',
+        'nyt',
+        'light'
+      );
+
+      await iframe.locator('body').waitFor({ state: 'visible' });
+      await page.waitForTimeout(500);
+
+      const activeItem = iframe.locator('[aria-current="location"]');
+      await expect(activeItem).toBeVisible();
+
+      // Dot marker should be visible
+      const dot = activeItem.locator('.rounded-full').first();
+      await expect(dot).toBeVisible();
+    });
+
+    test('seal marker renders correctly', async ({ page }) => {
+      const iframe = await navigateToStoryWithTheme(
+        page,
+        'components-navigation-tableofcontents--seal-marker',
+        'chinese-aesthetic',
+        'light'
+      );
+
+      await iframe.locator('body').waitFor({ state: 'visible' });
+      await page.waitForTimeout(500);
+
+      const activeItem = iframe.locator('[aria-current="location"]');
+      await expect(activeItem).toBeVisible();
+
+      // Seal marker should be visible (square shape)
+      const seal = activeItem.locator('.rounded-sm').first();
+      await expect(seal).toBeVisible();
+    });
+
+    test('line marker renders correctly', async ({ page }) => {
+      const iframe = await navigateToStoryWithTheme(
+        page,
+        'components-navigation-tableofcontents--line-marker',
+        'nyt',
+        'light'
+      );
+
+      await iframe.locator('body').waitFor({ state: 'visible' });
+      await page.waitForTimeout(500);
+
+      const activeItem = iframe.locator('[aria-current="location"]');
+      await expect(activeItem).toBeVisible();
+
+      // Line marker uses absolute positioning
+      const line = activeItem.locator('.absolute').first();
+      await expect(line).toBeVisible();
+    });
+  });
+});

--- a/tests/themes/brutalism/components.spec.ts
+++ b/tests/themes/brutalism/components.spec.ts
@@ -255,6 +255,108 @@ test.describe('Brutalism Theme: Components', () => {
   });
 });
 
+// =============================================================================
+// TABLE OF CONTENTS - Theme-specific styling
+// =============================================================================
+test.describe('Brutalism Theme: TableOfContents', () => {
+  test('has thick left border (4px)', async ({ page }) => {
+    const iframe = await navigateToStoryWithTheme(
+      page,
+      'components-navigation-tableofcontents--default',
+      'brutalism',
+      'light'
+    );
+
+    await iframe.locator('body').waitFor({ state: 'visible' });
+    await page.waitForTimeout(500);
+
+    const toc = iframe.locator('nav').first();
+    await expect(toc).toBeVisible();
+
+    const borderLeftWidth = await getComputedStyleProperty(toc, 'border-left-width');
+    expect(parsePixelValue(borderLeftWidth)).toBe(4);
+  });
+
+  test('has black border color (high contrast)', async ({ page }) => {
+    const iframe = await navigateToStoryWithTheme(
+      page,
+      'components-navigation-tableofcontents--default',
+      'brutalism',
+      'light'
+    );
+
+    await iframe.locator('body').waitFor({ state: 'visible' });
+    await page.waitForTimeout(500);
+
+    const toc = iframe.locator('nav').first();
+    const borderColor = await getComputedStyleProperty(toc, 'border-left-color');
+    const parsedColor = parseColor(borderColor);
+
+    // Border should be black or very dark
+    expect(parsedColor).not.toBeNull();
+    if (parsedColor) {
+      expect(parsedColor.r).toBeLessThan(50);
+      expect(parsedColor.g).toBeLessThan(50);
+      expect(parsedColor.b).toBeLessThan(50);
+    }
+  });
+
+  test('active item has inverted colors (white on black)', async ({ page }) => {
+    const iframe = await navigateToStoryWithTheme(
+      page,
+      'components-navigation-tableofcontents--default',
+      'brutalism',
+      'light'
+    );
+
+    await iframe.locator('body').waitFor({ state: 'visible' });
+    await page.waitForTimeout(500);
+
+    const activeItem = iframe.locator('[aria-current="location"]');
+    await expect(activeItem).toBeVisible();
+
+    const bgColor = await getComputedStyleProperty(activeItem, 'background-color');
+    const textColor = await getComputedStyleProperty(activeItem, 'color');
+
+    const bgParsed = parseColor(bgColor);
+    const textParsed = parseColor(textColor);
+
+    // Background should be dark/black (inverted)
+    expect(bgParsed).not.toBeNull();
+    if (bgParsed) {
+      expect(bgParsed.r).toBeLessThan(50);
+      expect(bgParsed.g).toBeLessThan(50);
+      expect(bgParsed.b).toBeLessThan(50);
+    }
+
+    // Text should be light/white (inverted)
+    expect(textParsed).not.toBeNull();
+    if (textParsed) {
+      expect(textParsed.r).toBeGreaterThan(200);
+      expect(textParsed.g).toBeGreaterThan(200);
+      expect(textParsed.b).toBeGreaterThan(200);
+    }
+  });
+
+  test('uses monospace font', async ({ page }) => {
+    const iframe = await navigateToStoryWithTheme(
+      page,
+      'components-navigation-tableofcontents--default',
+      'brutalism',
+      'light'
+    );
+
+    await iframe.locator('body').waitFor({ state: 'visible' });
+    await page.waitForTimeout(500);
+
+    const link = iframe.locator('nav a').first();
+    await expect(link).toBeVisible();
+
+    const fontFamily = await getComputedStyleProperty(link, 'font-family');
+    expect(fontFamily.toLowerCase()).toMatch(/mono|menlo|consolas|sf mono|ui-monospace/);
+  });
+});
+
 test.describe('Brutalism Theme: Design Tokens', () => {
   test('has correct accent color (red)', async ({ page }) => {
     const iframe = await navigateToStoryWithTheme(

--- a/tests/themes/chinese-aesthetic/accessibility.spec.ts
+++ b/tests/themes/chinese-aesthetic/accessibility.spec.ts
@@ -110,7 +110,7 @@ test.describe('Chinese Aesthetic: Focus Indicators', () => {
   test('interactive components show focus state', async ({ page }) => {
     const iframe = await navigateToStoryWithTheme(
       page,
-      'components-themes-chinese-aesthetic-tableofcontents--default',
+      'components-navigation-tableofcontents--default',
       'chinese-aesthetic',
       'light'
     );
@@ -197,7 +197,7 @@ test.describe('Chinese Aesthetic: Keyboard Navigation', () => {
   test('TableOfContents links are focusable', async ({ page }) => {
     const iframe = await navigateToStoryWithTheme(
       page,
-      'components-themes-chinese-aesthetic-tableofcontents--default',
+      'components-navigation-tableofcontents--default',
       'chinese-aesthetic',
       'light'
     );
@@ -345,7 +345,7 @@ test.describe('Chinese Aesthetic: Screen Reader', () => {
   test('TableOfContents has navigation role', async ({ page }) => {
     const iframe = await navigateToStoryWithTheme(
       page,
-      'components-themes-chinese-aesthetic-tableofcontents--default',
+      'components-navigation-tableofcontents--default',
       'chinese-aesthetic',
       'light'
     );
@@ -440,7 +440,7 @@ test.describe('Chinese Aesthetic: Typography Accessibility', () => {
   test('body text meets minimum size for CJK (16px+)', async ({ page }) => {
     const iframe = await navigateToStoryWithTheme(
       page,
-      'components-themes-chinese-aesthetic-tableofcontents--default',
+      'components-navigation-tableofcontents--default',
       'chinese-aesthetic',
       'light'
     );
@@ -516,7 +516,7 @@ test.describe('Chinese Aesthetic: Color Independence', () => {
   test('TableOfContents active state has multiple indicators', async ({ page }) => {
     const iframe = await navigateToStoryWithTheme(
       page,
-      'components-themes-chinese-aesthetic-tableofcontents--default',
+      'components-navigation-tableofcontents--default',
       'chinese-aesthetic',
       'light'
     );

--- a/tests/themes/chinese-aesthetic/components.spec.ts
+++ b/tests/themes/chinese-aesthetic/components.spec.ts
@@ -558,14 +558,15 @@ test.describe('Chinese Aesthetic: ScrollLandscape', () => {
 });
 
 // =============================================================================
-// TABLE OF CONTENTS (目录)
+// TABLE OF CONTENTS (目录) - Now in Navigation Components
 // =============================================================================
 test.describe('Chinese Aesthetic: TableOfContents', () => {
   test.describe('Variants', () => {
     test('default variant renders with proper spacing', async ({ page }) => {
-      const iframe = await navigateToStory(
+      const iframe = await navigateToStoryWithTheme(
         page,
-        'components-themes-chinese-aesthetic-tableofcontents--default'
+        'components-navigation-tableofcontents--default',
+        'chinese-aesthetic'
       );
 
       await iframe.locator('body').waitFor({ state: 'visible' });
@@ -576,10 +577,11 @@ test.describe('Chinese Aesthetic: TableOfContents', () => {
       await expect(iframe.locator('text=目录')).toBeVisible();
     });
 
-    test('scroll variant has left border', async ({ page }) => {
-      const iframe = await navigateToStory(
+    test('scroll variant has left border via navigation tokens', async ({ page }) => {
+      const iframe = await navigateToStoryWithTheme(
         page,
-        'components-themes-chinese-aesthetic-tableofcontents--scroll-variant'
+        'components-navigation-tableofcontents--scroll-variant',
+        'chinese-aesthetic'
       );
 
       await iframe.locator('body').waitFor({ state: 'visible' });
@@ -588,18 +590,19 @@ test.describe('Chinese Aesthetic: TableOfContents', () => {
       const toc = iframe.locator('nav[aria-label="卷轴目录"]');
       await expect(toc).toBeVisible();
 
-      const hasBorderLeft = await toc.evaluate((el) => {
-        return el.className.includes('border-l');
+      // Chinese aesthetic theme has no border (border-width: 0)
+      const borderWidth = await toc.evaluate((el) => {
+        return getComputedStyle(el).borderLeftWidth;
       });
-      expect(hasBorderLeft).toBe(true);
+      expect(borderWidth).toBe('0px');
     });
   });
 
   test.describe('Active Item Styling', () => {
-    test('active item has accent color', async ({ page }) => {
+    test('active item has accent color from navigation tokens', async ({ page }) => {
       const iframe = await navigateToStoryWithTheme(
         page,
-        'components-themes-chinese-aesthetic-tableofcontents--default',
+        'components-navigation-tableofcontents--default',
         'chinese-aesthetic'
       );
 
@@ -612,7 +615,7 @@ test.describe('Chinese Aesthetic: TableOfContents', () => {
       const textColor = await getComputedStyleProperty(activeItem, 'color');
       const parsedColor = parseColor(textColor);
 
-      // Should be seal red
+      // Should be seal red (accent-primary for chinese-aesthetic)
       expect(parsedColor).not.toBeNull();
       expect(parsedColor!.r).toBeGreaterThan(150);
     });
@@ -620,9 +623,10 @@ test.describe('Chinese Aesthetic: TableOfContents', () => {
 
   test.describe('Marker Styles', () => {
     test('seal marker displays square indicator', async ({ page }) => {
-      const iframe = await navigateToStory(
+      const iframe = await navigateToStoryWithTheme(
         page,
-        'components-themes-chinese-aesthetic-tableofcontents--seal-marker'
+        'components-navigation-tableofcontents--seal-marker',
+        'chinese-aesthetic'
       );
 
       await iframe.locator('body').waitFor({ state: 'visible' });
@@ -942,7 +946,7 @@ test.describe('Chinese Aesthetic: Dark Mode Components', () => {
     test('renders with proper contrast on dark background', async ({ page }) => {
       const iframe = await navigateToStoryWithTheme(
         page,
-        'components-themes-chinese-aesthetic-tableofcontents--default',
+        'components-navigation-tableofcontents--default',
         'chinese-aesthetic',
         'dark'
       );
@@ -967,7 +971,7 @@ test.describe('Chinese Aesthetic: Dark Mode Components', () => {
     test('active item accent color adapts to dark mode', async ({ page }) => {
       const iframe = await navigateToStoryWithTheme(
         page,
-        'components-themes-chinese-aesthetic-tableofcontents--default',
+        'components-navigation-tableofcontents--default',
         'chinese-aesthetic',
         'dark'
       );

--- a/tests/themes/nyt/typography.spec.ts
+++ b/tests/themes/nyt/typography.spec.ts
@@ -1,4 +1,11 @@
 import { test, expect } from '@playwright/test';
+import {
+  navigateToStoryWithTheme,
+  getComputedStyleProperty,
+  parsePixelValue,
+  parseColor,
+  getCSSVariable,
+} from '../../utils';
 
 /**
  * NYT Theme Typography Tests
@@ -344,5 +351,89 @@ test.describe('NYT Theme: Typography', () => {
       expect(tokens.h1.trim()).toBe('700');
       expect(tokens.h2.trim()).toBe('600');
     });
+  });
+});
+
+// =============================================================================
+// TABLE OF CONTENTS - NYT Theme-specific styling
+// =============================================================================
+test.describe('NYT Theme: TableOfContents', () => {
+  test('has thin left border (1px classic newspaper style)', async ({ page }) => {
+    const iframe = await navigateToStoryWithTheme(
+      page,
+      'components-navigation-tableofcontents--default',
+      'nyt',
+      'light'
+    );
+
+    await iframe.locator('body').waitFor({ state: 'visible' });
+    await page.waitForTimeout(500);
+
+    const toc = iframe.locator('nav').first();
+    await expect(toc).toBeVisible();
+
+    const borderLeftWidth = await getComputedStyleProperty(toc, 'border-left-width');
+    expect(parsePixelValue(borderLeftWidth)).toBe(1);
+  });
+
+  test('uses serif font family (Georgia)', async ({ page }) => {
+    const iframe = await navigateToStoryWithTheme(
+      page,
+      'components-navigation-tableofcontents--default',
+      'nyt',
+      'light'
+    );
+
+    await iframe.locator('body').waitFor({ state: 'visible' });
+    await page.waitForTimeout(500);
+
+    const link = iframe.locator('nav a').first();
+    await expect(link).toBeVisible();
+
+    const fontFamily = await getComputedStyleProperty(link, 'font-family');
+    expect(fontFamily.toLowerCase()).toContain('georgia');
+  });
+
+  test('active item has accent color text', async ({ page }) => {
+    const iframe = await navigateToStoryWithTheme(
+      page,
+      'components-navigation-tableofcontents--default',
+      'nyt',
+      'light'
+    );
+
+    await iframe.locator('body').waitFor({ state: 'visible' });
+    await page.waitForTimeout(500);
+
+    const activeItem = iframe.locator('[aria-current="location"]');
+    await expect(activeItem).toBeVisible();
+
+    const textColor = await getComputedStyleProperty(activeItem, 'color');
+    const parsedColor = parseColor(textColor);
+
+    // NYT accent is blue (#1a73e8), so should have prominent blue component
+    expect(parsedColor).not.toBeNull();
+    if (parsedColor) {
+      // Blue component should be significant
+      expect(parsedColor.b).toBeGreaterThan(100);
+    }
+  });
+
+  test('navigation tokens are correctly applied', async ({ page }) => {
+    const iframe = await navigateToStoryWithTheme(
+      page,
+      'components-navigation-tableofcontents--default',
+      'nyt',
+      'light'
+    );
+
+    await iframe.locator('body').waitFor({ state: 'visible' });
+    await page.waitForTimeout(500);
+
+    // Check navigation-specific CSS variables
+    const borderWidth = await getCSSVariable(iframe, '--navigation-toc-border-width');
+
+    // NYT uses default border width which should be 1px
+    expect(parsePixelValue(borderWidth)).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- Create `navigation.json` semantic tokens for ToC styling (border, item, active states)
- Add theme-specific overrides for Chinese Aesthetic (seal red, no border) and Brutalism (thick border, inverted active state)
- Update TableOfContents component to use navigation tokens for theme-aware styling
- Change default marker style from 'dot' to 'line'
- Move TableOfContents from "Chinese Aesthetic Theme Components" to "Navigation Components" in Storybook
- Update EssayLayout to use the shared TableOfContents component

## Test plan
- [ ] Verify ToC renders correctly in NYT theme (1px border, blue accent)
- [ ] Verify ToC renders correctly in Chinese Aesthetic theme (no border, seal red accent)
- [ ] Verify ToC renders correctly in Brutalism theme (4px border, white-on-black active state)
- [ ] Run `npx playwright test --project=components` for navigation tests
- [ ] Run `npx playwright test --project=themes-chinese-aesthetic` for theme tests
- [ ] Verify Storybook stories render correctly under Components/Navigation/TableOfContents

🤖 Generated with [Claude Code](https://claude.com/claude-code)