### PR TITLE
feat(seo): Cloudflare Web Analytics beacon

### DIFF
--- a/apps/blog/app/(en)/layout.tsx
+++ b/apps/blog/app/(en)/layout.tsx
@@ -12,6 +12,7 @@ import {
 import { LanguageProvider } from '@/lib/i18n';
 import { SITE_AUTHOR, SITE_URL } from '@/lib/constants';
 import { JsonLd } from '@/components/seo';
+import { CloudflareAnalytics } from '@/components/analytics';
 import { siteGraph } from '@/lib/jsonld';
 
 export const metadata: Metadata = {
@@ -67,6 +68,7 @@ export default function EnRootLayout({ children }: EnRootLayoutProps) {
           href="/feed.xml"
         />
         <JsonLd data={siteGraph('en')} />
+        <CloudflareAnalytics />
         <script
           dangerouslySetInnerHTML={{
             __html: `

--- a/apps/blog/app/(zh)/layout.tsx
+++ b/apps/blog/app/(zh)/layout.tsx
@@ -12,6 +12,7 @@ import {
 import { LanguageProvider } from '@/lib/i18n';
 import { SITE_AUTHOR, SITE_URL } from '@/lib/constants';
 import { JsonLd } from '@/components/seo';
+import { CloudflareAnalytics } from '@/components/analytics';
 import { siteGraph } from '@/lib/jsonld';
 
 export const metadata: Metadata = {
@@ -66,6 +67,7 @@ export default function ZhRootLayout({ children }: ZhRootLayoutProps) {
           href="/zh/feed.xml"
         />
         <JsonLd data={siteGraph('zh')} />
+        <CloudflareAnalytics />
         <script
           dangerouslySetInnerHTML={{
             __html: `

--- a/apps/blog/components/analytics/CloudflareAnalytics.tsx
+++ b/apps/blog/components/analytics/CloudflareAnalytics.tsx
@@ -1,0 +1,27 @@
+/**
+ * Cloudflare Web Analytics beacon.
+ *
+ * Cookieless, GDPR-friendly, ~1 KB. The token in `data-cf-beacon` is
+ * the site identifier — public by design, not a secret. It's safe to
+ * commit; the dashboard is protected by Cloudflare account auth, not
+ * by the token itself.
+ *
+ * Gated on `NODE_ENV === 'production'` so that `pnpm dev` doesn't
+ * report localhost traffic to the live dashboard.
+ */
+
+const CF_BEACON_TOKEN = '4188bb0ef7414a7680ae773778307d2c';
+
+const beaconConfig = JSON.stringify({ token: CF_BEACON_TOKEN });
+
+export function CloudflareAnalytics() {
+  if (process.env.NODE_ENV !== 'production') return null;
+
+  return (
+    <script
+      defer
+      src="https://static.cloudflareinsights.com/beacon.min.js"
+      data-cf-beacon={beaconConfig}
+    />
+  );
+}

--- a/apps/blog/components/analytics/index.ts
+++ b/apps/blog/components/analytics/index.ts
@@ -1,0 +1,1 @@
+export { CloudflareAnalytics } from './CloudflareAnalytics';


### PR DESCRIPTION
## Summary

Adds the Cloudflare Web Analytics beacon to both root layouts. Cookieless, GDPR-friendly, ~1 KB script. Unblocks the entire measurement story for SEO — we can finally see whether the prior SEO PRs actually move traffic.

## Implementation

- `components/analytics/CloudflareAnalytics.tsx` — server component returning the beacon script tag.
- Gated on `NODE_ENV === 'production'` so `pnpm dev` doesn't pollute the dashboard with localhost pageviews.
- Mounted in `(en)/layout.tsx` and `(zh)/layout.tsx` head, after `JsonLd`, before the inline theme script.

The beacon token (`4188bb0e…`) is committed — it's a public site identifier, not a secret. Dashboard access is protected by Cloudflare account auth, not by token obscurity.

## Verified

- `out/index.html` and `out/zh/index.html` both contain `<script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon="...">`
- 174 tests pass.

## What this unblocks

Once DNS is live on `www.feitong.phd`, you'll start seeing:
- Pageviews, unique visitors, top pages, referrers, country breakdown
- Bot vs human filtering (automatic)
- Real-user Core Web Vitals

Pair with Google Search Console (already verified via DNS TXT — submit the sitemap after DNS lights up) for the complete measurement picture: GSC for search-side metrics (impressions, queries, CTR), Cloudflare for site-side (what visitors do after landing).

## Remaining SEO work

| Item | State |
|---|---|
| GSC verification + sitemap submission | DNS TXT added; submit sitemap after DNS resolves |
| Bing Webmaster Tools | optional; 2-minute mirror of GSC |
| Favicons + PWA manifest | needs 3 brand decisions |
| Draft-validation noise fix | small follow-up, no decisions needed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)