### PR TITLE
feat(seo): JSON-LD structured data + Atom feeds

### DIFF
--- a/apps/blog/app/(en)/essays/[slug]/page.tsx
+++ b/apps/blog/app/(en)/essays/[slug]/page.tsx
@@ -5,6 +5,8 @@ import { getEssayBySlug, getEssaySlugs, getTranslation } from '@/lib/essays';
 import { getMDXComponents } from '@/components/mdx/MDXComponents';
 import { mdxOptions } from '@/lib/mdx-options';
 import { EssayLayout, EssayHeader } from '@/components/essay';
+import { JsonLd } from '@/components/seo';
+import { breadcrumbSchema, essayPostingSchema } from '@/lib/jsonld';
 
 interface EssayPageProps {
   params: Promise<{ slug: string }>;
@@ -150,22 +152,33 @@ export default async function EssayPage({ params }: EssayPageProps) {
 
   const { title, description, date, type, topics, readingTime, content, toc } =
     essay;
+  const urlPath = `/essays/${slug}`;
 
   return (
-    <EssayLayout
-      toc={toc}
-      header={
-        <EssayHeader
-          type={type}
-          topics={topics}
-          title={title}
-          description={description}
-          date={date}
-          readingTime={readingTime}
-        />
-      }
-    >
-      <MDXRemote source={content} components={getMDXComponents()} options={{ mdxOptions }} />
-    </EssayLayout>
+    <>
+      <JsonLd data={essayPostingSchema(essay, urlPath)} />
+      <JsonLd
+        data={breadcrumbSchema([
+          { name: 'Home', url: '/' },
+          { name: 'Essays', url: '/essays' },
+          { name: title, url: urlPath },
+        ])}
+      />
+      <EssayLayout
+        toc={toc}
+        header={
+          <EssayHeader
+            type={type}
+            topics={topics}
+            title={title}
+            description={description}
+            date={date}
+            readingTime={readingTime}
+          />
+        }
+      >
+        <MDXRemote source={content} components={getMDXComponents()} options={{ mdxOptions }} />
+      </EssayLayout>
+    </>
   );
 }

--- a/apps/blog/app/(en)/layout.tsx
+++ b/apps/blog/app/(en)/layout.tsx
@@ -11,6 +11,8 @@ import {
 } from '@/components/layout';
 import { LanguageProvider } from '@/lib/i18n';
 import { SITE_AUTHOR, SITE_URL } from '@/lib/constants';
+import { JsonLd } from '@/components/seo';
+import { siteGraph } from '@/lib/jsonld';
 
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
@@ -58,6 +60,13 @@ export default function EnRootLayout({ children }: EnRootLayoutProps) {
   return (
     <html lang="en" data-theme="nyt" data-mode="light" suppressHydrationWarning>
       <head>
+        <link
+          rel="alternate"
+          type="application/atom+xml"
+          title="Algo Mind — Essays"
+          href="/feed.xml"
+        />
+        <JsonLd data={siteGraph('en')} />
         <script
           dangerouslySetInnerHTML={{
             __html: `

--- a/apps/blog/app/(en)/periodics/[slug]/page.tsx
+++ b/apps/blog/app/(en)/periodics/[slug]/page.tsx
@@ -6,6 +6,8 @@ import { getMDXComponents } from '@/components/mdx/MDXComponents';
 import { mdxOptions } from '@/lib/mdx-options';
 import { EssayLayout } from '@/components/essay';
 import { PeriodicHeader } from '@/components/periodic';
+import { JsonLd } from '@/components/seo';
+import { breadcrumbSchema, periodicPostingSchema } from '@/lib/jsonld';
 
 interface PeriodicPageProps {
   params: Promise<{ slug: string }>;
@@ -152,23 +154,34 @@ export default async function PeriodicPage({ params }: PeriodicPageProps) {
 
   const { title, description, date, issue, type, topics, readingTime, content, toc } =
     periodic;
+  const urlPath = `/periodics/${slug}`;
 
   return (
-    <EssayLayout
-      toc={toc}
-      header={
-        <PeriodicHeader
-          issue={issue}
-          type={type}
-          topics={topics}
-          title={title}
-          description={description}
-          date={date}
-          readingTime={readingTime}
-        />
-      }
-    >
-      <MDXRemote source={content} components={getMDXComponents()} options={{ mdxOptions }} />
-    </EssayLayout>
+    <>
+      <JsonLd data={periodicPostingSchema(periodic, urlPath)} />
+      <JsonLd
+        data={breadcrumbSchema([
+          { name: 'Home', url: '/' },
+          { name: 'Periodics', url: '/periodics' },
+          { name: title, url: urlPath },
+        ])}
+      />
+      <EssayLayout
+        toc={toc}
+        header={
+          <PeriodicHeader
+            issue={issue}
+            type={type}
+            topics={topics}
+            title={title}
+            description={description}
+            date={date}
+            readingTime={readingTime}
+          />
+        }
+      >
+        <MDXRemote source={content} components={getMDXComponents()} options={{ mdxOptions }} />
+      </EssayLayout>
+    </>
   );
 }

--- a/apps/blog/app/(en)/series/[slug]/page.tsx
+++ b/apps/blog/app/(en)/series/[slug]/page.tsx
@@ -6,6 +6,8 @@ import { getMDXComponents } from '@/components/mdx/MDXComponents';
 import { mdxOptions } from '@/lib/mdx-options';
 import { EssayLayout } from '@/components/essay';
 import { SeriesHeader } from '@/components/series';
+import { JsonLd } from '@/components/seo';
+import { breadcrumbSchema, seriesPageSchema } from '@/lib/jsonld';
 
 interface SeriesPageProps {
   params: Promise<{ slug: string }>;
@@ -150,24 +152,35 @@ export default async function SeriesItemPage({ params }: SeriesPageProps) {
 
   const { title, description, date, updated, category, topics, itemCount, readingTime, content, toc } =
     series;
+  const urlPath = `/series/${slug}`;
 
   return (
-    <EssayLayout
-      toc={toc}
-      header={
-        <SeriesHeader
-          category={category}
-          topics={topics}
-          title={title}
-          description={description}
-          date={date}
-          updated={updated}
-          itemCount={itemCount}
-          readingTime={readingTime}
-        />
-      }
-    >
-      <MDXRemote source={content} components={getMDXComponents()} options={{ mdxOptions }} />
-    </EssayLayout>
+    <>
+      <JsonLd data={seriesPageSchema(series, urlPath)} />
+      <JsonLd
+        data={breadcrumbSchema([
+          { name: 'Home', url: '/' },
+          { name: 'Series', url: '/series' },
+          { name: title, url: urlPath },
+        ])}
+      />
+      <EssayLayout
+        toc={toc}
+        header={
+          <SeriesHeader
+            category={category}
+            topics={topics}
+            title={title}
+            description={description}
+            date={date}
+            updated={updated}
+            itemCount={itemCount}
+            readingTime={readingTime}
+          />
+        }
+      >
+        <MDXRemote source={content} components={getMDXComponents()} options={{ mdxOptions }} />
+      </EssayLayout>
+    </>
   );
 }

--- a/apps/blog/app/(zh)/layout.tsx
+++ b/apps/blog/app/(zh)/layout.tsx
@@ -11,6 +11,8 @@ import {
 } from '@/components/layout';
 import { LanguageProvider } from '@/lib/i18n';
 import { SITE_AUTHOR, SITE_URL } from '@/lib/constants';
+import { JsonLd } from '@/components/seo';
+import { siteGraph } from '@/lib/jsonld';
 
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
@@ -57,6 +59,13 @@ export default function ZhRootLayout({ children }: ZhRootLayoutProps) {
   return (
     <html lang="zh" data-theme="nyt" data-mode="light" data-language="zh" suppressHydrationWarning>
       <head>
+        <link
+          rel="alternate"
+          type="application/atom+xml"
+          title="思算 — 随笔"
+          href="/zh/feed.xml"
+        />
+        <JsonLd data={siteGraph('zh')} />
         <script
           dangerouslySetInnerHTML={{
             __html: `

--- a/apps/blog/app/(zh)/zh/essays/[slug]/page.tsx
+++ b/apps/blog/app/(zh)/zh/essays/[slug]/page.tsx
@@ -5,6 +5,8 @@ import { getEssayBySlug, getEssaySlugs, getTranslation } from '@/lib/essays';
 import { getMDXComponents } from '@/components/mdx/MDXComponents';
 import { mdxOptions } from '@/lib/mdx-options';
 import { EssayLayout, EssayHeader } from '@/components/essay';
+import { JsonLd } from '@/components/seo';
+import { breadcrumbSchema, essayPostingSchema } from '@/lib/jsonld';
 
 interface ZhEssayPageProps {
   params: Promise<{ slug: string }>;
@@ -151,23 +153,34 @@ export default async function ZhEssayPage({ params }: ZhEssayPageProps) {
 
   const { title, description, date, type, topics, readingTime, content, toc } =
     essay;
+  const urlPath = `/zh/essays/${slug}`;
 
   return (
-    <EssayLayout
-      toc={toc}
-      header={
-        <EssayHeader
-          type={type}
-          topics={topics}
-          title={title}
-          description={description}
-          date={date}
-          readingTime={readingTime}
-          language="zh"
-        />
-      }
-    >
-      <MDXRemote source={content} components={getMDXComponents()} options={{ mdxOptions }} />
-    </EssayLayout>
+    <>
+      <JsonLd data={essayPostingSchema(essay, urlPath)} />
+      <JsonLd
+        data={breadcrumbSchema([
+          { name: '首页', url: '/zh' },
+          { name: '文章', url: '/zh/essays' },
+          { name: title, url: urlPath },
+        ])}
+      />
+      <EssayLayout
+        toc={toc}
+        header={
+          <EssayHeader
+            type={type}
+            topics={topics}
+            title={title}
+            description={description}
+            date={date}
+            readingTime={readingTime}
+            language="zh"
+          />
+        }
+      >
+        <MDXRemote source={content} components={getMDXComponents()} options={{ mdxOptions }} />
+      </EssayLayout>
+    </>
   );
 }

--- a/apps/blog/app/(zh)/zh/feed.xml/route.ts
+++ b/apps/blog/app/(zh)/zh/feed.xml/route.ts
@@ -1,0 +1,12 @@
+import { buildAtomFeed } from '@/lib/feed';
+
+export const dynamic = 'force-static';
+
+export function GET() {
+  return new Response(buildAtomFeed('zh'), {
+    headers: {
+      'Content-Type': 'application/atom+xml; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600',
+    },
+  });
+}

--- a/apps/blog/app/(zh)/zh/periodics/[slug]/page.tsx
+++ b/apps/blog/app/(zh)/zh/periodics/[slug]/page.tsx
@@ -6,6 +6,8 @@ import { getMDXComponents } from '@/components/mdx/MDXComponents';
 import { mdxOptions } from '@/lib/mdx-options';
 import { EssayLayout } from '@/components/essay';
 import { PeriodicHeader } from '@/components/periodic';
+import { JsonLd } from '@/components/seo';
+import { breadcrumbSchema, periodicPostingSchema } from '@/lib/jsonld';
 
 interface PeriodicPageProps {
   params: Promise<{ slug: string }>;
@@ -155,24 +157,35 @@ export default async function ZhPeriodicPage({ params }: PeriodicPageProps) {
 
   const { title, description, date, issue, type, topics, readingTime, content, toc } =
     periodic;
+  const urlPath = `/zh/periodics/${slug}`;
 
   return (
-    <EssayLayout
-      toc={toc}
-      header={
-        <PeriodicHeader
-          issue={issue}
-          type={type}
-          topics={topics}
-          title={title}
-          description={description}
-          date={date}
-          readingTime={readingTime}
-          language="zh"
-        />
-      }
-    >
-      <MDXRemote source={content} components={getMDXComponents()} options={{ mdxOptions }} />
-    </EssayLayout>
+    <>
+      <JsonLd data={periodicPostingSchema(periodic, urlPath)} />
+      <JsonLd
+        data={breadcrumbSchema([
+          { name: '首页', url: '/zh' },
+          { name: '文摘', url: '/zh/periodics' },
+          { name: title, url: urlPath },
+        ])}
+      />
+      <EssayLayout
+        toc={toc}
+        header={
+          <PeriodicHeader
+            issue={issue}
+            type={type}
+            topics={topics}
+            title={title}
+            description={description}
+            date={date}
+            readingTime={readingTime}
+            language="zh"
+          />
+        }
+      >
+        <MDXRemote source={content} components={getMDXComponents()} options={{ mdxOptions }} />
+      </EssayLayout>
+    </>
   );
 }

--- a/apps/blog/app/(zh)/zh/series/[slug]/page.tsx
+++ b/apps/blog/app/(zh)/zh/series/[slug]/page.tsx
@@ -6,6 +6,8 @@ import { getMDXComponents } from '@/components/mdx/MDXComponents';
 import { mdxOptions } from '@/lib/mdx-options';
 import { EssayLayout } from '@/components/essay';
 import { SeriesHeader } from '@/components/series';
+import { JsonLd } from '@/components/seo';
+import { breadcrumbSchema, seriesPageSchema } from '@/lib/jsonld';
 
 interface SeriesPageProps {
   params: Promise<{ slug: string }>;
@@ -153,25 +155,36 @@ export default async function ZhSeriesItemPage({ params }: SeriesPageProps) {
 
   const { title, description, date, updated, category, topics, itemCount, readingTime, content, toc } =
     series;
+  const urlPath = `/zh/series/${slug}`;
 
   return (
-    <EssayLayout
-      toc={toc}
-      header={
-        <SeriesHeader
-          category={category}
-          topics={topics}
-          title={title}
-          description={description}
-          date={date}
-          updated={updated}
-          itemCount={itemCount}
-          readingTime={readingTime}
-          language="zh"
-        />
-      }
-    >
-      <MDXRemote source={content} components={getMDXComponents()} options={{ mdxOptions }} />
-    </EssayLayout>
+    <>
+      <JsonLd data={seriesPageSchema(series, urlPath)} />
+      <JsonLd
+        data={breadcrumbSchema([
+          { name: '首页', url: '/zh' },
+          { name: '系列', url: '/zh/series' },
+          { name: title, url: urlPath },
+        ])}
+      />
+      <EssayLayout
+        toc={toc}
+        header={
+          <SeriesHeader
+            category={category}
+            topics={topics}
+            title={title}
+            description={description}
+            date={date}
+            updated={updated}
+            itemCount={itemCount}
+            readingTime={readingTime}
+            language="zh"
+          />
+        }
+      >
+        <MDXRemote source={content} components={getMDXComponents()} options={{ mdxOptions }} />
+      </EssayLayout>
+    </>
   );
 }

--- a/apps/blog/app/feed.xml/route.ts
+++ b/apps/blog/app/feed.xml/route.ts
@@ -1,0 +1,12 @@
+import { buildAtomFeed } from '@/lib/feed';
+
+export const dynamic = 'force-static';
+
+export function GET() {
+  return new Response(buildAtomFeed('en'), {
+    headers: {
+      'Content-Type': 'application/atom+xml; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600',
+    },
+  });
+}

--- a/apps/blog/components/seo/JsonLd.tsx
+++ b/apps/blog/components/seo/JsonLd.tsx
@@ -1,0 +1,23 @@
+import { serializeJsonLd } from '@/lib/jsonld';
+
+interface JsonLdProps {
+  data: unknown;
+}
+
+/**
+ * Server-rendered <script type="application/ld+json"> tag.
+ *
+ * Use one component per schema graph. Embedding multiple top-level
+ * schemas inside a single script is also valid, but separating them
+ * keeps individual schemas debuggable in tools like the Rich Results
+ * Test.
+ */
+export function JsonLd({ data }: JsonLdProps) {
+  return (
+    <script
+      type="application/ld+json"
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{ __html: serializeJsonLd(data) }}
+    />
+  );
+}

--- a/apps/blog/components/seo/index.ts
+++ b/apps/blog/components/seo/index.ts
@@ -1,0 +1,1 @@
+export { JsonLd } from './JsonLd';

--- a/apps/blog/lib/feed.ts
+++ b/apps/blog/lib/feed.ts
@@ -1,0 +1,102 @@
+/**
+ * Atom feed builder.
+ *
+ * Atom is preferred over RSS 2.0 here for its stricter schema, native
+ * `updated` semantics, and explicit `<author>` and `<id>` requirements
+ * — all useful for AI engines that consume feeds.
+ */
+
+import { SITE_URL, SITE_AUTHOR } from './constants';
+import { getAllEssays } from './essays';
+import { getAllPeriodics } from './periodics';
+import type { Language } from '@/types/content';
+
+interface FeedEntry {
+  title: string;
+  description?: string;
+  url: string;
+  date: string;
+  updated?: string;
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function isoDate(value: string): string {
+  return new Date(value).toISOString();
+}
+
+function entriesFor(locale: Language): FeedEntry[] {
+  const essays = getAllEssays({ language: locale }).map((essay) => ({
+    title: essay.title,
+    description: essay.description,
+    url: locale === 'zh' ? `/zh/essays/${essay.slug}` : `/essays/${essay.slug}`,
+    date: essay.date,
+  }));
+  const periodics = getAllPeriodics({ language: locale }).map((periodic) => ({
+    title: periodic.title,
+    description: periodic.description,
+    url:
+      locale === 'zh'
+        ? `/zh/periodics/${periodic.slug}`
+        : `/periodics/${periodic.slug}`,
+    date: periodic.date,
+  }));
+  return [...essays, ...periodics]
+    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+    .slice(0, 20);
+}
+
+export function buildAtomFeed(locale: Language): string {
+  const feedPath = locale === 'zh' ? '/zh/feed.xml' : '/feed.xml';
+  const homePath = locale === 'zh' ? '/zh' : '/';
+  const feedUrl = `${SITE_URL}${feedPath}`;
+  const homeUrl = `${SITE_URL}${homePath}`;
+  const title = locale === 'zh' ? '思算 — 随笔' : 'Algo Mind — Essays';
+  const subtitle =
+    locale === 'zh'
+      ? '思算 — Feitong Yang 关于 AI、软件工程、产品思考与职业的随笔。'
+      : 'Essays by Feitong Yang on AI, software engineering, product thinking, and career.';
+
+  const entries = entriesFor(locale);
+  const updated = entries[0]?.date
+    ? isoDate(entries[0].date)
+    : new Date().toISOString();
+
+  const entryXml = entries
+    .map((entry) => {
+      const entryUrl = `${SITE_URL}${entry.url}`;
+      return `  <entry>
+    <id>${entryUrl}</id>
+    <title>${escapeXml(entry.title)}</title>
+    <link rel="alternate" href="${entryUrl}"/>
+    <published>${isoDate(entry.date)}</published>
+    <updated>${isoDate(entry.updated ?? entry.date)}</updated>${
+      entry.description
+        ? `\n    <summary>${escapeXml(entry.description)}</summary>`
+        : ''
+    }
+    <author><name>${escapeXml(SITE_AUTHOR.name)}</name></author>
+  </entry>`;
+    })
+    .join('\n');
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="${locale === 'zh' ? 'zh-CN' : 'en-US'}">
+  <id>${feedUrl}</id>
+  <title>${escapeXml(title)}</title>
+  <subtitle>${escapeXml(subtitle)}</subtitle>
+  <link rel="self" href="${feedUrl}"/>
+  <link rel="alternate" href="${homeUrl}"/>
+  <updated>${updated}</updated>
+  <author><name>${escapeXml(SITE_AUTHOR.name)}</name></author>
+${entryXml}
+</feed>
+`;
+}

--- a/apps/blog/lib/jsonld.ts
+++ b/apps/blog/lib/jsonld.ts
@@ -1,0 +1,179 @@
+/**
+ * Schema.org JSON-LD helpers.
+ *
+ * Output is consumed by Google's Rich Results Test, AI answer engines
+ * (Perplexity, AI Overviews, ChatGPT Search), and search-engine knowledge
+ * graphs. The shapes here intentionally stay close to schema.org defaults
+ * so future fields can be added without rewriting consumers.
+ */
+
+import { SITE_URL, SITE_AUTHOR } from './constants';
+import type { EssayMeta, PeriodicMeta, SeriesMeta, Language } from '@/types/content';
+
+type Locale = Language;
+
+const PERSON_ID = `${SITE_URL}/#person`;
+const PUBLISHER_ID = `${SITE_URL}/#publisher`;
+const WEBSITE_ID_EN = `${SITE_URL}/#website`;
+const WEBSITE_ID_ZH = `${SITE_URL}/zh/#website`;
+
+const SAME_AS = [
+  'https://www.linkedin.com/in/feitong-yang-88088a55/',
+  'http://scholar.google.com/citations?user=94Xx9u0AAAAJ',
+  'http://neurotree.org/neurotree/tree.php?pid=65050',
+];
+
+function abs(path: string): string {
+  if (path.startsWith('http')) return path;
+  return `${SITE_URL}${path.startsWith('/') ? path : `/${path}`}`;
+}
+
+export function personSchema() {
+  return {
+    '@type': 'Person',
+    '@id': PERSON_ID,
+    name: SITE_AUTHOR.name,
+    url: SITE_AUTHOR.url,
+    jobTitle: 'Founding Engineer',
+    worksFor: {
+      '@type': 'Organization',
+      name: 'Fundamental Research Labs',
+      url: 'https://fairies.ai/',
+    },
+    alumniOf: [
+      { '@type': 'CollegeOrUniversity', name: 'Johns Hopkins University' },
+    ],
+    sameAs: SAME_AS,
+  };
+}
+
+export function publisherSchema(locale: Locale) {
+  return {
+    '@type': 'Organization',
+    '@id': PUBLISHER_ID,
+    name: locale === 'zh' ? '思算' : 'Algo Mind',
+    url: SITE_URL,
+    founder: { '@id': PERSON_ID },
+  };
+}
+
+export function websiteSchema(locale: Locale) {
+  const id = locale === 'zh' ? WEBSITE_ID_ZH : WEBSITE_ID_EN;
+  const url = locale === 'zh' ? `${SITE_URL}/zh` : SITE_URL;
+  return {
+    '@type': 'WebSite',
+    '@id': id,
+    url,
+    name: locale === 'zh' ? '思算' : 'Algo Mind',
+    inLanguage: locale === 'zh' ? 'zh-CN' : 'en-US',
+    publisher: { '@id': PUBLISHER_ID },
+    author: { '@id': PERSON_ID },
+  };
+}
+
+/**
+ * `@graph` envelope. Lets us emit several connected nodes in one script
+ * block with `@id` references between them — the schema.org idiom for
+ * "these things are the same entity across multiple types".
+ */
+export function siteGraph(locale: Locale) {
+  return {
+    '@context': 'https://schema.org',
+    '@graph': [personSchema(), publisherSchema(locale), websiteSchema(locale)],
+  };
+}
+
+interface BlogPostingArgs {
+  title: string;
+  description?: string;
+  url: string;
+  datePublished: string;
+  dateModified?: string;
+  topics?: string[];
+  image?: string;
+  locale: Locale;
+}
+
+export function blogPostingSchema(args: BlogPostingArgs) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BlogPosting',
+    headline: args.title,
+    description: args.description || undefined,
+    url: abs(args.url),
+    datePublished: args.datePublished,
+    dateModified: args.dateModified || args.datePublished,
+    inLanguage: args.locale === 'zh' ? 'zh-CN' : 'en-US',
+    author: { '@id': PERSON_ID },
+    publisher: { '@id': PUBLISHER_ID },
+    mainEntityOfPage: { '@type': 'WebPage', '@id': abs(args.url) },
+    image: args.image ? abs(args.image) : undefined,
+    keywords: args.topics?.join(', ') || undefined,
+  };
+}
+
+export function essayPostingSchema(essay: EssayMeta, urlPath: string) {
+  return blogPostingSchema({
+    title: essay.title,
+    description: essay.description,
+    url: urlPath,
+    datePublished: essay.date,
+    topics: essay.topics as string[],
+    locale: essay.lang,
+  });
+}
+
+export function periodicPostingSchema(periodic: PeriodicMeta, urlPath: string) {
+  return blogPostingSchema({
+    title: periodic.title,
+    description:
+      periodic.description ||
+      (periodic.lang === 'zh'
+        ? `${periodic.title} - 第${periodic.issue}期`
+        : `${periodic.title} - Issue #${periodic.issue}`),
+    url: urlPath,
+    datePublished: periodic.date,
+    topics: periodic.topics as string[],
+    locale: periodic.lang,
+  });
+}
+
+export function seriesPageSchema(series: SeriesMeta, urlPath: string) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'CollectionPage',
+    name: series.title,
+    description: series.description || undefined,
+    url: abs(urlPath),
+    datePublished: series.date,
+    dateModified: series.updated || series.date,
+    inLanguage: series.lang === 'zh' ? 'zh-CN' : 'en-US',
+    author: { '@id': PERSON_ID },
+    publisher: { '@id': PUBLISHER_ID },
+    mainEntityOfPage: { '@type': 'WebPage', '@id': abs(urlPath) },
+    keywords: series.topics.join(', ') || undefined,
+  };
+}
+
+export interface BreadcrumbItem {
+  name: string;
+  url: string;
+}
+
+export function breadcrumbSchema(items: BreadcrumbItem[]) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: items.map((item, i) => ({
+      '@type': 'ListItem',
+      position: i + 1,
+      name: item.name,
+      item: abs(item.url),
+    })),
+  };
+}
+
+/** Serialize for embedding inside a `<script type="application/ld+json">`. */
+export function serializeJsonLd(value: unknown): string {
+  return JSON.stringify(value).replace(/</g, '\\u003c');
+}


### PR DESCRIPTION
## Summary

Half of PR 5 in the SEO plan. Lands the two pieces that don't need brand assets:

- **JSON-LD** (schema.org structured data) on every page. The single highest-leverage GEO signal — AI answer engines lean heavily on schema for entity resolution.
- **Atom feeds** at `/feed.xml` and `/zh/feed.xml`, with auto-discovery `<link>` tags in both root layouts.

Deferring (need brand input from you):
- OG images (default brand card vs. per-essay autogenerated cards via `next/og`)
- Favicons (icon source / generated)

## JSON-LD details

**One `@graph` per layout** — `Person` + `Organization` + `WebSite` connected by `@id` cross-references. The `Person` carries the identity signals that matter for AI engines:

- `jobTitle: 'Founding Engineer'`, `worksFor: Fundamental Research Labs`
- `alumniOf: Johns Hopkins University`
- `sameAs: [LinkedIn, Google Scholar, NeuroTree]` — these are what answer engines use to confirm "this is the same Feitong Yang they see elsewhere"

**Per-page schema** on detail pages:

- Essay/periodic: `BlogPosting` + `BreadcrumbList`
- Series: `CollectionPage` + `BreadcrumbList`
- Both reference the layout's `Person` and `Organization` by `@id` — entity stays singular across pages.

**Wrong-language fallback pages stay clean** — they're already `noindex` from PR 110, and they don't emit per-page `BlogPosting`. Only the layout-level site graph renders, which is correct.

**Code:**

- `apps/blog/lib/jsonld.ts` — pure schema builders, server-only.
- `apps/blog/components/seo/JsonLd.tsx` — server component, escapes `<` to `<` to prevent script-tag breakout.
- One `<JsonLd>` per top-level schema so each block validates independently in the [Rich Results Test](https://search.google.com/test/rich-results).

## Atom feeds

- `apps/blog/lib/feed.ts` builds RFC 4287 Atom XML for the requested locale (essays + periodics, newest 20).
- `apps/blog/app/feed.xml/route.ts` (en) and `apps/blog/app/(zh)/zh/feed.xml/route.ts` (zh).
- Both use `export const dynamic = 'force-static'` so they pre-render at build time under `output: 'export'`.
- `<link rel="alternate" type="application/atom+xml" href="/feed.xml">` (and zh equivalent) in the layout `<head>` for reader auto-discovery.

## Verified in build output

| URL | What renders |
|---|---|
| `/` | 1 JSON-LD block: `@graph (Person, Organization, WebSite)` |
| `/zh/` | Same shape with `inLanguage: zh-CN`, publisher `思算` |
| `/essays/decision-game/` | 3 blocks: site graph + `BlogPosting` + `BreadcrumbList`. BlogPosting refs Person/Org via `@id` |
| `/zh/essays/decision-game-zh/` | Same shape, zh-CN |
| `/essays/10k-code-zh/` (noindex fallback) | Only layout's site graph, no per-page schema. `<meta name="robots" content="noindex, follow">` |
| `/feed.xml` | 2.1 KB Atom XML, 5 entries |
| `/zh/feed.xml` | 8.6 KB Atom XML |
| Both layouts' `<head>` | `<link rel="alternate" type="application/atom+xml" ...>` |

164 tests pass. Build clean under `output: 'export'`.

## Test plan

- [ ] CI passes
- [ ] After deploy, run `https://www.feitong.phd/essays/decision-game/` through the [Rich Results Test](https://search.google.com/test/rich-results) → should detect `BlogPosting`, `BreadcrumbList`, `Person`. Article rich-result eligibility depends on having an `image` field, which I left optional pending the OG-image PR.
- [ ] Run a feed validator like `https://validator.w3.org/feed/` on `/feed.xml` and `/zh/feed.xml`.
- [ ] Subscribe to `/feed.xml` in a reader (NetNewsWire, Feedly) to confirm it renders.

## Remaining SEO work after this PR

Per `plan/docs/seo/order-of-operations.md`:

- **OG images + favicons** — needs your input on brand assets. Want a Satori-generated text card (built from title + author) or supplied art?
- **PR 6 — Search Console verification + analytics** (after DNS lights up on `www.feitong.phd`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)