### PR TITLE
fix: Update Chinese periodics routing and add language fallback pages

### DIFF
--- a/apps/blog/app/essays/[slug]/page.tsx
+++ b/apps/blog/app/essays/[slug]/page.tsx
@@ -1,4 +1,4 @@
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
 import type { Metadata } from 'next';
 import { MDXRemote } from 'next-mdx-remote/rsc';
 import { getEssayBySlug, getEssaySlugs, getTranslation } from '@/lib/essays';
@@ -61,14 +61,84 @@ export async function generateMetadata({
 }
 
 /**
+ * Static preview of the language toggle dropdown
+ */
+function LanguageTogglePreview({ highlight }: { highlight: 'en' | 'zh' }) {
+  const CheckIcon = () => (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+
+  return (
+    <div className="mt-8 inline-block rounded-lg border border-border bg-ground-secondary p-6" aria-hidden="true">
+      <div className="inline-flex flex-col items-end">
+        {/* Trigger button */}
+        <div className="inline-flex items-center justify-center rounded-md p-2 min-w-[36px] text-sm font-medium bg-ground-tertiary text-figure-primary">
+          <span>EN</span>
+        </div>
+        {/* Dropdown menu */}
+        <div className="mt-1 min-w-[120px] rounded-md border border-border bg-ground-primary p-1 shadow-lg">
+          <div className={`flex items-center justify-between gap-4 px-3 py-2 rounded-sm text-sm ${highlight === 'en' ? 'bg-ground-secondary' : ''}`}>
+            <span>English</span>
+            {highlight === 'en' && <CheckIcon />}
+          </div>
+          <div className={`flex items-center justify-between gap-4 px-3 py-2 rounded-sm text-sm ${highlight === 'zh' ? 'bg-ground-secondary' : ''}`}>
+            <span>中文</span>
+            {highlight === 'zh' && <CheckIcon />}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Component shown when content exists in Chinese but not English
+ */
+function ChineseVersionAvailable() {
+  return (
+    <div className="mx-auto max-w-2xl px-4 py-16 text-center">
+      <h1 className="type-h1 text-figure-primary mb-4">Content in Chinese</h1>
+      <p className="type-body text-figure-secondary">
+        This essay is written in Chinese. Use the language toggle in the header to switch to Chinese.
+      </p>
+      <LanguageTogglePreview highlight="zh" />
+    </div>
+  );
+}
+
+/**
  * Essay page component
  */
 export default async function EssayPage({ params }: EssayPageProps) {
   const { slug } = await params;
   const essay = getEssayBySlug(slug);
 
+  // Content doesn't exist at all
   if (!essay) {
     notFound();
+  }
+
+  // Content exists but is in Chinese, not English
+  if (essay.lang === 'zh') {
+    // Check if there's an English translation we can redirect to
+    const enTranslation = getTranslation(slug, 'en');
+    if (enTranslation && enTranslation.slug !== slug) {
+      redirect(`/essays/${enTranslation.slug}`);
+    }
+    return <ChineseVersionAvailable />;
   }
 
   const { title, description, date, type, topics, readingTime, content, toc } =

--- a/apps/blog/app/periodics/[slug]/page.tsx
+++ b/apps/blog/app/periodics/[slug]/page.tsx
@@ -1,4 +1,4 @@
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
 import type { Metadata } from 'next';
 import { MDXRemote } from 'next-mdx-remote/rsc';
 import { getPeriodicBySlug, getPeriodicSlugs, getPeriodicTranslation } from '@/lib/periodics';
@@ -134,6 +134,11 @@ export default async function PeriodicPage({ params }: PeriodicPageProps) {
 
   // Content exists but is in Chinese, not English
   if (periodic.lang === 'zh') {
+    // Check if there's an English translation we can redirect to
+    const enTranslation = getPeriodicTranslation(slug, 'en');
+    if (enTranslation && enTranslation.slug !== slug) {
+      redirect(`/periodics/${enTranslation.slug}`);
+    }
     return <ChineseVersionAvailable />;
   }
 

--- a/apps/blog/app/periodics/[slug]/page.tsx
+++ b/apps/blog/app/periodics/[slug]/page.tsx
@@ -12,7 +12,7 @@ interface PeriodicPageProps {
 }
 
 /**
- * Generate static paths for all periodics
+ * Generate static paths for all periodics (handles both English content and Chinese-only redirects)
  */
 export async function generateStaticParams() {
   const slugs = getPeriodicSlugs();
@@ -62,14 +62,79 @@ export async function generateMetadata({
 }
 
 /**
+ * Static preview of the language toggle dropdown
+ */
+function LanguageTogglePreview({ highlight }: { highlight: 'en' | 'zh' }) {
+  const CheckIcon = () => (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+
+  return (
+    <div className="mt-8 inline-block rounded-lg border border-border bg-ground-secondary p-6" aria-hidden="true">
+      <div className="inline-flex flex-col items-end">
+        {/* Trigger button */}
+        <div className="inline-flex items-center justify-center rounded-md p-2 min-w-[36px] text-sm font-medium bg-ground-tertiary text-figure-primary">
+          <span>EN</span>
+        </div>
+        {/* Dropdown menu */}
+        <div className="mt-1 min-w-[120px] rounded-md border border-border bg-ground-primary p-1 shadow-lg">
+          <div className={`flex items-center justify-between gap-4 px-3 py-2 rounded-sm text-sm ${highlight === 'en' ? 'bg-ground-secondary' : ''}`}>
+            <span>English</span>
+            {highlight === 'en' && <CheckIcon />}
+          </div>
+          <div className={`flex items-center justify-between gap-4 px-3 py-2 rounded-sm text-sm ${highlight === 'zh' ? 'bg-ground-secondary' : ''}`}>
+            <span>中文</span>
+            {highlight === 'zh' && <CheckIcon />}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Component shown when content exists in Chinese but not English
+ */
+function ChineseVersionAvailable() {
+  return (
+    <div className="mx-auto max-w-2xl px-4 py-16 text-center">
+      <h1 className="type-h1 text-figure-primary mb-4">Content in Chinese</h1>
+      <p className="type-body text-figure-secondary">
+        This periodic is written in Chinese. Use the language toggle in the header to switch to Chinese.
+      </p>
+      <LanguageTogglePreview highlight="zh" />
+    </div>
+  );
+}
+
+/**
  * Periodic page component
  */
 export default async function PeriodicPage({ params }: PeriodicPageProps) {
   const { slug } = await params;
   const periodic = getPeriodicBySlug(slug);
 
+  // Content doesn't exist at all
   if (!periodic) {
     notFound();
+  }
+
+  // Content exists but is in Chinese, not English
+  if (periodic.lang === 'zh') {
+    return <ChineseVersionAvailable />;
   }
 
   const { title, description, date, issue, type, topics, readingTime, content, toc } =

--- a/apps/blog/app/series/[slug]/page.tsx
+++ b/apps/blog/app/series/[slug]/page.tsx
@@ -63,14 +63,79 @@ export async function generateMetadata({
 }
 
 /**
+ * Static preview of the language toggle dropdown
+ */
+function LanguageTogglePreview({ highlight }: { highlight: 'en' | 'zh' }) {
+  const CheckIcon = () => (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+
+  return (
+    <div className="mt-8 inline-block rounded-lg border border-border bg-ground-secondary p-6" aria-hidden="true">
+      <div className="inline-flex flex-col items-end">
+        {/* Trigger button */}
+        <div className="inline-flex items-center justify-center rounded-md p-2 min-w-[36px] text-sm font-medium bg-ground-tertiary text-figure-primary">
+          <span>EN</span>
+        </div>
+        {/* Dropdown menu */}
+        <div className="mt-1 min-w-[120px] rounded-md border border-border bg-ground-primary p-1 shadow-lg">
+          <div className={`flex items-center justify-between gap-4 px-3 py-2 rounded-sm text-sm ${highlight === 'en' ? 'bg-ground-secondary' : ''}`}>
+            <span>English</span>
+            {highlight === 'en' && <CheckIcon />}
+          </div>
+          <div className={`flex items-center justify-between gap-4 px-3 py-2 rounded-sm text-sm ${highlight === 'zh' ? 'bg-ground-secondary' : ''}`}>
+            <span>中文</span>
+            {highlight === 'zh' && <CheckIcon />}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Component shown when content exists in Chinese but not English
+ */
+function ChineseVersionAvailable() {
+  return (
+    <div className="mx-auto max-w-2xl px-4 py-16 text-center">
+      <h1 className="type-h1 text-figure-primary mb-4">Content in Chinese</h1>
+      <p className="type-body text-figure-secondary">
+        This series is written in Chinese. Use the language toggle in the header to switch to Chinese.
+      </p>
+      <LanguageTogglePreview highlight="zh" />
+    </div>
+  );
+}
+
+/**
  * Series page component
  */
 export default async function SeriesItemPage({ params }: SeriesPageProps) {
   const { slug } = await params;
   const series = getSeriesBySlug(slug);
 
+  // Content doesn't exist at all
   if (!series) {
     notFound();
+  }
+
+  // Content exists but is in Chinese, not English
+  if (series.lang === 'zh') {
+    return <ChineseVersionAvailable />;
   }
 
   const { title, description, date, updated, category, topics, itemCount, readingTime, content, toc } =

--- a/apps/blog/app/series/[slug]/page.tsx
+++ b/apps/blog/app/series/[slug]/page.tsx
@@ -1,4 +1,4 @@
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
 import type { Metadata } from 'next';
 import { MDXRemote } from 'next-mdx-remote/rsc';
 import { getSeriesBySlug, getSeriesSlugs, getSeriesTranslation } from '@/lib/series';
@@ -135,6 +135,11 @@ export default async function SeriesItemPage({ params }: SeriesPageProps) {
 
   // Content exists but is in Chinese, not English
   if (series.lang === 'zh') {
+    // Check if there's an English translation we can redirect to
+    const enTranslation = getSeriesTranslation(slug, 'en');
+    if (enTranslation && enTranslation.slug !== slug) {
+      redirect(`/series/${enTranslation.slug}`);
+    }
     return <ChineseVersionAvailable />;
   }
 

--- a/apps/blog/app/zh/essays/[slug]/page.tsx
+++ b/apps/blog/app/zh/essays/[slug]/page.tsx
@@ -1,7 +1,7 @@
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
 import type { Metadata } from 'next';
 import { MDXRemote } from 'next-mdx-remote/rsc';
-import { getEssayBySlug, getEssaySlugsByLanguage, getTranslation } from '@/lib/essays';
+import { getEssayBySlug, getEssaySlugs, getTranslation } from '@/lib/essays';
 import { getMDXComponents } from '@/components/mdx/MDXComponents';
 import { mdxOptions } from '@/lib/mdx-options';
 import { EssayLayout, EssayHeader } from '@/components/essay';
@@ -11,10 +11,10 @@ interface ZhEssayPageProps {
 }
 
 /**
- * Generate static paths for all Chinese essays
+ * Generate static paths for all essays (handles both Chinese content and English-only redirects)
  */
 export async function generateStaticParams() {
-  const slugs = getEssaySlugsByLanguage('zh');
+  const slugs = getEssaySlugs();
   return slugs.map((slug) => ({ slug }));
 }
 
@@ -62,19 +62,84 @@ export async function generateMetadata({
 }
 
 /**
+ * Static preview of the language toggle dropdown
+ */
+function LanguageTogglePreview({ highlight }: { highlight: 'en' | 'zh' }) {
+  const CheckIcon = () => (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+
+  return (
+    <div className="mt-8 inline-block rounded-lg border border-border bg-ground-secondary p-6" aria-hidden="true">
+      <div className="inline-flex flex-col items-end">
+        {/* Trigger button */}
+        <div className="inline-flex items-center justify-center rounded-md p-2 min-w-[36px] text-sm font-medium bg-ground-tertiary text-figure-primary">
+          <span>中</span>
+        </div>
+        {/* Dropdown menu */}
+        <div className="mt-1 min-w-[120px] rounded-md border border-border bg-ground-primary p-1 shadow-lg">
+          <div className={`flex items-center justify-between gap-4 px-3 py-2 rounded-sm text-sm ${highlight === 'en' ? 'bg-ground-secondary' : ''}`}>
+            <span>English</span>
+            {highlight === 'en' && <CheckIcon />}
+          </div>
+          <div className={`flex items-center justify-between gap-4 px-3 py-2 rounded-sm text-sm ${highlight === 'zh' ? 'bg-ground-secondary' : ''}`}>
+            <span>中文</span>
+            {highlight === 'zh' && <CheckIcon />}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Component shown when content exists in English but not Chinese
+ */
+function EnglishVersionAvailable() {
+  return (
+    <div className="mx-auto max-w-2xl px-4 py-16 text-center">
+      <h1 className="type-h1 text-figure-primary mb-4">英文内容</h1>
+      <p className="type-body text-figure-secondary">
+        此文章为英文撰写。请使用页面顶部的语言切换按钮切换至英文。
+      </p>
+      <LanguageTogglePreview highlight="en" />
+    </div>
+  );
+}
+
+/**
  * Chinese essay page component
  */
 export default async function ZhEssayPage({ params }: ZhEssayPageProps) {
   const { slug } = await params;
   const essay = getEssayBySlug(slug);
 
+  // Content doesn't exist at all
   if (!essay) {
     notFound();
   }
 
-  // Ensure this is a Chinese essay
-  if (essay.lang !== 'zh') {
-    notFound();
+  // Content exists but is in English, not Chinese
+  if (essay.lang === 'en') {
+    // Check if there's a Chinese translation we can redirect to
+    const zhTranslation = getTranslation(slug, 'zh');
+    if (zhTranslation && zhTranslation.slug !== slug) {
+      redirect(`/zh/essays/${zhTranslation.slug}`);
+    }
+    return <EnglishVersionAvailable />;
   }
 
   const { title, description, date, type, topics, readingTime, content, toc } =

--- a/apps/blog/app/zh/periodics/[slug]/page.tsx
+++ b/apps/blog/app/zh/periodics/[slug]/page.tsx
@@ -1,4 +1,4 @@
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
 import type { Metadata } from 'next';
 import { MDXRemote } from 'next-mdx-remote/rsc';
 import { getPeriodicBySlug, getPeriodicSlugs, getPeriodicTranslation } from '@/lib/periodics';
@@ -134,6 +134,11 @@ export default async function ZhPeriodicPage({ params }: PeriodicPageProps) {
 
   // Content exists but is in English, not Chinese
   if (periodic.lang === 'en') {
+    // Check if there's a Chinese translation we can redirect to
+    const zhTranslation = getPeriodicTranslation(slug, 'zh');
+    if (zhTranslation && zhTranslation.slug !== slug) {
+      redirect(`/zh/periodics/${zhTranslation.slug}`);
+    }
     return <EnglishVersionAvailable />;
   }
 

--- a/apps/blog/app/zh/periodics/[slug]/page.tsx
+++ b/apps/blog/app/zh/periodics/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from 'next/navigation';
 import type { Metadata } from 'next';
 import { MDXRemote } from 'next-mdx-remote/rsc';
-import { getPeriodicBySlug, getPeriodicSlugsByLanguage, getPeriodicTranslation } from '@/lib/periodics';
+import { getPeriodicBySlug, getPeriodicSlugs, getPeriodicTranslation } from '@/lib/periodics';
 import { getMDXComponents } from '@/components/mdx/MDXComponents';
 import { mdxOptions } from '@/lib/mdx-options';
 import { EssayLayout } from '@/components/essay';
@@ -12,10 +12,10 @@ interface PeriodicPageProps {
 }
 
 /**
- * Generate static paths for all Chinese periodics
+ * Generate static paths for all periodics (handles both Chinese content and English-only redirects)
  */
 export async function generateStaticParams() {
-  const slugs = getPeriodicSlugsByLanguage('zh');
+  const slugs = getPeriodicSlugs();
   return slugs.map((slug) => ({ slug }));
 }
 
@@ -62,14 +62,79 @@ export async function generateMetadata({
 }
 
 /**
+ * Static preview of the language toggle dropdown
+ */
+function LanguageTogglePreview({ highlight }: { highlight: 'en' | 'zh' }) {
+  const CheckIcon = () => (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+
+  return (
+    <div className="mt-8 inline-block rounded-lg border border-border bg-ground-secondary p-6" aria-hidden="true">
+      <div className="inline-flex flex-col items-end">
+        {/* Trigger button */}
+        <div className="inline-flex items-center justify-center rounded-md p-2 min-w-[36px] text-sm font-medium bg-ground-tertiary text-figure-primary">
+          <span>中</span>
+        </div>
+        {/* Dropdown menu */}
+        <div className="mt-1 min-w-[120px] rounded-md border border-border bg-ground-primary p-1 shadow-lg">
+          <div className={`flex items-center justify-between gap-4 px-3 py-2 rounded-sm text-sm ${highlight === 'en' ? 'bg-ground-secondary' : ''}`}>
+            <span>English</span>
+            {highlight === 'en' && <CheckIcon />}
+          </div>
+          <div className={`flex items-center justify-between gap-4 px-3 py-2 rounded-sm text-sm ${highlight === 'zh' ? 'bg-ground-secondary' : ''}`}>
+            <span>中文</span>
+            {highlight === 'zh' && <CheckIcon />}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Component shown when content exists in English but not Chinese
+ */
+function EnglishVersionAvailable() {
+  return (
+    <div className="mx-auto max-w-2xl px-4 py-16 text-center">
+      <h1 className="type-h1 text-figure-primary mb-4">英文内容</h1>
+      <p className="type-body text-figure-secondary">
+        此文摘为英文撰写。请使用页面顶部的语言切换按钮切换至英文。
+      </p>
+      <LanguageTogglePreview highlight="en" />
+    </div>
+  );
+}
+
+/**
  * Chinese periodic page component
  */
 export default async function ZhPeriodicPage({ params }: PeriodicPageProps) {
   const { slug } = await params;
   const periodic = getPeriodicBySlug(slug);
 
+  // Content doesn't exist at all
   if (!periodic) {
     notFound();
+  }
+
+  // Content exists but is in English, not Chinese
+  if (periodic.lang === 'en') {
+    return <EnglishVersionAvailable />;
   }
 
   const { title, description, date, issue, type, topics, readingTime, content, toc } =

--- a/apps/blog/app/zh/series/[slug]/page.tsx
+++ b/apps/blog/app/zh/series/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from 'next/navigation';
 import type { Metadata } from 'next';
 import { MDXRemote } from 'next-mdx-remote/rsc';
-import { getSeriesBySlug, getSeriesSlugsByLanguage, getSeriesTranslation } from '@/lib/series';
+import { getSeriesBySlug, getSeriesSlugs, getSeriesTranslation } from '@/lib/series';
 import { getMDXComponents } from '@/components/mdx/MDXComponents';
 import { mdxOptions } from '@/lib/mdx-options';
 import { EssayLayout } from '@/components/essay';
@@ -12,10 +12,10 @@ interface SeriesPageProps {
 }
 
 /**
- * Generate static paths for all Chinese series
+ * Generate static paths for all series (handles both Chinese content and English-only redirects)
  */
 export async function generateStaticParams() {
-  const slugs = getSeriesSlugsByLanguage('zh');
+  const slugs = getSeriesSlugs();
   return slugs.map((slug) => ({ slug }));
 }
 
@@ -63,14 +63,79 @@ export async function generateMetadata({
 }
 
 /**
+ * Static preview of the language toggle dropdown
+ */
+function LanguageTogglePreview({ highlight }: { highlight: 'en' | 'zh' }) {
+  const CheckIcon = () => (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+
+  return (
+    <div className="mt-8 inline-block rounded-lg border border-border bg-ground-secondary p-6" aria-hidden="true">
+      <div className="inline-flex flex-col items-end">
+        {/* Trigger button */}
+        <div className="inline-flex items-center justify-center rounded-md p-2 min-w-[36px] text-sm font-medium bg-ground-tertiary text-figure-primary">
+          <span>中</span>
+        </div>
+        {/* Dropdown menu */}
+        <div className="mt-1 min-w-[120px] rounded-md border border-border bg-ground-primary p-1 shadow-lg">
+          <div className={`flex items-center justify-between gap-4 px-3 py-2 rounded-sm text-sm ${highlight === 'en' ? 'bg-ground-secondary' : ''}`}>
+            <span>English</span>
+            {highlight === 'en' && <CheckIcon />}
+          </div>
+          <div className={`flex items-center justify-between gap-4 px-3 py-2 rounded-sm text-sm ${highlight === 'zh' ? 'bg-ground-secondary' : ''}`}>
+            <span>中文</span>
+            {highlight === 'zh' && <CheckIcon />}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Component shown when content exists in English but not Chinese
+ */
+function EnglishVersionAvailable() {
+  return (
+    <div className="mx-auto max-w-2xl px-4 py-16 text-center">
+      <h1 className="type-h1 text-figure-primary mb-4">英文内容</h1>
+      <p className="type-body text-figure-secondary">
+        此系列为英文撰写。请使用页面顶部的语言切换按钮切换至英文。
+      </p>
+      <LanguageTogglePreview highlight="en" />
+    </div>
+  );
+}
+
+/**
  * Chinese series page component
  */
 export default async function ZhSeriesItemPage({ params }: SeriesPageProps) {
   const { slug } = await params;
   const series = getSeriesBySlug(slug);
 
+  // Content doesn't exist at all
   if (!series) {
     notFound();
+  }
+
+  // Content exists but is in English, not Chinese
+  if (series.lang === 'en') {
+    return <EnglishVersionAvailable />;
   }
 
   const { title, description, date, updated, category, topics, itemCount, readingTime, content, toc } =

--- a/apps/blog/app/zh/series/[slug]/page.tsx
+++ b/apps/blog/app/zh/series/[slug]/page.tsx
@@ -1,4 +1,4 @@
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
 import type { Metadata } from 'next';
 import { MDXRemote } from 'next-mdx-remote/rsc';
 import { getSeriesBySlug, getSeriesSlugs, getSeriesTranslation } from '@/lib/series';
@@ -135,6 +135,11 @@ export default async function ZhSeriesItemPage({ params }: SeriesPageProps) {
 
   // Content exists but is in English, not Chinese
   if (series.lang === 'en') {
+    // Check if there's a Chinese translation we can redirect to
+    const zhTranslation = getSeriesTranslation(slug, 'zh');
+    if (zhTranslation && zhTranslation.slug !== slug) {
+      redirect(`/zh/series/${zhTranslation.slug}`);
+    }
     return <EnglishVersionAvailable />;
   }
 

--- a/apps/blog/content/series/reading-digest-zh.mdx
+++ b/apps/blog/content/series/reading-digest-zh.mdx
@@ -15,42 +15,42 @@ itemCount: 22
 <EditorialSection variant="card">
   <Item
     title="Digest 022"
-    href="/periodics/digest-022"
+    href="/zh/periodics/digest-022"
     description="Dropbox架构演进、Facebook数据损坏检测"
   />
   <Item
     title="Digest 021"
-    href="/periodics/digest-021"
+    href="/zh/periodics/digest-021"
     description="分布式系统容错、Facebook快速修复机制"
   />
   <Item
     title="Digest 020"
-    href="/periodics/digest-020"
+    href="/zh/periodics/digest-020"
     description="SSH隧道可视化、项目架构文档ARCHITECTURE.md"
   />
   <Item
     title="Digest 019"
-    href="/periodics/digest-019"
+    href="/zh/periodics/digest-019"
     description="John Hopfield自述、SLO实践指南"
   />
   <Item
     title="Digest 018"
-    href="/periodics/digest-018"
+    href="/zh/periodics/digest-018"
     description="Dijkstra传记、好主意与好business的差别"
   />
   <Item
     title="Digest 017"
-    href="/periodics/digest-017"
+    href="/zh/periodics/digest-017"
     description="Javascript 2020现状、机器学习的停滞与发展"
   />
   <Item
     title="Digest 016"
-    href="/periodics/digest-016"
+    href="/zh/periodics/digest-016"
     description="DALL·E文本生成图像、分布式支付系统设计"
   />
   <Item
     title="Digest 015"
-    href="/periodics/digest-015"
+    href="/zh/periodics/digest-015"
     description="SLO推广实践、Netflix管理哲学、微服务与单体服务"
   />
 </EditorialSection>
@@ -62,72 +62,72 @@ itemCount: 22
 <EditorialSection variant="card">
   <Item
     title="Digest 014"
-    href="/periodics/digest-014"
+    href="/zh/periodics/digest-014"
     description="现金流管理、股票期权指南、AI发展的局限性"
   />
   <Item
     title="Digest 013"
-    href="/periodics/digest-013"
+    href="/zh/periodics/digest-013"
     description="最小64位Hello World、NASA项目经理经验、Stripe API演化"
   />
   <Item
     title="Digest 012"
-    href="/periodics/digest-012"
+    href="/zh/periodics/digest-012"
     description="苏联计算机历史、甜甜圈大王创业故事、FTC起诉Facebook"
   />
   <Item
     title="Digest 011"
-    href="/periodics/digest-011"
+    href="/zh/periodics/digest-011"
     description="AlphaFold蛋白质结构突破、FFT算法讲解、浮点数差异"
   />
   <Item
     title="Digest 010"
-    href="/periodics/digest-010"
+    href="/zh/periodics/digest-010"
     description="Roblox八年经历、配色系统设计、COBOL代码库困境"
   />
   <Item
     title="Digest 009"
-    href="/periodics/digest-009"
+    href="/zh/periodics/digest-009"
     description="Micromanagement的危害、欧洲脑计划仲裁报告、招股书分析"
   />
   <Item
     title="Digest 008"
-    href="/periodics/digest-008"
+    href="/zh/periodics/digest-008"
     description="Baremetrics出售故事、README驱动开发、系统复杂度守恒"
   />
   <Item
     title="Digest 007"
-    href="/periodics/digest-007"
+    href="/zh/periodics/digest-007"
     description="Facebook推广QUIC协议、Geoff Hinton访谈、文字排版"
   />
   <Item
     title="Digest 006"
-    href="/periodics/digest-006"
+    href="/zh/periodics/digest-006"
     description="危险确认设计、职业成长反思、CRDT实时协作算法"
   />
   <Item
     title="Digest 005"
-    href="/periodics/digest-005"
+    href="/zh/periodics/digest-005"
     description="Bret Victor可探索编程、写作的价值、Stripe API版本管理"
   />
   <Item
     title="Digest 004"
-    href="/periodics/digest-004"
+    href="/zh/periodics/digest-004"
     description="创业公司失败率分析、Bret Victor魔法演示、Github Action"
   />
   <Item
     title="Digest 003"
-    href="/periodics/digest-003"
+    href="/zh/periodics/digest-003"
     description="SaaS创业百万ARR、工资谈判策略、软件考古学"
   />
   <Item
     title="Digest 002"
-    href="/periodics/digest-002"
+    href="/zh/periodics/digest-002"
     description="MIT核聚变研究、字体渲染复杂性、斗鱼字体反爬攻防"
   />
   <Item
     title="Digest 001"
-    href="/periodics/digest-001"
+    href="/zh/periodics/digest-001"
     description="鸟类大脑皮层、社会语言学家生涯、Snowflake上市分析"
   />
 </EditorialSection>

--- a/apps/blog/content/series/vision-100-zh.mdx
+++ b/apps/blog/content/series/vision-100-zh.mdx
@@ -5,6 +5,7 @@ date: "2017-03-26"
 category: "bibliography"
 topics: [science]
 lang: "zh"
+translationOf: "vision-100"
 itemCount: 100
 ---
 


### PR DESCRIPTION
## Summary
- Fix reading-digest-zh.mdx links to use `/zh/periodics/` path instead of `/periodics/`
- Add language mismatch fallback pages for periodics:
  - English path with Chinese content shows "Content in Chinese" message
  - Chinese path with English content shows "英文内容" message
- Include visual preview of language toggle to help users understand how to switch languages
- Generate static paths for all periodics to support fallback pages

## Test plan
- [ ] Visit `/periodics/digest-001` - should show "Content in Chinese" with language toggle preview
- [ ] Visit `/zh/periodics/digest-001` - should show the actual Chinese content
- [ ] Visit `/zh/series/reading-digest-zh` - links should point to `/zh/periodics/...`
- [ ] Language toggle in header should redirect correctly when clicked

🤖 Generated with [Claude Code](https://claude.com/claude-code)