### PR TITLE
Add essay: The Era of Decision Games

### DIFF
--- a/apps/blog/components/mdx/MDXComponents.tsx
+++ b/apps/blog/components/mdx/MDXComponents.tsx
@@ -259,6 +259,7 @@ export function getMDXComponents(): MDXComponentMap {
     WideBlock,
 
     // UI components exposed to MDX
+    Blockquote,
     Callout,
     Badge,
     Figure,

--- a/apps/blog/content/essays/decision-game.mdx
+++ b/apps/blog/content/essays/decision-game.mdx
@@ -1,0 +1,120 @@
+---
+title: 'The Era of Decision Games'
+description: "As AI agents handle execution, human work shifts to decision-making. Everyone says AI will take your job. They're wrong. It will take your tasks—and leave you with something harder: the decisions."
+date: '2026-02-08'
+type: opinion
+topics:
+  - technical
+  - ai
+lang: en
+---
+
+Picture this: you ask an agent to "clean up one endpoint." Ten minutes later it has touched dozens of files, rewritten authentication logic, updated tests, and asks one final question: _"Do you want the safer version, or the faster version?"_
+
+That is the new bottleneck. Not typing. Not building. Deciding.
+
+2026 kicked off with an explosion of autonomous AI agents, closer to Jarvis than ever, as they came alive on people's computers. The launch of [OpenClaw](https://github.com/openclaw/openclaw) has introduced millions of "Clawds" that run across various platforms, from MacMini and PC boxes to Raspberry Pi, and quickly spawned a wave of variants, [NanoClaw](https://github.com/qwibitai/nanoclaw), [PicoClaw](https://github.com/sipeed/picoclaw), and [IronClaw](https://github.com/nearai/ironclaw). Simultaneously, major Foundational Models—such as Claude, GPT, and Kimi—have become more agentic than ever, fundamentally incorporating [Agent Swarm](https://www.marktechpost.com/2026/01/27/moonshot-ai-releases-kimi-k2-5-an-open-source-visual-agentic-intelligence-model-with-native-swarm-execution/) or Agent Team capabilities.
+
+This is, in many ways, the natural culmination of 2025, which, thanks to the AI community's collective efforts, lived up to its promise as the year of AI agents. With products like Manus, Claude Code, and OpenClaw demonstrating advanced autonomy, such as navigating environments, managing cross-application logic, and self-correcting, **execution fundamentally transforms into a zero-marginal-cost commodity**.
+
+In this new era, deploying thousands of 'digital specialists' renders the ability to build, code, or execute tasks no longer a key challenge or competitive advantage. **Many people say AI will take your job. They're wrong. It will take your tasks, and leave you with something harder: making the decisions.**
+
+<Blockquote variant="pullquote">
+
+AI is commoditizing execution. What remains scarce, and what will define this coming era, is the quality of human decision-making.
+
+</Blockquote>
+
+## The Decision Game
+
+The paradigm shift first started within software development. The entire industry is on an unstoppable trajectory of change, moving away from manual coding entirely.
+
+The shift happened in a mere three years. Developers moved from copying and pasting code from ChatGPT in 2023 to relying on Cursor's effective autocomplete by mid-2024. This quickly accelerated to accepting batched changes from agents like Cursor Agent, and finally, with the arrival of Claude Code, they stopped writing any line of code entirely, and stepped into a true point of no return for the profession.
+
+This acceleration exposes a critical mismatch between Computer Science education and the new demands of the developer job. **For years, the old game was to learn craft**, mastering basic algorithms and practicing competitive coding like LeetCode. Now, a single prompt can generate high-quality implementations of most algorithms and data structures. **The new challenge, and the new game, is judgment**: deciding the right way to prompt an AI to get a working version of the Ford–Fulkerson algorithm to solve the maximum volume of traffic a city's road network can handle.
+
+While coding agents empowered everyone to write software more productively, veteran developers achieve 10x-100x quality and speed not just by coding, but by making superior design decisions, feature choices, architecture, and tradeoffs. The proof is in the products: Manus was built by seasoned engineers from the Chinese AI ecosystem, Lovable was created by experienced designers who understood what users actually need, and even OpenClaw traces back to veteran developers with deep systems expertise. The breakout successes come from people who already knew what to build—agents just let them build it faster.
+
+This trend is spreading beyond software. Agents like [Shortcut AI](https://shortcut.ai/) (spreadsheets, [already stirring controversy at the Excel World Championship](https://www.datarails.com/excel-world-championship-2025/#:~:text=Controversy%3A%20Enter%20the%20AI%20Overlords)), [Claude Cowork](https://claude.com/blog/cowork-research-preview) (knowledge work), [Manus](https://manus.im/) (general-purpose agent), and [Composer](https://trycomposer.ai/) (browser automation) are entering various fields.
+
+This shift elevates human effort from the low-level mechanics of execution to the high-level art of orchestration and decision making. In the recent documentary [*The Thinking Game*](https://blog.google/technology/google-deepmind/the-thinking-game/), Demis Hassabis describes the pursuit of AGI as exactly that — a thinking game.
+
+Now, when the AGI is approaching our daily life, how to leverage, orchestrate, and use the intelligence machine is a Decision game.
+
+**The pursuit of AGI is the Thinking Game. The mastery of AGI will be the Decision Game.**
+
+## Winning the Decision Game
+
+For decades, certain industries have cultivated decision-making skills, giving rise to the discipline of Decision Science. However, quality training in this area has historically been limited to privileged groups or specific professions, not widely available.
+
+Consider the world of hedge funds and trading firms, for example. The lore is filled with tales of legendary traders who made significant, profitable bets. These individuals might not be the most technically proficient; they often hire software engineers and analysts for tasks like data collection and analysis. Yet, because the trader ultimately makes the critical market decision, they claim the largest share of the profit.
+
+This exclusivity is changing. The era of decision-making being the sole privilege of traders or leaders is ending. In the coming years, everyone will have their own "agents" to execute tasks, leading to widespread efficiency gains.
+
+<Blockquote variant="pullquote">
+
+Efficiency without a sense of direction is merely high-speed entropy.
+
+</Blockquote>
+
+### What makes one a good decision maker?
+
+The core elements of effective decision-making are:
+
+- **Intuition**: The heuristic power to select the optimal path from a multitude of independent options, particularly when data is unclear and the consequences are significant.
+- **Taste**: The capacity to define what constitutes an "excellent" outcome even when the goalposts are in flux.
+- **Knowledge**: Deep, specialized understanding of the domain essential for making informed decisions.
+
+An obsession with finding a "secret sauce" to becoming a superior decision-maker is a common pitfall. It mirrors the tendency to idolize successful people, suggesting they possess some mysterious, innate quality. As a cognitive psychologist, I believe this notion is vastly overblown. While certain heuristics are difficult to articulate, the capacity for good judgment is absolutely trainable.
+
+### Deep Knowledge is the True Foundation
+
+A critical, often overlooked, element is deep knowledge. Highly effective decision-makers, such as successful market traders, first gain an intimate understanding of the market, its structure, and its participants before forming any insights. This profound knowledge allows them to make sound decisions even when faced with new, imperfect, or partial information.
+
+In stark contrast, leaders lacking deep knowledge are easily manipulated by subordinates, leading to poor decisions. Consider the case of Meta and Mark Zuckerberg's decision-making regarding LLM talent, which contributed to the failure of LLAMA 4. Now, contrast this with the foundational success of DeepMind's Demis Hassabis, Anthropic, early OpenAI, and even Elon Musk’s XAI. **If your goal is to develop excellent "taste" and form solid judgment, deep knowledge is the non-negotiable foundation.**
+
+### Acquiring Deep Knowledge is More Accessible Than Ever
+
+Gaining deep knowledge is simpler now than at any point in history. It only requires focused, diligent study. You must actively seek out all available resources to educate yourself. There is no hidden, mystical knowledge about human nature or the world that cannot be learned.
+
+The current generation of tools, especially Large Language Models (LLMs) and agents, are the best teachers available. They are knowledgeable, infinitely patient, and will never hesitate to encourage you, "you are absolutely right."
+
+Therefore, the most effective strategy for improving decision-making is to intentionally cultivate a learning environment and a robust feedback loop: **Make a decision, observe the outcome, update your judgment, learn new knowledge, and make decisions again.**
+
+## Toward a Society of Better Decision-Makers
+
+The advancement of AI should benefit everyone, improving the lives of all people, rather than being confined to a privileged elite or a small Silicon Valley circle. There is vast potential to build and innovate using the power of AI.
+
+### More Environments for Agents
+
+The digital world currently limits AI agents. Existing infrastructure is built for rigid, programmatic systems or human interaction, leaving agents, a new digital "species" that consumes information and acts within the digital world, constrained. While AI intelligence (the "brain") is advancing steadily and rapidly, the environment enabling its full potential remains underdeveloped. The long-standing dominance of the human-to-AI chatbot model is outdated, feeling like a relic from the 1960s, offering little innovation beyond systems like Eliza.
+
+Consequently, a significant focus in new software development must shift to creating supportive environments _for_ these agents. This will allow them to automate more tasks for humans and continue to drive down execution costs.
+
+### The Human Interface that improves decision making quality
+
+As AI Agents become exponentially more efficient, the critical challenge shifts to the Human-Agent Interface. Since agents can generate content 100 times faster than a person can consume and verify it, and human consumption speed increases very slowly, traditional interfaces are destined to fail. This imbalance will only lead to human exhaustion and force people to serve the AI, resulting in a dystopian outcome.
+
+Therefore, superior interface design must offer human affordance. In this new era, the primary affordance is empowering humans to make decisions more easily and effectively.
+
+What would such an interface look like? I believe it must do five things well:
+
+- **Surface only the essential decisions** — resolve the trivial ones autonomously, and present the human with the choices that actually matter.
+- **Be transparent and auditable** — give even non-technical users a clear trail of every decision made.
+- **Provide robust guardrails** — self-correction mechanisms that catch errors before they compound.
+- **Communicate confidence honestly** — so users know when the agent is certain and when it is guessing.
+- **Support contingency thinking** — the ability to roll back a faulty decision, or to explore "what if" branches before committing.
+
+Above all, the interface should be designed to optimize decision-making, not task execution. As agents mature and earn trust, the interface should simplify. The intricate details will only matter for debugging, not for daily use.
+
+## An Invitation to the New Era
+
+In 1959, John McCarthy envisioned a system called the Advice Taker in his paper, "[Programs with Common Sense](https://www-formal.stanford.edu/jmc/mcc59.pdf)."<Note>McCarthy, J. (1959). Programs with Common Sense. *Proceedings of the Teddington Conference on the Mechanization of Thought Processes*, pp. 75–91. This paper is widely considered the first proposal to use logic for knowledge representation in a computer program.</Note> Instead of detailed, step-by-step programming, the Advice Taker would operate by accepting declarative facts and rules as initial knowledge, then using logical deduction to determine the necessary course of action. Its function was to take a goal and relevant information and autonomously reason through the intermediate steps—mirroring how a person processes advice to decide what to do.
+
+That concept is now a reality. While not a formal logic engine as McCarthy described, the spirit of the Advice Taker lives on in modern systems. These technologies take your intention, knowledge, and judgment and translate them into action, handling the intermediate reasoning, execution, and difficult labor on their own.
+
+The new focus shifts to us. The challenge is to provide superior "advice", to infuse these machines with the taste, judgment, and deep knowledge they cannot yet generate. This is how we ensure that our lives, and the lives of future generations, are not just more productive, but profoundly more human.
+
+I invite you to step into this decision game as a builder, a thinker, and a decision-maker. Learn deeply, decide deliberately, and use agents as force multipliers for what you believe should exist.
+
+Your decisions are now the product.

--- a/apps/blog/content/essays/job-search-reflection.mdx
+++ b/apps/blog/content/essays/job-search-reflection.mdx
@@ -6,6 +6,7 @@ type: narrative
 topics:
   - career
 lang: en
+draft: true
 ---
 
 After several successful and unsuccessful research and internship experiences, I think I want a position that has the following general features:

--- a/apps/blog/content/essays/offer-negotiation.mdx
+++ b/apps/blog/content/essays/offer-negotiation.mdx
@@ -6,6 +6,7 @@ type: guide
 topics:
   - career
 lang: en
+draft: true
 ---
 
 When it comes to negotiating job offers, there are several key resources and principles that can make a significant difference in the outcome. Here's a distillation of the most important lessons.

--- a/apps/blog/content/essays/shortcut-agent-making-of.mdx
+++ b/apps/blog/content/essays/shortcut-agent-making-of.mdx
@@ -1,0 +1,35 @@
+---
+title: "The Making of Shortcut Agent — How It Starts"
+description: "A behind-the-scenes look at the planning and thinking that goes into building an AI agent project, before a single line of code is written."
+date: "2026-02-08"
+type: narrative
+topics:
+  - technical
+  - ai
+lang: en
+draft: true
+---
+
+[Shortcut AI](https://shortcut.ai/) is a best spreadsheet AI agent who completes tedious, time-consuming tasks within a spreadsheet for you, so you can focus on making wise business decisions, develop insights into the market, or simply enjoy more time with your family instead of bending your head against Excel workbooks. We offer five different products where you can meet the AI near the sheet: A [Web Application](), A [Desktop Application](), A [Microsoft Excel Add-In](), A [Google Sheet Add-in], and an [Service API].
+
+Starting from today, I will share behind-the-scenes stories about the journey of building Shortcut AI, including the products we have built and failed before, the research we conducted, and the lessons we learned along the way.
+
+(the ideas is how we end up with the final product and what have we tried.)
+
+# Encountering the Spreadsheet Problem
+
+# Data versus Environment 
+
+## Why `openpyxl`, `pandas`, and simply python libaries are not enough
+
+# Going to the Real World
+
+## Application Automation: AppleScript and COM API
+
+## Competing the control with Users
+
+# Breaking into the Sheet Environment: Getting the APIs
+
+# Extracting the "Brain" out of the Sheet Environment
+
+To enable the brain orchestrating way more environments.

--- a/apps/blog/lib/essays.ts
+++ b/apps/blog/lib/essays.ts
@@ -37,13 +37,25 @@ export interface GetEssaysOptions {
  * Returns slugs from .mdx files, excluding:
  * - Files starting with underscore (e.g., _template.mdx)
  * - Non-.mdx files
+ * - Draft essays (in production)
  */
-export function getEssaySlugs(): string[] {
+export function getEssaySlugs(options: { includeDrafts?: boolean } = {}): string[] {
+  const { includeDrafts = process.env.NODE_ENV === 'development' } = options;
+
   try {
     const files = fs.readdirSync(ESSAYS_DIRECTORY);
-    return files
+    const slugs = files
       .filter((file) => file.endsWith('.mdx') && !file.startsWith('_'))
       .map((file) => file.replace(/\.mdx$/, ''));
+
+    if (includeDrafts) {
+      return slugs;
+    }
+
+    return slugs.filter((slug) => {
+      const meta = getEssayMeta(slug);
+      return meta && !meta.draft;
+    });
   } catch {
     // Directory doesn't exist yet
     return [];
@@ -62,7 +74,7 @@ export function getAllEssays(options: GetEssaysOptions = {}): EssayMeta[] {
     language,
   } = options;
 
-  const slugs = getEssaySlugs();
+  const slugs = getEssaySlugs({ includeDrafts: true });
   const essays: EssayMeta[] = [];
 
   for (const slug of slugs) {
@@ -89,9 +101,10 @@ export function getAllEssays(options: GetEssaysOptions = {}): EssayMeta[] {
 /**
  * Get a single essay by slug (with full content)
  *
- * Returns null if essay doesn't exist.
+ * Returns null if essay doesn't exist or is a draft in production.
  */
-export function getEssayBySlug(slug: string): Essay | null {
+export function getEssayBySlug(slug: string, options: { includeDrafts?: boolean } = {}): Essay | null {
+  const { includeDrafts = process.env.NODE_ENV === 'development' } = options;
   const filePath = path.join(ESSAYS_DIRECTORY, `${slug}.mdx`);
 
   if (!fs.existsSync(filePath)) {
@@ -103,6 +116,11 @@ export function getEssayBySlug(slug: string): Essay | null {
 
   try {
     const frontmatter = validateFrontmatter(data);
+
+    if (!includeDrafts && frontmatter.draft) {
+      return null;
+    }
+
     const stats = readingTime(content);
     // Extract table of contents from h2 and h3 headings
     const toc = extractHeadings(content, { minLevel: 2, maxLevel: 3 });

--- a/plan/essay/building_agent/SERIES_PLAN.md
+++ b/plan/essay/building_agent/SERIES_PLAN.md
@@ -1,0 +1,291 @@
+# Building AI Agents: Essay Series Plan
+
+A series of essays reflecting on LLM-based agent development, from conceptual foundations to human implications.
+
+## Series Thesis
+
+The shift from traditional RL-style agents to LLM-based agents represents not just a technical change, but a fundamental reorientation: from engineering intelligent internal systems that act outward, to engineering contexts that bring the external world inward. This reorientation has profound implications for how agents work, how we build them, and how humans collaborate with them.
+
+---
+
+## Essay Structure
+
+### Foundation Layer
+
+#### Essay 1: Two Paradigms of Agent Building
+**Status:** To brainstorm
+**Core thesis:** There are two mental models for building agents—the RL tradition (outward: planning systems that act on environments) and the LLM-era approach (inward: context engineering that brings environments into the model). These were competing; now converging. The empirical evidence suggests: keep agent internals simple, let the LLM handle complexity.
+
+**Opens with:** What is an agent? (Establish working definition before diving into paradigms)
+
+**Key tensions to explore:**
+- Outward direction: equip agent "brain" with planning components (like autonomous vehicles)
+- Inward direction: build tools/retrieval to populate context (context engineering)
+- Why overcomplicating agent internals gets obsoleted by next LLM release
+- The convergence: even RL-influenced approaches now emphasize context
+
+**References to incorporate:**
+- Anthropic's guidance on avoiding "overly brittle hardcoded logic"
+- The "Goldilocks zone" principle
+- Historical examples of over-engineered agent architectures
+
+---
+
+### Mechanics Layer
+
+#### Essay 2: Context Engineering—The New Core Skill
+**Status:** To brainstorm
+**Core thesis:** Context engineering is the practice of curating and maintaining the optimal set of tokens during LLM inference. It is now the primary engineering challenge for agent builders. "Most agent failures are context failures, not model failures."
+
+**Key concepts to cover:**
+- The 4 patterns: Write, Select, Compress, Isolate
+- Context as finite resource with diminishing returns
+- Karpathy's analogy: LLM = CPU, context window = RAM
+- Just-in-time retrieval vs. upfront loading
+- Sub-agent architectures for context isolation
+
+**References:**
+- Anthropic: "Effective Context Engineering for AI Agents"
+- LangChain: "Context Engineering for Agents" (Lance Martin)
+- The ACE framework (arxiv:2510.04618)
+
+---
+
+#### Essay 3: Context as Program
+**Status:** To brainstorm
+**Core thesis:** The LLM context window is not just data—it is a program being executed. We are "context programming," not just context engineering. This frame reveals what tooling we lack.
+
+**Key ideas:**
+- REPL analogy: each turn is Read-Eval-Print
+- The context IS the program (tokens = instructions + data)
+- What programming tools we take for granted but lack for context:
+  - Version control (track context evolution)
+  - Debuggers (inspect why model behaved a certain way)
+  - Refactoring tools (restructure context systematically)
+  - Composable abstractions (reusable context patterns)
+  - Type systems (schemas for context structure)
+- Google ADK insight: "Context is a compiled view over a richer stateful system"
+
+**Questions to explore:**
+- What would a "context IDE" look like?
+- How do we version and diff contexts?
+- What are the "functions" and "variables" of context programming?
+
+---
+
+#### Essay 4: The Language Layer—Hypothesis-Driven Problem Solving
+**Status:** To brainstorm
+**Core thesis:** A new model of problem-solving with software systems. Intelligence no longer resides in code (durable, rigid artifacts); it resides in language (fluid, regenerable intent). Natural language becomes the layer where humans express hypotheses, and code becomes ephemeral verification—generated, tested, discarded, regenerated.
+
+**The paradigm shift:**
+```
+Traditional:  Human → writes code → code executes → result
+              (solution lives in CODE)
+
+New:          Human → expresses idea in language → agent generates code →
+              code tests hypothesis → result informs next hypothesis
+              (solution lives in LANGUAGE)
+```
+
+**Key insight:** This is not just "flexibility"—it's a fundamental change in where intelligence resides:
+- Old: Intelligence crystallized in code (durable, rigid)
+- New: Intelligence expressed in language (fluid, regenerable)
+
+**The spectrum (practical view):**
+```
+Most Rigid                                          Most Flexible
+    |                                                      |
+    v                                                      v
+Stored procedures → Retrieval of code → Language → Language +
+(execute fixed)     (retrieve & adapt)   (generate)   dynamic tool use
+```
+
+**Key analogies from CS:**
+- Early vs. late binding in OOP
+- Compile-time vs. runtime resolution
+- JIT compilation: compile at execution time based on context
+- Stored procedures vs. dynamic SQL
+
+**ARC2 observations (to describe abstractly):**
+- Natural language as hypothesis space
+- Code as verification/execution layer
+- Storing ideas (flexible) vs. storing code (rigid)
+- Why language-level retrieval beats code-level retrieval for adaptability
+
+**Trade-offs:**
+- Late binding: flexible but requires generation, potential variability
+- Early binding: rigid but predictable, cacheable
+- When to choose which point on the spectrum
+
+**Questions to explore:**
+- What does "code as ephemeral verification" mean for software engineering?
+- How does this change what we store, version, and maintain?
+- What are the implications for knowledge management in organizations?
+
+---
+
+### Implications Layer
+
+#### Essay 5: The Decision Game
+**Status:** To brainstorm
+**Core thesis:** (Prescriptive) As agents handle execution, human work shifts to decision-making: what should the agent do? Has it done well? Is the quality sufficient? App developers should design systems that empower users to play this game well.
+
+**Key observations:**
+- Daily work becomes: design decisions, quality assessment, technology choices
+- Parallel to DeepMind's "The Thinking Game" (developing AI) → "The Decision Game" (using AI)
+- Not writing code line-by-line, but steering, judging, selecting
+
+**Implications for individuals:**
+- What skills to cultivate (judgment, evaluation, domain expertise)
+- What becomes less valuable (rote execution)
+- The new leverage: good decisions compound through agent execution
+
+**Implications for app developers:**
+- Design for decision-making, not just task execution
+- Surface the right information for human judgment
+- Make agent reasoning inspectable
+- Allow appropriate human intervention points
+
+**Questions to explore:**
+- What does "good decision-making" look like in human-agent collaboration?
+- How do we develop decision-making skills?
+- What interfaces support the decision game?
+
+---
+
+#### Essay 6: Future of Human-Agent Interaction (HCI Brainstorm)
+**Status:** To brainstorm — pick one or combine several topics
+**Core thesis:** TBD — select from candidates below
+
+**Candidate Topics:**
+
+**A. The Collaboration Spectrum**
+- From "tool" (human drives) to "collaborator" (turn-taking) to "delegate" (agent drives)
+- When to use which mode? How to switch fluidly?
+- Interface patterns for each mode
+- The grammar of human-agent turn-taking
+
+**B. Trust Calibration**
+- How do users develop appropriate trust (not over-trust, not under-trust)?
+- What makes agent behavior predictable/trustable?
+- Transparency vs. cognitive load trade-off
+- The danger of anthropomorphization
+- Designing for calibrated trust
+
+**C. The Autonomy Dial**
+- Fully manual ↔ fully autonomous: where to set it?
+- Context-dependent autonomy (high-stakes vs. routine)
+- User control over the autonomy level
+- Dynamic autonomy: systems that adjust based on confidence
+
+**D. Skill Transformation**
+- What human skills become more valuable? (judgment, domain expertise, evaluation)
+- What becomes less valuable? (rote execution, syntax knowledge)
+- How do we educate for this shift?
+- The new shape of expertise
+
+**E. Error Recovery Patterns**
+- How users detect agent mistakes
+- How to design for graceful correction
+- The "undo" problem in agentic systems
+- Verification without re-doing the work
+
+**F. Mental Model Design**
+- Users need accurate mental models of agent capabilities
+- How to communicate what agents can/cannot do
+- Progressive disclosure of agent reasoning
+- The explanation problem: when does explanation help vs. overwhelm?
+
+**Open question:** Which of these becomes Essay 6? Or should multiple become Essays 6, 7, 8...?
+
+---
+
+## Potential Additional Essays
+
+### Essay 2.5: Trust and Verification
+**Status:** Consider adding
+**Purpose:** Bridge between mechanics (how agents work) and implications (human role). How do we know the agent did a good job? Connects to the decision game but may deserve standalone treatment. (Note: overlaps with HCI candidate B above)
+
+---
+
+## Ordering Rationale
+
+The series builds **bottom-up**:
+
+1. **Two Paradigms** — Opens with "what is an agent?" then establishes the conceptual landscape. Reader understands the historical context and why we think about agents the way we do now.
+
+2. **Context Engineering** — Dives into the "inward direction" paradigm. Reader understands the practical challenges and solutions.
+
+3. **Context as Program** — Deepens the conceptual model. Reader sees context not as static data but as dynamic program, revealing what tooling we lack.
+
+4. **The Language Layer** — Proposes a new model of problem-solving: intelligence resides in language, code is ephemeral verification. Reader understands a paradigm shift in how humans and software systems collaborate.
+
+5. **Decision Game** — Zooms out to human implications. Reader understands what this means for their work and skills. (Prescriptive: this is where we should go.)
+
+6. **Future HCI** — Explores broader implications for human-agent interaction. (Topic TBD from candidates.)
+
+Each essay builds on the previous:
+- Essay 2 requires understanding from Essay 1 (why context engineering is the focus)
+- Essay 3 requires Essay 2 (deepens the context concept)
+- Essay 4 requires Essay 2-3 (builds on context to propose new problem-solving model)
+- Essay 5 requires Essay 4 (why decisions matter when language drives execution)
+- Essay 6 requires Essay 5 (broader HCI implications beyond the decision game)
+
+---
+
+## Cross-References
+
+| Essay | Builds On | Sets Up |
+|-------|-----------|---------|
+| 1. Two Paradigms | — | All subsequent essays |
+| 2. Context Engineering | 1 (why inward) | 3, 4 (context details) |
+| 3. Context as Program | 2 (what context is) | 4 (programming metaphor) |
+| 4. The Language Layer | 2, 3 (context + program) | 5 (why decisions matter) |
+| 5. Decision Game | 4 (language-driven execution) | 6 (broader HCI) |
+| 6. Future HCI | 5 (decision-making role) | — |
+
+---
+
+## Open Questions for the Series
+
+1. **ARC2 handling:** How abstractly to describe? What details can be shared?
+
+2. **Trust/Verification essay:** Should this be standalone (Essay 2.5) or folded into Decision Game or Essay 6?
+
+3. **Practical examples:** What concrete agent systems to reference throughout?
+
+4. **Essay 6 topic:** Which HCI candidate(s) to develop? Or expand into multiple essays?
+
+5. **Target length:** ~2000 words per essay (8-10 min read) — expand only if topic demands
+
+---
+
+## Key Sources
+
+### Context Engineering
+- [Anthropic: Effective Context Engineering for AI Agents](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents)
+- [Lance Martin: Context Engineering for Agents](https://rlancemartin.github.io/2025/06/23/context_engineering/)
+- [LangChain: The Rise of Context Engineering](https://blog.langchain.com/the-rise-of-context-engineering/)
+- [LangChain: Context Engineering for Agents](https://blog.langchain.com/context-engineering-for-agents/)
+- [ACE Framework (arxiv:2510.04618)](https://arxiv.org/abs/2510.04618)
+
+### Late Binding / Software Design
+- [Wikipedia: Late Binding](https://en.wikipedia.org/wiki/Late_binding)
+- [ResearchGate: Describing Binding Time in Software Design Patterns](https://www.researchgate.net/publication/313738165_Describing_binding_time_in_software_design_patterns)
+
+### To Research
+- DeepMind "The Thinking Game" documentary
+- Historical RL-based agent architectures (for contrast)
+- Specific over-engineered agent systems that were obsoleted
+
+---
+
+## Next Steps
+
+1. [x] Fold "What is an agent?" into Essay 1 (done)
+2. [x] Rename Essay 4 to "The Language Layer" with new framing (done)
+3. [x] Add Essay 6 HCI candidates for brainstorming (done)
+4. [ ] Brainstorm Essay 1: Two Paradigms — gather concrete examples of RL-style vs LLM-era agents
+5. [ ] Outline the ARC2 observations for Essay 4 (abstract form)
+6. [ ] Decide on Essay 6 topic from candidates
+7. [ ] Decide on Trust/Verification as standalone or integrated

--- a/plan/essay/building_agent/essay1_two_paradigms.md
+++ b/plan/essay/building_agent/essay1_two_paradigms.md
@@ -1,0 +1,242 @@
+# Essay 1: Two Paradigms of Agent Building
+
+## Status
+Brainstorming
+
+## Target
+~2000 words (8-10 min read)
+
+## Audience
+Agent developers, or people planning to develop AI agents
+
+---
+
+## Brainstorming
+
+### The Two Paradigms
+
+**Paradigm 1: The Cognition-Less Robot (RL Tradition)**
+
+The agent is a system that must learn or be programmed to behave intelligently. Intelligence is something you BUILD INTO the agent.
+
+Historical lineage:
+- Classic RL: Markov Decision Process, agent-environment loop
+  - State → Agent → Action → Environment → Reward → State...
+  - Agent's job: learn a policy π(s) → a that maximizes reward
+- Deep RL: Neural networks as function approximators (DQN, A3C, PPO)
+  - The "brain" is a trained neural network
+  - Still: intelligence must be trained into the agent
+- OpenAI Gym (2016): Standardized interface for agent-environment interaction
+  - `env.reset()`, `env.step(action)`, `observation, reward, done, info`
+  - The agent is a black box that receives observations and outputs actions
+- Self-driving cars: Perception → Planning → Control pipeline
+  - Multiple modules: object detection, path planning, motion control
+  - The "intelligence" is distributed across engineered subsystems
+
+**Key characteristic:** The agent's internal architecture determines its capabilities. If you want smarter behavior, you must build better internals (better perception, better planning, better policy).
+
+**Direction:** Outward — the agent acts ON the environment
+
+---
+
+**Paradigm 2: The Cognition-Equipped Collaborator (LLM-Native)**
+
+The agent already has intelligence (the LLM). The engineering challenge is getting the right information INTO the model's context.
+
+Key developments:
+- LLMs as general-purpose reasoners (GPT-3, GPT-4, Claude)
+  - The model already "knows how to think"
+  - No training required for new tasks—just prompting
+- Tool use / function calling
+  - The model decides when to use tools
+  - Tools bring external information INTO context
+- ReAct (2022): Interleaved reasoning and acting
+  - Reasoning traces + actions in the same context
+  - The "intelligence" is in how context is populated
+- Context engineering (2024-2025)
+  - The 4 patterns: Write, Select, Compress, Isolate
+  - "Most agent failures are context failures, not model failures"
+
+**Key characteristic:** The agent's internal architecture can be simple. Capabilities depend on what's in the context window, not what's in the agent's code.
+
+**Direction:** Inward — bring the environment INTO the agent's context
+
+---
+
+### The Shift in Mental Model
+
+| Aspect | RL Tradition | LLM-Native |
+|--------|--------------|------------|
+| Where intelligence lives | In agent architecture (trained/engineered) | In the LLM (pre-trained) |
+| Primary engineering challenge | Build better internals | Curate better context |
+| Agent complexity | High (multiple components) | Can be low (thin wrapper) |
+| Adaptability | Requires retraining/redesign | Just change the prompt/context |
+| Direction of effort | Agent → Environment (outward) | Environment → Context (inward) |
+
+---
+
+### Why This Matters
+
+1. **Architecture choices follow mental models**
+   - If you think "agent needs intelligence," you build complex internals
+   - If you think "LLM has intelligence," you focus on context engineering
+
+2. **Over-engineering trap**
+   - Early LLM agents (AutoGPT, BabyAGI) imported RL mental models
+   - Added memory systems, planning modules, task queues
+   - Much of this complexity was unnecessary—or got obsoleted by better models
+   - Example: AutoGPT removed vector DB memory by late 2023
+
+3. **The convergence**
+   - Even RL-influenced approaches now emphasize context
+   - Anthropic's guidance: "Find the simplest solution possible"
+   - The LLM IS the planning system—you don't need to build one around it
+
+4. **Implications for practitioners**
+   - Don't fight the model's intelligence
+   - Invest in context engineering over architecture engineering
+   - Expect complexity in agent internals to get obsoleted by model improvements
+
+---
+
+### Core Claims (Candidate Theses)
+
+**A. Descriptive:** "The dominant mental model for agents has shifted from 'build intelligent internals' to 'engineer rich context.'"
+
+**B. Prescriptive (bold):** "Keep agent internals simple; complexity should live in context, not architecture."
+
+**C. Historical:** "The LLM gives agents cognition for free—this changes everything about how we should build them."
+
+---
+
+### Open Questions
+
+1. What is the right definition of "agent" to open with?
+2. How much RL history is needed? (Enough to understand the paradigm, not a survey)
+3. Should we name specific systems (AutoGPT, BabyAGI) as cautionary tales, or keep abstract?
+4. How to handle the nuance that some complexity IS needed? (Not "never add complexity" but "add only when demonstrably needed")
+
+---
+
+## Essay Structure Outline
+
+### Option A: Historical Narrative
+
+1. **Open with definition:** What is an agent? (the action-selection loop)
+2. **The old paradigm:** Where agents came from (RL, Gym, self-driving)
+   - Key insight: intelligence must be built into the agent
+3. **The LLM changes everything:** Cognition comes pre-installed
+   - The shift in engineering challenge
+4. **The new paradigm:** Context engineering
+   - ReAct, tool use, the 4 patterns
+5. **The convergence:** Why over-engineered agents got obsoleted
+   - AutoGPT example (optional: in details section?)
+6. **Implications for practitioners:** What this means for how you build
+
+---
+
+### Option B: Problem-Solution
+
+1. **Open with a problem:** Why do some agents feel over-engineered?
+2. **Diagnosis:** They're using the wrong mental model
+3. **The two paradigms:** Cognition-less vs cognition-equipped
+4. **The right model for LLM agents:** Context engineering
+5. **Evidence:** What works vs what got obsoleted
+6. **Prescription:** Keep internals simple, invest in context
+
+---
+
+### Option C: Thesis-First
+
+1. **Open with thesis:** The mental model for agents has shifted. Here's why it matters.
+2. **The old paradigm:** RL tradition, build intelligent internals
+3. **The new paradigm:** LLM-native, engineer rich context
+4. **Why the shift happened:** LLMs provide cognition
+5. **What this means for you:** Practical implications
+
+---
+
+## Lede Candidates
+
+### Lede A: Definition + Shift
+> What is an agent? At its core, an agent is a system that observes its environment, decides what to do, and acts. This loop—observe, decide, act—has been the foundation of agent research for decades, from classic reinforcement learning to self-driving cars.
+>
+> But the arrival of large language models has changed something fundamental about this loop. The "decide" part—the intelligence—used to be the hard problem. Now it comes pre-installed.
+
+### Lede B: Two Questions
+> When building an AI agent, there are two very different questions you might ask:
+>
+> 1. How do I make this agent smarter?
+> 2. How do I give this agent the right information?
+>
+> The first question comes from the reinforcement learning tradition. The second comes from the LLM era. Which question you ask shapes everything about how you build.
+
+### Lede C: The Over-Engineering Trap
+> In 2023, a wave of ambitious agent projects—AutoGPT, BabyAGI, and their many descendants—promised autonomous AI that could plan, remember, and execute complex tasks. Many of these projects added sophisticated memory systems, planning modules, and task queues. Most of this complexity turned out to be unnecessary.
+>
+> What went wrong? These projects were built on a mental model from the pre-LLM era—one where agent intelligence had to be engineered from scratch. But LLMs change the equation.
+
+### Lede D: Cognition-Less to Cognition-Equipped
+> For decades, building an agent meant building a brain. In reinforcement learning, you trained neural networks to make decisions. In robotics, you engineered perception and planning pipelines. The agent was a cognition-less system, and your job was to give it cognition.
+>
+> LLMs invert this. The cognition is already there. Your job is no longer to build a brain—it's to give the brain the right information.
+
+---
+
+## Extra Details (Expandable Content)
+
+These sections could be collapsed/expandable in the UI, or linked as "deep dives":
+
+### Detail 1: RL History Primer
+- Markov Decision Processes
+- The agent-environment interface (state, action, reward)
+- Deep RL milestones (DQN, AlphaGo, etc.)
+- Why this created the "build intelligent internals" mental model
+
+### Detail 2: The AutoGPT Story
+- What it promised (autonomous goal completion)
+- The architecture (memory, planning, execution loops)
+- What happened (vector DB removed, complexity didn't help)
+- Lessons learned
+
+### Detail 3: Context Engineering Deep Dive
+- The 4 patterns in detail (Write, Select, Compress, Isolate)
+- Concrete examples of each
+- (Note: This might be Essay 2 territory—link forward?)
+
+### Detail 4: Self-Driving as Case Study
+- Perception → Planning → Control pipeline
+- Why this architecture made sense for vision + control
+- Why it's the wrong model for LLM agents
+- (The modular "brain" vs the integrated LLM)
+
+---
+
+## References to Incorporate
+
+### RL Tradition
+- [x] Sutton & Barto: "Reinforcement Learning: An Introduction" — defines agent as "interactive, goal-seeking... can sense aspects of their environments, and can choose actions to influence their environments"
+- [x] OpenAI Gym (2016): arxiv:1606.01540 — standardized agent-environment interface: `reset()`, `step(action)` → `(observation, reward, done, info)`
+- [x] MDP framework: Agent-environment loop at discrete time steps, agent observes state, produces action, gets reward, transitions
+- [ ] Deep RL milestones (DQN paper, AlphaGo, etc.)
+- [ ] Self-driving architecture papers (perception → planning → control)
+
+### LLM-Native Paradigm
+- [x] ReAct paper (arxiv:2210.03629)
+- [x] Anthropic: Building Effective Agents
+- [x] Lilian Weng: LLM Powered Autonomous Agents
+- [x] Context engineering articles (Anthropic, LangChain, Lance Martin)
+
+### Cautionary Tales
+- [x] AutoGPT/BabyAGI retrospectives
+- [ ] Specific examples of removed complexity
+
+---
+
+## Next Steps
+
+1. [ ] Choose essay structure (A, B, or C)
+2. [ ] Choose or refine lede
+3. [ ] Decide which "extra details" to include vs. link forward
+4. [ ] Research more concrete RL tradition examples
+5. [ ] Draft opening section

--- a/plan/essay/building_agent/essay5_decision_game_outline.md
+++ b/plan/essay/building_agent/essay5_decision_game_outline.md
@@ -1,0 +1,103 @@
+# Hello, the Era of Decision Games
+
+## Essay Outline
+
+---
+
+### 1. OPENING SCENE [Placeholder: Author to write]
+
+> *[Your personal moment—a specific instance where you faced a decision about agent output. The concrete detail matters: what time, what task, what you saw, what you felt, what you decided.]*
+
+---
+
+### 2. ZOOM OUT: What Was That Moment?
+
+- That wasn't coding. That was deciding.
+- **Card 1: The Core Shift** — Agents handle execution; humans shift to decision-making
+- **Card 3: What daily work becomes** — Design decisions, quality assessment, technology choices
+- Brief: this is happening to me, and to many others
+
+---
+
+### 3. THE GAME HAS CHANGED
+
+- **Card 2: The DeepMind parallel** — "The Thinking Game" (developing AI) → "The Decision Game" (using AI)
+- **Card 5: What's becoming less valuable** — Rote execution, syntax knowledge, boilerplate writing
+- The old game was craft. The new game is judgment.
+
+---
+
+### 4. THE PIVOT — Highlighted Quote
+
+> **"Everyone says AI will take your job. They're wrong. It will take your tasks—and leave you with something harder: the decisions."**
+
+*This is the hinge of the essay. Everything before sets it up. Everything after explores what it means.*
+
+---
+
+### 5. HOW TO PLAY THE DECISION GAME
+
+- **Card 9: Taste** — Knowing something is off before you can articulate why. Pattern recognition before full comprehension.
+- **Card 10: Meta-decisions** — When to pause the agent, when to chat, when to trust and let it continue. Real-time decisions during execution.
+- **Card 11: The learning loop** — Make a decision → observe outcome → update judgment. Taste comes from deciding, not watching.
+- **Card 6: The leverage insight** — Good decisions compound through agent execution. One good decision → agent executes at scale.
+
+---
+
+### 6. THE HARD PROBLEM
+
+- **Card 14: The asymmetry** — Agents produce 100x faster than humans can verify. Traditional QA doesn't scale.
+- **Card 12: Verification without full understanding** — How do you know agent work is correct if you don't understand every detail? This is NOT "review every line."
+- This is genuinely unsolved. Acknowledge the tension.
+
+---
+
+### 7. WHAT WE NEED TO BUILD
+
+- **Card 13: Infrastructure for trust**
+  - Auditability (can I trace what happened?)
+  - Guardrails (constraints that prevent bad outcomes)
+  - Automated checks / tests
+  - Sampling-based review
+  - Confidence signals from the agent itself
+  - Rollback mechanisms
+- **Card 7: Implications for app developers**
+  - Design for decision-making, not just task execution
+  - Surface the right information for human judgment
+  - Make agent reasoning inspectable
+  - Allow appropriate human intervention points
+
+---
+
+### 8. CLOSING [Placeholder: Author to write]
+
+> *[Return to your perspective. What have you learned? What are you still figuring out? End with something true and slightly open.]*
+
+---
+
+## Cards Reference
+
+| Card | Content |
+|------|---------|
+| 1 | The Core Shift: agents execute, humans decide |
+| 2 | DeepMind parallel: Thinking Game → Decision Game |
+| 3 | Daily work: design decisions, quality assessment, tech choices |
+| 4 | Skills gaining value: judgment, evaluation, domain expertise |
+| 5 | Skills losing value: rote execution, syntax knowledge |
+| 6 | Leverage: good decisions compound through agent execution |
+| 7 | App developers: design for decision-making |
+| 8 | Open questions: what is good decision-making? how to develop it? |
+| 9 | Taste: knowing "good" before fully understanding |
+| 10 | Meta-decisions: when to chat, pause, trust |
+| 11 | Learning loop: decide → observe → update judgment |
+| 12 | Verification without full understanding |
+| 13 | Infrastructure for trust: auditability, guardrails, etc. |
+| 14 | Asymmetry problem: agents produce faster than humans verify |
+
+---
+
+## Open Questions
+
+- Card 4 (skills gaining value) and Card 8 (open questions) aren't explicitly placed in the outline. Weave in as needed, or save for a follow-up piece.
+- Target length: ~2000 words (per series plan)
+- Tone: First-person, NYT feature style—scenes and moments over abstractions


### PR DESCRIPTION
## Summary
- Adds new opinion essay exploring how AI agents commoditize execution and shift human work toward decision-making
- Registers `Blockquote` as a custom MDX component (was only available as HTML element override, not for direct `<Blockquote variant="pullquote">` usage in MDX)
- Adds draft filtering to the essay system — drafts are hidden in production, visible in development
- Marks `job-search-reflection` and `offer-negotiation` essays as drafts

## Test plan
- [ ] Verify the essay renders correctly at `/essays/decision-game` in dev
- [ ] Confirm pullquote Blockquotes render with correct styling (centered, top/bottom borders)
- [ ] Confirm sidenote (McCarthy citation) renders in margin on desktop, expandable on mobile
- [ ] Verify draft essays are hidden in production build (`pnpm build`)
- [ ] Verify draft essays are visible in dev (`pnpm dev`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)