### PR TITLE
feat(blog): Add interactive 3D landing page with particle galaxy effect

### DIFF
--- a/apps/blog/app/page.tsx
+++ b/apps/blog/app/page.tsx
@@ -1,5 +1,5 @@
-import { HomePage } from '@/components/pages';
+import { LandingPage } from '@/components/pages';
 
 export default function Page() {
-  return <HomePage language="en" />;
+  return <LandingPage language="en" />;
 }

--- a/apps/blog/app/zh/page.tsx
+++ b/apps/blog/app/zh/page.tsx
@@ -1,5 +1,5 @@
-import { HomePage } from '@/components/pages';
+import { LandingPage } from '@/components/pages';
 
 export default function ZhPage() {
-  return <HomePage language="zh" />;
+  return <LandingPage language="zh" />;
 }

--- a/apps/blog/components/experiments/ExperimentCanvas.tsx
+++ b/apps/blog/components/experiments/ExperimentCanvas.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import { Suspense, useState, useCallback, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import type { ExperimentCanvasProps, NavigationTarget } from './types';
+
+/**
+ * Loading fallback while Three.js initializes
+ */
+function LoadingFallback() {
+  return (
+    <div className="absolute inset-0 flex items-center justify-center bg-ground-primary">
+      <div className="text-figure-secondary text-body-sm animate-pulse">
+        Loading...
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Wrapper component that sets up the Three.js canvas for experiments
+ *
+ * Handles:
+ * - Canvas initialization with proper settings
+ * - Mobile detection
+ * - Navigation routing
+ * - Loading states
+ * - Client-only rendering (Three.js requires browser APIs)
+ */
+export function ExperimentCanvas({
+  experiment,
+  language,
+  children,
+}: ExperimentCanvasProps) {
+  const router = useRouter();
+  const [isMobile, setIsMobile] = useState(false);
+  const [hoveredNav, setHoveredNav] = useState<NavigationTarget | null>(null);
+  const [isMounted, setIsMounted] = useState(false);
+  const [Canvas, setCanvas] = useState<React.ComponentType<Record<string, unknown>> | null>(null);
+
+  // Only render Three.js components on the client
+  useEffect(() => {
+    setIsMounted(true);
+    // Dynamically import Canvas
+    import('@react-three/fiber').then((mod) => {
+      setCanvas(() => mod.Canvas);
+    });
+  }, []);
+
+  // Detect mobile on mount
+  useEffect(() => {
+    if (!isMounted) return;
+    const checkMobile = () => {
+      setIsMobile(window.innerWidth < 768 || 'ontouchstart' in window);
+    };
+    checkMobile();
+    window.addEventListener('resize', checkMobile);
+    return () => window.removeEventListener('resize', checkMobile);
+  }, [isMounted]);
+
+  // Handle navigation
+  const handleNavigate = useCallback(
+    (target: NavigationTarget) => {
+      const basePath = language === 'zh' ? '/zh' : '';
+      const paths: Record<NavigationTarget, string> = {
+        essays: `${basePath}/essays`,
+        about: `${basePath}/about`,
+        periodics: `${basePath}/periodics`,
+        series: `${basePath}/series`,
+      };
+      router.push(paths[target]);
+    },
+    [router, language]
+  );
+
+  // Handle hover state
+  const handleHoverNav = useCallback((target: NavigationTarget | null) => {
+    setHoveredNav(target);
+  }, []);
+
+  const { Scene } = experiment;
+
+  return (
+    <div className="relative h-screen w-full overflow-hidden bg-black">
+      {/* Three.js Canvas - only render on client */}
+      {isMounted && Canvas ? (
+        <Suspense fallback={<LoadingFallback />}>
+          <Canvas
+            className="absolute inset-0"
+            camera={{ position: [0, 0, 5], fov: 75 }}
+            dpr={[1, isMobile ? 1.5 : 2]}
+            gl={{
+              antialias: !isMobile,
+              alpha: true,
+              powerPreference: 'high-performance',
+            }}
+          >
+            <Scene
+              language={language}
+              isMobile={isMobile}
+              onNavigate={handleNavigate}
+              onHoverNav={handleHoverNav}
+            />
+          </Canvas>
+        </Suspense>
+      ) : (
+        <LoadingFallback />
+      )}
+
+      {/* Hovered navigation label */}
+      {hoveredNav && (
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+          <span className="text-display font-serif text-white/90 drop-shadow-lg transition-opacity duration-300">
+            {hoveredNav.charAt(0).toUpperCase() + hoveredNav.slice(1)}
+          </span>
+        </div>
+      )}
+
+      {/* Overlay content (navigation, scroll indicator, etc.) */}
+      {children}
+    </div>
+  );
+}

--- a/apps/blog/components/experiments/HeroCanvas.tsx
+++ b/apps/blog/components/experiments/HeroCanvas.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { Suspense, useState, useCallback, useEffect, lazy } from 'react';
+import { useRouter } from 'next/navigation';
+import type { NavigationTarget } from './types';
+import type { Language } from '@/lib/i18n';
+
+// Lazily import the ParticleGalaxy scene
+const ParticleGalaxyScene = lazy(() =>
+  import('./ParticleGalaxy').then((mod) => ({ default: mod.ParticleGalaxy.Scene }))
+);
+
+/**
+ * Loading fallback while Three.js initializes
+ */
+function LoadingFallback() {
+  return (
+    <div className="absolute inset-0 flex items-center justify-center bg-black">
+      <div className="text-white/50 text-body-sm animate-pulse">
+        Loading...
+      </div>
+    </div>
+  );
+}
+
+interface HeroCanvasProps {
+  language: Language;
+  children?: React.ReactNode;
+}
+
+/**
+ * Client-only 3D Hero Canvas
+ *
+ * This component handles the Three.js Canvas setup entirely on the client side.
+ * It uses dynamic imports to prevent Three.js from being bundled for SSR.
+ */
+export function HeroCanvas({ language, children }: HeroCanvasProps) {
+  const router = useRouter();
+  const [isMobile, setIsMobile] = useState(false);
+  const [hoveredNav, setHoveredNav] = useState<NavigationTarget | null>(null);
+  const [isMounted, setIsMounted] = useState(false);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const [Canvas, setCanvas] = useState<React.ComponentType<any> | null>(null);
+
+  // Only render on the client
+  useEffect(() => {
+    setIsMounted(true);
+    // Dynamically import Canvas from @react-three/fiber
+    import('@react-three/fiber').then((mod) => {
+      setCanvas(() => mod.Canvas);
+    });
+  }, []);
+
+  // Detect mobile
+  useEffect(() => {
+    if (!isMounted) return;
+    const checkMobile = () => {
+      setIsMobile(window.innerWidth < 768 || 'ontouchstart' in window);
+    };
+    checkMobile();
+    window.addEventListener('resize', checkMobile);
+    return () => window.removeEventListener('resize', checkMobile);
+  }, [isMounted]);
+
+  // Handle navigation
+  const handleNavigate = useCallback(
+    (target: NavigationTarget) => {
+      const basePath = language === 'zh' ? '/zh' : '';
+      const paths: Record<NavigationTarget, string> = {
+        essays: `${basePath}/essays`,
+        about: `${basePath}/about`,
+        periodics: `${basePath}/periodics`,
+        series: `${basePath}/series`,
+      };
+      router.push(paths[target]);
+    },
+    [router, language]
+  );
+
+  // Handle hover state
+  const handleHoverNav = useCallback((target: NavigationTarget | null) => {
+    setHoveredNav(target);
+  }, []);
+
+  return (
+    <div className="relative h-screen w-full overflow-hidden bg-black">
+      {/* Three.js Canvas - only render on client */}
+      {isMounted && Canvas ? (
+        <Suspense fallback={<LoadingFallback />}>
+          <Canvas
+            className="absolute inset-0"
+            camera={{ position: [0, 0, 5], fov: 75 }}
+            dpr={[1, isMobile ? 1.5 : 2]}
+            gl={{
+              antialias: !isMobile,
+              alpha: true,
+              powerPreference: 'high-performance',
+            }}
+          >
+            <Suspense fallback={null}>
+              <ParticleGalaxyScene
+                language={language}
+                isMobile={isMobile}
+                onNavigate={handleNavigate}
+                onHoverNav={handleHoverNav}
+              />
+            </Suspense>
+          </Canvas>
+        </Suspense>
+      ) : (
+        <LoadingFallback />
+      )}
+
+      {/* Hovered navigation label */}
+      {hoveredNav && (
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+          <span className="text-display font-serif text-white/90 drop-shadow-lg transition-opacity duration-300">
+            {hoveredNav.charAt(0).toUpperCase() + hoveredNav.slice(1)}
+          </span>
+        </div>
+      )}
+
+      {/* Overlay content */}
+      {children}
+    </div>
+  );
+}

--- a/apps/blog/components/experiments/NavigationOverlay.tsx
+++ b/apps/blog/components/experiments/NavigationOverlay.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import Link from 'next/link';
+import type { Language } from '@/lib/i18n';
+
+interface NavigationOverlayProps {
+  /** Current language */
+  language: Language;
+  /** Whether to show the overlay visually (vs just for screen readers) */
+  visible?: boolean;
+}
+
+/**
+ * Accessible navigation overlay for the experiment canvas
+ *
+ * Provides keyboard and screen reader accessible navigation
+ * as a fallback/complement to the interactive 3D navigation.
+ *
+ * When visible=false, navigation is hidden visually but
+ * remains accessible to screen readers.
+ */
+export function NavigationOverlay({
+  language,
+  visible = false,
+}: NavigationOverlayProps) {
+  const basePath = language === 'zh' ? '/zh' : '';
+
+  const navItems = [
+    { href: `${basePath}/essays`, label: language === 'zh' ? '文章' : 'Essays' },
+    {
+      href: `${basePath}/periodics`,
+      label: language === 'zh' ? '周刊' : 'Periodics',
+    },
+    { href: `${basePath}/series`, label: language === 'zh' ? '系列' : 'Series' },
+    { href: `${basePath}/about`, label: language === 'zh' ? '关于' : 'About' },
+  ];
+
+  return (
+    <nav
+      className={
+        visible
+          ? 'absolute bottom-8 left-1/2 z-10 flex -translate-x-1/2 gap-6'
+          : 'sr-only'
+      }
+      aria-label={language === 'zh' ? '主导航' : 'Main navigation'}
+    >
+      {navItems.map((item) => (
+        <Link
+          key={item.href}
+          href={item.href}
+          className={
+            visible
+              ? 'text-body text-white/70 transition-colors hover:text-white'
+              : ''
+          }
+        >
+          {item.label}
+        </Link>
+      ))}
+    </nav>
+  );
+}

--- a/apps/blog/components/experiments/ParticleGalaxy/NavigationCluster.tsx
+++ b/apps/blog/components/experiments/ParticleGalaxy/NavigationCluster.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { useRef, useState, useMemo } from 'react';
+import { useFrame } from '@react-three/fiber';
+import { Html } from '@react-three/drei';
+import * as THREE from 'three';
+
+interface NavigationClusterProps {
+  /** Position in 3D space */
+  position: [number, number, number];
+  /** Display label */
+  label: string;
+  /** Number of particles in the cluster */
+  particleCount?: number;
+  /** Callback when clicked */
+  onClick: () => void;
+  /** Callback when hover state changes */
+  onHover: (isHovered: boolean) => void;
+}
+
+/**
+ * Interactive navigation cluster within the particle field
+ *
+ * A denser cluster of particles that:
+ * - Glows brighter on hover
+ * - Shows a label on hover
+ * - Navigates on click
+ */
+export function NavigationCluster({
+  position,
+  label,
+  particleCount = 200,
+  onClick,
+  onHover,
+}: NavigationClusterProps) {
+  const groupRef = useRef<THREE.Group>(null);
+  const [isHovered, setIsHovered] = useState(false);
+
+  // Create geometry with particle positions
+  const geometry = useMemo(() => {
+    const geo = new THREE.BufferGeometry();
+    const positions = new Float32Array(particleCount * 3);
+
+    for (let i = 0; i < particleCount; i++) {
+      const i3 = i * 3;
+      // Gaussian-like distribution for denser center
+      const r = Math.random() * 0.5;
+      const theta = Math.random() * Math.PI * 2;
+      const phi = Math.acos(2 * Math.random() - 1);
+
+      positions[i3] = r * Math.sin(phi) * Math.cos(theta);
+      positions[i3 + 1] = r * Math.sin(phi) * Math.sin(theta);
+      positions[i3 + 2] = r * Math.cos(phi);
+    }
+
+    geo.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+    return geo;
+  }, [particleCount]);
+
+  // Animate glow and pulsing
+  useFrame((state) => {
+    if (!groupRef.current) return;
+
+    // Gentle pulsing
+    const pulse = 1 + Math.sin(state.clock.elapsedTime * 2) * 0.05;
+    groupRef.current.scale.setScalar(pulse);
+  });
+
+  const handlePointerEnter = () => {
+    setIsHovered(true);
+    onHover(true);
+    document.body.style.cursor = 'pointer';
+  };
+
+  const handlePointerLeave = () => {
+    setIsHovered(false);
+    onHover(false);
+    document.body.style.cursor = 'auto';
+  };
+
+  const color = isHovered ? '#ffffff' : '#88aaff';
+  const opacity = isHovered ? 1 : 0.6;
+
+  return (
+    <group ref={groupRef} position={position}>
+      {/* Invisible hit area for pointer events */}
+      <mesh
+        onPointerEnter={handlePointerEnter}
+        onPointerLeave={handlePointerLeave}
+        onClick={onClick}
+      >
+        <sphereGeometry args={[0.6, 16, 16]} />
+        <meshBasicMaterial transparent opacity={0} />
+      </mesh>
+
+      {/* Particle cluster */}
+      <points geometry={geometry}>
+        <pointsMaterial
+          size={0.04}
+          color={color}
+          transparent
+          opacity={opacity}
+          sizeAttenuation
+          depthWrite={false}
+          blending={THREE.AdditiveBlending}
+        />
+      </points>
+
+      {/* Glow sphere */}
+      <mesh>
+        <sphereGeometry args={[0.3, 16, 16]} />
+        <meshBasicMaterial
+          color={color}
+          transparent
+          opacity={isHovered ? 0.15 : 0.05}
+          depthWrite={false}
+          blending={THREE.AdditiveBlending}
+        />
+      </mesh>
+
+      {/* Label (HTML overlay) */}
+      {isHovered && (
+        <Html center distanceFactor={8}>
+          <div className="pointer-events-none whitespace-nowrap rounded-full bg-black/50 px-4 py-2 text-body font-medium text-white backdrop-blur-sm">
+            {label}
+          </div>
+        </Html>
+      )}
+    </group>
+  );
+}

--- a/apps/blog/components/experiments/ParticleGalaxy/Particles.tsx
+++ b/apps/blog/components/experiments/ParticleGalaxy/Particles.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import { useRef, useMemo, useEffect } from 'react';
+import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+
+interface ParticlesProps {
+  /** Number of particles */
+  count: number;
+  /** Mouse position (normalized -1 to 1) */
+  mouse: React.MutableRefObject<{ x: number; y: number }>;
+}
+
+/**
+ * Particle system for the galaxy effect
+ *
+ * Creates a field of particles that:
+ * - Slowly rotate and drift
+ * - React to mouse movement (gentle repulsion)
+ * - Have varying sizes and subtle color variation
+ */
+export function Particles({ count, mouse }: ParticlesProps) {
+  const pointsRef = useRef<THREE.Points>(null);
+  const originalPositions = useRef<Float32Array | null>(null);
+
+  // Generate particle data
+  const { positions, colors } = useMemo(() => {
+    const positions = new Float32Array(count * 3);
+    const colors = new Float32Array(count * 3);
+
+    // Base colors for variation (white, light blue, light purple)
+    const baseColors = [
+      new THREE.Color(0xffffff), // white
+      new THREE.Color(0xcce5ff), // light blue
+      new THREE.Color(0xe5ccff), // light purple
+      new THREE.Color(0xffeedd), // warm white
+    ];
+
+    for (let i = 0; i < count; i++) {
+      const i3 = i * 3;
+
+      // Spherical distribution with some randomness
+      const radius = 3 + Math.random() * 4;
+      const theta = Math.random() * Math.PI * 2;
+      const phi = Math.acos(2 * Math.random() - 1);
+
+      positions[i3] = radius * Math.sin(phi) * Math.cos(theta);
+      positions[i3 + 1] = radius * Math.sin(phi) * Math.sin(theta);
+      positions[i3 + 2] = radius * Math.cos(phi);
+
+      // Random color from base colors
+      const color = baseColors[Math.floor(Math.random() * baseColors.length)];
+      colors[i3] = color.r;
+      colors[i3 + 1] = color.g;
+      colors[i3 + 2] = color.b;
+    }
+
+    return { positions, colors };
+  }, [count]);
+
+  // Create geometry with attributes
+  const geometry = useMemo(() => {
+    const geo = new THREE.BufferGeometry();
+    geo.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+    geo.setAttribute('color', new THREE.BufferAttribute(colors, 3));
+    return geo;
+  }, [positions, colors]);
+
+  // Store original positions for mouse interaction
+  useEffect(() => {
+    originalPositions.current = positions.slice();
+  }, [positions]);
+
+  // Animation loop
+  useFrame((state) => {
+    if (!pointsRef.current || !originalPositions.current) return;
+
+    const positionAttr = pointsRef.current.geometry.attributes.position as THREE.BufferAttribute;
+    const positionArray = positionAttr.array as Float32Array;
+    const original = originalPositions.current;
+
+    const time = state.clock.elapsedTime;
+
+    for (let i = 0; i < count; i++) {
+      const i3 = i * 3;
+
+      // Get original position
+      const x = original[i3];
+      const y = original[i3 + 1];
+      const z = original[i3 + 2];
+
+      // Slow rotation around Y axis
+      const rotationSpeed = 0.05;
+      const cos = Math.cos(time * rotationSpeed);
+      const sin = Math.sin(time * rotationSpeed);
+      const rotatedX = x * cos - z * sin;
+      const rotatedZ = x * sin + z * cos;
+
+      // Gentle drift/wave
+      const drift = Math.sin(time * 0.2 + i * 0.01) * 0.1;
+
+      // Mouse repulsion
+      const mouseX = mouse.current.x * 3;
+      const mouseY = mouse.current.y * 3;
+      const dx = rotatedX - mouseX;
+      const dy = y + drift - mouseY;
+      const dist = Math.sqrt(dx * dx + dy * dy);
+      const repulsionRadius = 1.5;
+      const repulsionStrength = 0.3;
+
+      let finalX = rotatedX;
+      let finalY = y + drift;
+      const finalZ = rotatedZ;
+
+      if (dist < repulsionRadius && dist > 0.01) {
+        const force = (1 - dist / repulsionRadius) * repulsionStrength;
+        finalX += (dx / dist) * force;
+        finalY += (dy / dist) * force;
+      }
+
+      positionArray[i3] = finalX;
+      positionArray[i3 + 1] = finalY;
+      positionArray[i3 + 2] = finalZ;
+    }
+
+    positionAttr.needsUpdate = true;
+  });
+
+  return (
+    <points ref={pointsRef} geometry={geometry}>
+      <pointsMaterial
+        size={0.05}
+        vertexColors
+        transparent
+        opacity={0.8}
+        sizeAttenuation
+        depthWrite={false}
+        blending={THREE.AdditiveBlending}
+      />
+    </points>
+  );
+}

--- a/apps/blog/components/experiments/ParticleGalaxy/index.tsx
+++ b/apps/blog/components/experiments/ParticleGalaxy/index.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { useRef, useEffect } from 'react';
+import type { SceneProps, Experiment, NavigationTarget } from '../types';
+import { Particles } from './Particles';
+import { NavigationCluster } from './NavigationCluster';
+
+/**
+ * Navigation cluster configuration
+ */
+const NAV_CLUSTERS: Array<{
+  target: NavigationTarget;
+  position: [number, number, number];
+  labels: { en: string; zh: string };
+}> = [
+  { target: 'essays', position: [-2.5, 0, 0], labels: { en: 'Essays', zh: '文章' } },
+  { target: 'series', position: [2.5, 0, 0], labels: { en: 'Series', zh: '系列' } },
+  { target: 'periodics', position: [0, 2, 0], labels: { en: 'Periodics', zh: '周刊' } },
+  { target: 'about', position: [0, -2, 0], labels: { en: 'About', zh: '关于' } },
+];
+
+/**
+ * ParticleGalaxy Scene Component
+ *
+ * A 3D particle field resembling a galaxy or star field.
+ * Navigation clusters are positioned in 3D space and reveal labels on hover.
+ */
+function ParticleGalaxyScene({
+  language,
+  isMobile,
+  onNavigate,
+  onHoverNav,
+}: SceneProps) {
+  const mouseRef = useRef({ x: 0, y: 0 });
+
+  // Track mouse position
+  useEffect(() => {
+    const handleMouseMove = (e: MouseEvent) => {
+      mouseRef.current.x = (e.clientX / window.innerWidth) * 2 - 1;
+      mouseRef.current.y = -(e.clientY / window.innerHeight) * 2 + 1;
+    };
+
+    const handleTouchMove = (e: TouchEvent) => {
+      if (e.touches.length > 0) {
+        mouseRef.current.x = (e.touches[0].clientX / window.innerWidth) * 2 - 1;
+        mouseRef.current.y = -(e.touches[0].clientY / window.innerHeight) * 2 + 1;
+      }
+    };
+
+    window.addEventListener('mousemove', handleMouseMove);
+    window.addEventListener('touchmove', handleTouchMove);
+
+    return () => {
+      window.removeEventListener('mousemove', handleMouseMove);
+      window.removeEventListener('touchmove', handleTouchMove);
+    };
+  }, []);
+
+  // Particle count based on device
+  const particleCount = isMobile ? 2000 : 6000;
+
+  return (
+    <>
+      {/* Ambient lighting */}
+      <ambientLight intensity={0.2} />
+
+      {/* Background particles */}
+      <Particles count={particleCount} mouse={mouseRef} />
+
+      {/* Navigation clusters */}
+      {NAV_CLUSTERS.map((cluster) => (
+        <NavigationCluster
+          key={cluster.target}
+          position={cluster.position}
+          label={cluster.labels[language]}
+          onClick={() => onNavigate(cluster.target)}
+          onHover={(isHovered) =>
+            onHoverNav(isHovered ? cluster.target : null)
+          }
+          particleCount={isMobile ? 100 : 200}
+        />
+      ))}
+    </>
+  );
+}
+
+/**
+ * ParticleGalaxy Experiment Definition
+ */
+export const ParticleGalaxy: Experiment = {
+  meta: {
+    name: 'Particle Galaxy',
+    description:
+      'A 3D particle field with interactive navigation clusters. Particles react to mouse movement.',
+    author: 'Blog Author',
+  },
+  navigationTriggers: NAV_CLUSTERS.map((cluster) => ({
+    type: 'hover' as const,
+    target: cluster.target,
+    position: { x: cluster.position[0], y: cluster.position[1], z: cluster.position[2] },
+  })),
+  Scene: ParticleGalaxyScene,
+};
+
+export default ParticleGalaxy;

--- a/apps/blog/components/experiments/README.md
+++ b/apps/blog/components/experiments/README.md
@@ -1,0 +1,217 @@
+# Experiments - Interactive Visual Art System
+
+This folder contains the system for creating interactive 3D visual experiments that serve as the landing page hero. Each experiment is a self-contained Three.js scene that can be swapped out to refresh the site's visual identity.
+
+## Architecture Overview
+
+```
+experiments/
+├── README.md              # This file
+├── types.ts               # Shared TypeScript interfaces
+├── index.ts               # Exports active experiment
+├── HeroCanvas.tsx         # Canvas wrapper for landing page
+├── ExperimentCanvas.tsx   # Generic canvas wrapper (reusable)
+├── NavigationOverlay.tsx  # Accessible screen-reader navigation
+└── ParticleGalaxy/        # Example experiment
+    ├── index.tsx          # Experiment definition & scene
+    ├── Particles.tsx      # Particle system component
+    └── NavigationCluster.tsx  # Interactive nav points
+```
+
+## Creating a New Experiment
+
+### Step 1: Create the Experiment Folder
+
+```bash
+mkdir apps/blog/components/experiments/YourExperiment
+```
+
+### Step 2: Implement the Scene Component
+
+Create `index.tsx` with your scene:
+
+```tsx
+'use client';
+
+import { useRef, useEffect } from 'react';
+import type { SceneProps, Experiment, NavigationTarget } from '../types';
+
+/**
+ * Your Scene Component
+ *
+ * This runs inside a React Three Fiber <Canvas>.
+ * Use R3F components like <mesh>, <group>, etc.
+ */
+function YourExperimentScene({
+  language,
+  isMobile,
+  onNavigate,
+  onHoverNav,
+}: SceneProps) {
+  // Adjust complexity for mobile
+  const quality = isMobile ? 'low' : 'high';
+
+  return (
+    <>
+      {/* Add lighting */}
+      <ambientLight intensity={0.5} />
+      <pointLight position={[10, 10, 10]} />
+
+      {/* Your 3D content here */}
+      <mesh onClick={() => onNavigate('essays')}>
+        <boxGeometry args={[1, 1, 1]} />
+        <meshStandardMaterial color="hotpink" />
+      </mesh>
+    </>
+  );
+}
+
+/**
+ * Experiment Definition
+ */
+export const YourExperiment: Experiment = {
+  meta: {
+    name: 'Your Experiment Name',
+    description: 'Brief description of the visual effect',
+    author: 'Your Name',
+    date: '2025-01-01',
+  },
+  navigationTriggers: [
+    { type: 'click', target: 'essays', position: { x: 0, y: 0, z: 0 } },
+  ],
+  Scene: YourExperimentScene,
+};
+
+export default YourExperiment;
+```
+
+### Step 3: Update HeroCanvas (Optional)
+
+If you want to use a different experiment, update `HeroCanvas.tsx`:
+
+```tsx
+// Change this import
+const YourExperimentScene = lazy(() =>
+  import('./YourExperiment').then((mod) => ({ default: mod.YourExperiment.Scene }))
+);
+```
+
+## Key Interfaces
+
+### SceneProps
+
+Props your scene receives from the canvas wrapper:
+
+```ts
+interface SceneProps {
+  language: 'en' | 'zh';          // Current language
+  isMobile: boolean;              // Device detection
+  onNavigate: (target) => void;   // Trigger navigation
+  onHoverNav: (target) => void;   // Show hover label
+}
+```
+
+### NavigationTarget
+
+Valid navigation targets:
+
+```ts
+type NavigationTarget = 'essays' | 'about' | 'periodics' | 'series';
+```
+
+### Experiment
+
+Full experiment definition:
+
+```ts
+interface Experiment {
+  meta: {
+    name: string;
+    description: string;
+    author?: string;
+    date?: string;
+  };
+  navigationTriggers: NavigationTrigger[];
+  Scene: React.ComponentType<SceneProps>;
+}
+```
+
+## Best Practices
+
+### Performance
+
+1. **Mobile optimization**: Always check `isMobile` and reduce complexity
+   ```tsx
+   const particleCount = isMobile ? 1000 : 5000;
+   ```
+
+2. **Use instancing**: For many similar objects, use `<instancedMesh>`
+
+3. **Limit draw calls**: Batch geometries when possible
+
+4. **GPU-based animation**: Use shaders for particle/vertex animation
+
+### Accessibility
+
+1. Always provide the `NavigationOverlay` as a fallback for screen readers
+2. Navigation should be discoverable - add subtle visual hints
+3. Ensure sufficient contrast for any text overlays
+
+### Code Organization
+
+1. Keep scene components client-only (`'use client'`)
+2. Extract reusable pieces (particles, materials) into separate files
+3. Document your experiment's concept and interaction model
+
+## Example: ParticleGalaxy
+
+The included `ParticleGalaxy` experiment demonstrates:
+
+- **Particle systems**: 6000 particles on desktop, 2000 on mobile
+- **Mouse interaction**: Particles react to cursor position
+- **Navigation clusters**: Dense particle groups that glow on hover
+- **Bilingual support**: Labels switch based on language prop
+
+### File Structure
+
+```
+ParticleGalaxy/
+├── index.tsx           # Scene + experiment definition
+├── Particles.tsx       # Background particle field
+└── NavigationCluster.tsx   # Interactive navigation points
+```
+
+## Useful Libraries
+
+These are already installed in the project:
+
+- `three` - Core Three.js library
+- `@react-three/fiber` - React renderer for Three.js
+- `@react-three/drei` - Useful helpers and abstractions
+
+### Common drei imports
+
+```tsx
+import {
+  OrbitControls,    // Camera controls
+  Html,             // HTML overlays in 3D
+  Text,             // 3D text
+  useTexture,       // Load textures
+  shaderMaterial,   // Create custom materials
+} from '@react-three/drei';
+```
+
+## Switching Experiments
+
+To change the active experiment on the landing page:
+
+1. Create your new experiment following the structure above
+2. Update the lazy import in `HeroCanvas.tsx`
+3. The landing page will automatically use the new experiment
+
+## Resources
+
+- [React Three Fiber Docs](https://docs.pmnd.rs/react-three-fiber)
+- [Three.js Docs](https://threejs.org/docs/)
+- [drei Helpers](https://github.com/pmndrs/drei)
+- [Three.js Examples](https://threejs.org/examples/)

--- a/apps/blog/components/experiments/index.ts
+++ b/apps/blog/components/experiments/index.ts
@@ -1,0 +1,17 @@
+// Experiment system exports
+export { ExperimentCanvas } from './ExperimentCanvas';
+export { NavigationOverlay } from './NavigationOverlay';
+export type {
+  Experiment,
+  ExperimentMeta,
+  ExperimentCanvasProps,
+  SceneProps,
+  NavigationTarget,
+  NavigationTrigger,
+} from './types';
+
+// Available experiments
+export { ParticleGalaxy } from './ParticleGalaxy';
+
+// Default/active experiment
+export { ParticleGalaxy as ActiveExperiment } from './ParticleGalaxy';

--- a/apps/blog/components/experiments/types.ts
+++ b/apps/blog/components/experiments/types.ts
@@ -1,0 +1,72 @@
+import type { ReactNode } from 'react';
+
+/**
+ * Navigation target for experiment interactions
+ */
+export type NavigationTarget = 'essays' | 'about' | 'periodics' | 'series';
+
+/**
+ * Describes how an experiment reveals navigation
+ */
+export interface NavigationTrigger {
+  /** Type of interaction that reveals this nav item */
+  type: 'hover' | 'click' | 'scroll' | 'gesture';
+  /** The page this trigger navigates to */
+  target: NavigationTarget;
+  /** Optional hint text for discoverability */
+  hint?: string;
+  /** Position in 3D space (normalized -1 to 1) */
+  position?: { x: number; y: number; z: number };
+}
+
+/**
+ * Props passed to experiment scene components
+ */
+export interface SceneProps {
+  /** Current language */
+  language: 'en' | 'zh';
+  /** Whether the device is mobile */
+  isMobile: boolean;
+  /** Callback when navigation is triggered */
+  onNavigate: (target: NavigationTarget) => void;
+  /** Callback when hovering over a navigation cluster */
+  onHoverNav: (target: NavigationTarget | null) => void;
+}
+
+/**
+ * Metadata for an experiment
+ */
+export interface ExperimentMeta {
+  /** Display name */
+  name: string;
+  /** Brief description */
+  description: string;
+  /** Author/creator */
+  author?: string;
+  /** Date created */
+  date?: string;
+}
+
+/**
+ * Full experiment definition
+ */
+export interface Experiment {
+  /** Experiment metadata */
+  meta: ExperimentMeta;
+  /** Navigation triggers this experiment supports */
+  navigationTriggers: NavigationTrigger[];
+  /** The scene component */
+  Scene: React.ComponentType<SceneProps>;
+}
+
+/**
+ * Props for the ExperimentCanvas wrapper
+ */
+export interface ExperimentCanvasProps {
+  /** The experiment to render */
+  experiment: Experiment;
+  /** Current language */
+  language: 'en' | 'zh';
+  /** Children to render as overlay (navigation, UI) */
+  children?: ReactNode;
+}

--- a/apps/blog/components/landing/IntroSection.tsx
+++ b/apps/blog/components/landing/IntroSection.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import Link from 'next/link';
+import type { Language } from '@/lib/i18n';
+
+interface IntroSectionProps {
+  /** Current language */
+  language: Language;
+  /** Whether to render as overlay on 3D canvas (dark background) */
+  variant?: 'default' | 'overlay';
+}
+
+const content = {
+  en: {
+    greeting: "Hello, I'm",
+    name: 'Feitong Yang',
+    bio: 'I write about technology, product design, and the intersection of human experience with digital tools. This is a space for long-form thinking, curated discoveries, and evergreen resources.',
+    aboutLink: 'Learn more about me',
+    navigation: [
+      { label: 'Essays', href: '/essays', description: 'Long-form pieces' },
+      { label: 'Series', href: '/series', description: 'Curated collections' },
+      { label: 'Periodics', href: '/periodics', description: 'Regular updates' },
+    ],
+  },
+  zh: {
+    greeting: '你好，我是',
+    name: '杨斐曈',
+    bio: '我写关于技术、产品设计以及人类体验与数字工具交汇的文章。这里是深度思考、精选发现和常青资源的空间。',
+    aboutLink: '了解更多关于我',
+    navigation: [
+      { label: '文章', href: '/zh/essays', description: '深度长文' },
+      { label: '系列', href: '/zh/series', description: '主题合集' },
+      { label: '期刊', href: '/zh/periodics', description: '定期更新' },
+    ],
+  },
+};
+
+/**
+ * Introduction section with personal bio and blog themes
+ * Supports two variants:
+ * - default: Standard section with theme-aware colors
+ * - overlay: Positioned over 3D canvas with light text on dark background
+ */
+export function IntroSection({
+  language,
+  variant = 'default',
+}: IntroSectionProps) {
+  const t = content[language];
+  const basePath = language === 'zh' ? '/zh' : '';
+
+  const isOverlay = variant === 'overlay';
+
+  // Overlay styles for dark background
+  const overlayStyles = {
+    container:
+      'pointer-events-auto absolute inset-0 flex items-center justify-center px-inset-lg',
+    // Semi-transparent backdrop to separate content from 3D background
+    backdrop:
+      'rounded-2xl bg-black/50 backdrop-blur-md border border-white/10 p-8 md:p-12',
+    wrapper: 'grid gap-8 md:grid-cols-2 md:items-center md:gap-12 max-w-4xl',
+    greeting: 'text-body-sm text-white/70 mb-2',
+    name: 'type-h1 text-white mb-4',
+    bio: 'type-body text-white/80 mb-6',
+    link: 'text-body text-white/90 hover:text-white inline-flex items-center gap-1 transition-colors',
+    navBox: 'space-y-4',
+    navTitle: 'type-h4 text-white mb-4',
+    navItem:
+      'group flex items-center gap-3 rounded-lg bg-white/5 border border-white/10 p-4 transition-colors hover:bg-white/10',
+    navLabel: 'type-body text-white font-medium group-hover:text-white',
+    navDescription: 'text-body-sm text-white/60',
+    navArrow:
+      'ml-auto text-white/40 transition-transform group-hover:translate-x-1 group-hover:text-white/80',
+  };
+
+  // Default styles using design tokens
+  const defaultStyles = {
+    container: 'mx-auto max-w-4xl px-inset-lg py-section-lg',
+    wrapper: 'grid gap-8 md:grid-cols-2 md:items-center md:gap-12',
+    greeting: 'text-body-sm text-figure-secondary mb-2',
+    name: 'type-h1 text-figure-primary mb-4',
+    bio: 'type-body text-figure-secondary mb-6',
+    link: 'text-body text-link hover:text-link-hover inline-flex items-center gap-1',
+    navBox: 'space-y-4',
+    navTitle: 'type-h4 text-figure-primary mb-4',
+    navItem:
+      'group flex items-center gap-3 rounded-lg bg-ground-secondary border border-border p-4 transition-colors hover:bg-ground-tertiary',
+    navLabel: 'type-body text-figure-primary font-medium',
+    navDescription: 'text-body-sm text-figure-secondary',
+    navArrow:
+      'ml-auto text-figure-muted transition-transform group-hover:translate-x-1 group-hover:text-figure-primary',
+  };
+
+  const styles = isOverlay ? overlayStyles : defaultStyles;
+
+  const sectionContent = (
+    <div className={styles.wrapper}>
+      {/* Bio */}
+      <div>
+        <p className={styles.greeting}>{t.greeting}</p>
+        <h2 className={styles.name}>{t.name}</h2>
+        <p className={styles.bio}>{t.bio}</p>
+        <Link href={`${basePath}/about`} className={styles.link}>
+          {t.aboutLink}
+          <span aria-hidden="true">→</span>
+        </Link>
+      </div>
+
+      {/* Navigation */}
+      <div className={styles.navBox}>
+        <h3 className={styles.navTitle}>
+          {language === 'en' ? 'Explore' : '探索'}
+        </h3>
+        <nav aria-label="Content sections">
+          {t.navigation.map((nav) => (
+            <Link key={nav.href} href={nav.href} className={styles.navItem}>
+              <div>
+                <div className={styles.navLabel}>{nav.label}</div>
+                <div className={styles.navDescription}>{nav.description}</div>
+              </div>
+              <span className={styles.navArrow} aria-hidden="true">
+                →
+              </span>
+            </Link>
+          ))}
+        </nav>
+      </div>
+    </div>
+  );
+
+  if (isOverlay) {
+    return (
+      <div className={styles.container}>
+        <div className={overlayStyles.backdrop}>{sectionContent}</div>
+      </div>
+    );
+  }
+
+  return <section className={styles.container}>{sectionContent}</section>;
+}

--- a/apps/blog/components/landing/index.ts
+++ b/apps/blog/components/landing/index.ts
@@ -1,0 +1,2 @@
+// Landing page components
+export { IntroSection } from './IntroSection';

--- a/apps/blog/components/pages/LandingPage.tsx
+++ b/apps/blog/components/pages/LandingPage.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import { NavigationOverlay } from '@/components/experiments/NavigationOverlay';
+import { IntroSection } from '@/components/landing';
+import type { Language } from '@/types/content';
+
+// Dynamically import HeroCanvas with SSR disabled
+const HeroCanvas = dynamic(
+  () => import('@/components/experiments/HeroCanvas').then((mod) => mod.HeroCanvas),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="flex h-screen w-full items-center justify-center bg-black">
+        <div className="text-white/50 text-body-sm animate-pulse">Loading...</div>
+      </div>
+    ),
+  }
+);
+
+export interface LandingPageProps {
+  /** Current language */
+  language: Language;
+}
+
+/**
+ * Full landing page with 3D hero and intro overlay
+ */
+export function LandingPage({ language }: LandingPageProps) {
+  return (
+    <section className="relative h-screen">
+      <HeroCanvas language={language}>
+        {/* Introduction overlay on top of 3D canvas */}
+        <IntroSection language={language} variant="overlay" />
+
+        {/* Accessible navigation overlay (screen reader only) */}
+        <NavigationOverlay language={language} visible={false} />
+      </HeroCanvas>
+    </section>
+  );
+}

--- a/apps/blog/components/pages/index.ts
+++ b/apps/blog/components/pages/index.ts
@@ -1,6 +1,9 @@
 export { HomePage } from './HomePage';
 export type { HomePageProps } from './HomePage';
 
+export { LandingPage } from './LandingPage';
+export type { LandingPageProps } from './LandingPage';
+
 export { EssaysIndexPage } from './EssaysIndexPage';
 export type { EssaysIndexPageProps } from './EssaysIndexPage';
 

--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -15,6 +15,8 @@
   "dependencies": {
     "@blog/tokens": "workspace:*",
     "@blog/ui": "workspace:*",
+    "@react-three/drei": "^9.88.0",
+    "@react-three/fiber": "^8.15.0",
     "clsx": "^2.1.1",
     "gray-matter": "^4.0.3",
     "next": "^14.0.0",
@@ -24,7 +26,8 @@
     "reading-time": "^1.5.0",
     "rehype-slug": "^6.0.0",
     "remark-gfm": "^3.0.0",
-    "tailwind-merge": "^2.6.0"
+    "tailwind-merge": "^2.6.0",
+    "three": "^0.160.0"
   },
   "devDependencies": {
     "@blog/config": "workspace:*",
@@ -33,6 +36,7 @@
     "@types/node": "^20.0.0",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
+    "@types/three": "^0.160.0",
     "@vitejs/plugin-react": "^4.0.0",
     "autoprefixer": "^10.4.0",
     "eslint-config-next": "^14.0.0",

--- a/tests/blog/landing-page.spec.ts
+++ b/tests/blog/landing-page.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Landing Page', () => {
+  test('should load the landing page without errors', async ({ page }) => {
+    // Navigate to the landing page
+    const response = await page.goto('http://localhost:3003');
+
+    // Page should return 200
+    expect(response?.status()).toBe(200);
+
+    // Wait for page to hydrate
+    await page.waitForLoadState('networkidle');
+
+    // Check that the hero section exists
+    const heroSection = page.locator('section.relative.h-screen').first();
+    await expect(heroSection).toBeVisible();
+
+    // Check that the intro overlay is visible
+    await expect(page.getByRole('heading', { name: 'Explore' })).toBeVisible({
+      timeout: 10000,
+    });
+  });
+
+  test('should display the 3D canvas after loading', async ({ page }) => {
+    await page.goto('http://localhost:3003');
+    await page.waitForLoadState('networkidle');
+
+    // Wait for the canvas to load (Three.js renders to a canvas element)
+    // Give it time to initialize
+    await page.waitForTimeout(3000);
+
+    // Check if canvas element exists in the hero section
+    const heroSection = page.locator('section.relative.h-screen').first();
+    await expect(heroSection).toBeVisible();
+  });
+
+  test('should have navigation links in intro section', async ({ page }) => {
+    await page.goto('http://localhost:3003');
+    await page.waitForLoadState('networkidle');
+
+    // Check navigation links exist in the intro overlay (with descriptions)
+    await expect(
+      page.getByRole('link', { name: 'Essays Long-form pieces' })
+    ).toBeVisible({ timeout: 5000 });
+    await expect(
+      page.getByRole('link', { name: 'Series Curated collections' })
+    ).toBeVisible();
+    await expect(
+      page.getByRole('link', { name: 'Periodics Regular updates' })
+    ).toBeVisible();
+  });
+
+  test('should have navigation overlay for accessibility', async ({ page }) => {
+    await page.goto('http://localhost:3003');
+    await page.waitForLoadState('networkidle');
+
+    // Check that the sr-only navigation is in the DOM
+    const nav = page.locator('nav.sr-only');
+    await expect(nav).toBeAttached();
+  });
+});


### PR DESCRIPTION
## Summary

- **Interactive 3D hero section** with particle galaxy effect (6000 particles on desktop, 2000 on mobile)
- **Mouse interaction** - particles react to cursor movement with gentle repulsion
- **Navigation clusters** - hoverable 3D points that reveal labels and navigate to sections
- **IntroSection overlay** - bio and navigation links with semi-transparent backdrop
- **Bilingual support** - full EN/ZH translations
- **Mobile optimized** - reduced particle count and simplified effects
- **Accessible** - screen-reader navigation overlay included

## New Components

### Experiments System (`apps/blog/components/experiments/`)
Modular system for creating swappable 3D visual experiments:
- `types.ts` - Shared TypeScript interfaces
- `HeroCanvas.tsx` - Canvas wrapper for landing page
- `ExperimentCanvas.tsx` - Generic reusable canvas wrapper
- `NavigationOverlay.tsx` - Accessible screen-reader navigation
- `ParticleGalaxy/` - First experiment implementation
- `README.md` - Documentation for creating new experiments

### Landing Components (`apps/blog/components/landing/`)
- `IntroSection.tsx` - Bio and navigation overlay with overlay/default variants

## Test plan

- [x] Playwright tests verify landing page loads correctly
- [x] Tests check for intro overlay visibility
- [x] Tests verify navigation links are present
- [x] Tests confirm accessibility navigation is attached

🤖 Generated with [Claude Code](https://claude.com/claude-code)