### PR TITLE
fix: allow empty description on draft essays

### DIFF
--- a/apps/blog/__tests__/content-types.test.ts
+++ b/apps/blog/__tests__/content-types.test.ts
@@ -92,9 +92,31 @@ describe('Content Types', () => {
       expect(() => validateFrontmatter(rest)).toThrow('title is required');
     });
 
-    it('throws for missing description', () => {
+    it('throws for missing description on a non-draft', () => {
       const { description, ...rest } = validFrontmatter;
       expect(() => validateFrontmatter(rest)).toThrow('description is required');
+    });
+
+    it('throws for empty-string description on a non-draft', () => {
+      expect(() =>
+        validateFrontmatter({ ...validFrontmatter, description: '' })
+      ).toThrow('description is required');
+    });
+
+    it('allows missing description on a draft', () => {
+      const { description, ...rest } = validFrontmatter;
+      const result = validateFrontmatter({ ...rest, draft: true });
+      expect(result.draft).toBe(true);
+      expect(result.description).toBe('');
+    });
+
+    it('allows empty-string description on a draft', () => {
+      const result = validateFrontmatter({
+        ...validFrontmatter,
+        description: '',
+        draft: true,
+      });
+      expect(result.description).toBe('');
     });
 
     it('throws for missing date', () => {

--- a/apps/blog/types/content.ts
+++ b/apps/blog/types/content.ts
@@ -331,8 +331,15 @@ export function validateFrontmatter(data: Record<string, unknown>): Frontmatter 
   if (typeof data.title !== 'string' || !data.title) {
     errors.push('title is required and must be a string');
   }
-  if (typeof data.description !== 'string' || !data.description) {
-    errors.push('description is required and must be a string');
+  const isDraft = data.draft === true;
+  // Drafts are work-in-progress — description may not be filled yet. For
+  // published essays, description is required and must be non-empty.
+  if (!isDraft) {
+    if (typeof data.description !== 'string' || !data.description) {
+      errors.push('description is required and must be a string');
+    }
+  } else if (data.description !== undefined && typeof data.description !== 'string') {
+    errors.push('description must be a string when provided');
   }
   if (typeof data.date !== 'string' || !data.date) {
     errors.push('date is required and must be a string');
@@ -371,7 +378,7 @@ export function validateFrontmatter(data: Record<string, unknown>): Frontmatter 
 
   return {
     title: data.title as string,
-    description: data.description as string,
+    description: (data.description as string | undefined) ?? '',
     date: data.date as string,
     type: data.type as EssayType,
     topics: data.topics as Topic[],
@@ -451,8 +458,13 @@ export function validateSeriesFrontmatter(data: Record<string, unknown>): Series
   if (typeof data.title !== 'string' || !data.title) {
     errors.push('title is required and must be a string');
   }
-  if (typeof data.description !== 'string' || !data.description) {
-    errors.push('description is required and must be a string');
+  const isSeriesDraft = data.draft === true;
+  if (!isSeriesDraft) {
+    if (typeof data.description !== 'string' || !data.description) {
+      errors.push('description is required and must be a string');
+    }
+  } else if (data.description !== undefined && typeof data.description !== 'string') {
+    errors.push('description must be a string when provided');
   }
   if (typeof data.date !== 'string' || !data.date) {
     errors.push('date is required and must be a string');
@@ -490,7 +502,7 @@ export function validateSeriesFrontmatter(data: Record<string, unknown>): Series
 
   return {
     title: data.title as string,
-    description: data.description as string,
+    description: (data.description as string | undefined) ?? '',
     date: data.date as string,
     updated: data.updated as string | undefined,
     category: data.category as SeriesCategory,


### PR DESCRIPTION
## Summary

Stops the noisy stderr spam during dev — six "description is required" errors that fired every time any essay page rendered (because `getAllEssays` is called from `RelatedEssays`, sitemap, feed, and JSON-LD, and every call parses every draft essay).

## The cause

Drafts are work-in-progress. By definition the description hasn't been decided yet. But `validateFrontmatter` required a non-empty `description` for every essay, including drafts. Each parse threw, `getEssayMeta` caught and logged, the essay was silently dropped from results. Functionally fine, very loud.

After PR #113 (RelatedEssays) this multiplied: every essay page render triggers a fresh `getAllEssays` call, so the same six errors fire on every page render in dev.

## The fix

`validateFrontmatter` (essays) and `validateSeriesFrontmatter`:

- If `draft: true`, description may be missing or empty.
- If not draft, description is still required and must be non-empty.
- Empty description normalizes to `''` in the returned `EssayMeta` so the `description: string` type contract is preserved. Consumers that render description already handle empty gracefully (truncation, conditional render, OG card omits the line).

## Tests

Four new cases:

- Non-draft with missing description → throws (regression guard)
- Non-draft with empty-string description → throws
- Draft with missing description → passes, normalizes to `''`
- Draft with empty-string description → passes

177 total tests pass.

## Remaining errors

After this fix, only one essay still complains during build:

```
Error parsing essay meta llm-comparison: Error: Invalid frontmatter:
  title is required and must be a string
  description is required and must be a string
  ...
```

`llm-comparison.mdx` has **zero frontmatter** and is **not marked draft**. It's also untracked (sitting in your working tree, not committed). Fix by either:

- Adding minimal frontmatter (`title`, `date`, `type`, `topics`, `draft: true`)
- Deleting the file (untracked, safe to remove)

Out of scope for this PR — that's a content fix, not a code fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)