### PR TITLE
Redesign /essays list as editorial rows

### DIFF
--- a/apps/blog/components/essay/EssayFilters.tsx
+++ b/apps/blog/components/essay/EssayFilters.tsx
@@ -2,9 +2,9 @@
 
 import * as React from 'react';
 import { useRouter, useSearchParams, usePathname } from 'next/navigation';
-import { Button, Badge } from '@blog/ui';
 import { cn } from '@/lib/utils';
 import { ESSAY_TYPES, TOPICS, getEssayTypeLabels, getTopicLabels } from '@/lib/constants';
+import { translate } from '@/lib/i18n/translations';
 import type { EssayType, Topic, Language } from '@/types/content';
 
 export interface EssayFiltersProps {
@@ -18,13 +18,21 @@ export interface EssayFiltersProps {
   language?: Language;
 }
 
+/** Shared chip styling: quiet text toggle, active = accent underline. */
+const CHIP_BASE =
+  'essay-chip inline-flex min-h-[44px] items-center px-2 text-body-sm leading-none ' +
+  'border-b-2 border-transparent transition-colors ' +
+  'focus:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring ' +
+  'focus-visible:ring-offset-2 focus-visible:ring-offset-ground-primary';
+const CHIP_INACTIVE = 'text-figure-muted hover:text-figure-primary';
+const CHIP_ACTIVE = 'text-figure-primary font-medium border-accent-primary';
+
 /**
  * EssayFilters - Filter controls for essay listings
  *
- * Features:
- * - Type filter (button group, mutually exclusive)
- * - Topic filter (toggleable badges, can select multiple)
- * - URL-based state via searchParams
+ * One quiet chip language across two logical groups (type is exclusive,
+ * topics are additive). No heavy borders or filled buttons; the active chip
+ * is marked with an accent underline. State lives in the URL via searchParams.
  */
 export function EssayFilters({
   selectedType = null,
@@ -36,13 +44,11 @@ export function EssayFilters({
   const searchParams = useSearchParams();
   const pathname = usePathname();
 
-  // Get localized labels
   const typeLabels = getEssayTypeLabels(language);
   const topicLabelMap = getTopicLabels(language);
 
-  // Build options with localized labels
   const essayTypeOptions: { value: EssayType | null; label: string }[] = [
-    { value: null, label: language === 'zh' ? '全部' : 'All' },
+    { value: null, label: translate(language, 'filter.all') },
     ...ESSAY_TYPES.map((type) => ({ value: type, label: typeLabels[type] })),
   ];
 
@@ -51,31 +57,24 @@ export function EssayFilters({
     label: topicLabelMap[topic],
   }));
 
-  // Determine base path from current pathname
   const basePath = pathname.startsWith('/zh') ? '/zh/essays' : '/essays';
 
-  /**
-   * Update URL with new filter values
-   */
   const updateFilters = React.useCallback(
     (type: EssayType | null, topicsList: Topic[]) => {
       const params = new URLSearchParams(searchParams.toString());
 
-      // Update type param
       if (type) {
         params.set('type', type);
       } else {
         params.delete('type');
       }
 
-      // Update topics param (comma-separated)
       if (topicsList.length > 0) {
         params.set('topics', topicsList.join(','));
       } else {
         params.delete('topics');
       }
 
-      // Navigate with new params
       const queryString = params.toString();
       router.push(queryString ? `${basePath}?${queryString}` : basePath, {
         scroll: false,
@@ -84,16 +83,10 @@ export function EssayFilters({
     [router, searchParams, basePath]
   );
 
-  /**
-   * Handle type filter change
-   */
   const handleTypeChange = (type: EssayType | null) => {
     updateFilters(type, selectedTopics);
   };
 
-  /**
-   * Handle topic toggle
-   */
   const handleTopicToggle = (topic: Topic) => {
     const newTopics = selectedTopics.includes(topic)
       ? selectedTopics.filter((t) => t !== topic)
@@ -101,92 +94,77 @@ export function EssayFilters({
     updateFilters(selectedType, newTopics);
   };
 
-  /**
-   * Clear all filters
-   */
   const handleClearAll = () => {
     updateFilters(null, []);
   };
 
   const hasActiveFilters = selectedType !== null || selectedTopics.length > 0;
-  const typeLabel = language === 'zh' ? '类型:' : 'Type:';
-  const topicsLabel = language === 'zh' ? '主题:' : 'Topics:';
-  const clearLabel = language === 'zh' ? '清除筛选' : 'Clear all filters';
 
   return (
-    <div className={cn('essay-filters space-y-4', className)} data-has-filters={hasActiveFilters}>
-      {/* Type filter - button group */}
-      <div className="essay-filters-type flex flex-wrap items-center gap-2">
-        <span className="essay-filters-label text-body-sm text-figure-muted">{typeLabel}</span>
-        <div
-          className="essay-filters-type-group flex flex-wrap gap-1"
-          role="group"
-          aria-label="Filter by essay type"
-        >
-          {essayTypeOptions.map(({ value, label }) => {
-            const isSelected = selectedType === value;
-            return (
-              <Button
-                key={label}
-                variant={isSelected ? 'primary' : 'ghost'}
-                size="sm"
-                onClick={() => handleTypeChange(value)}
-                aria-pressed={isSelected}
-                className="essay-filters-type-btn"
-                data-type={value ?? 'all'}
-                data-selected={isSelected}
-              >
-                {label}
-              </Button>
-            );
-          })}
-        </div>
+    <div className={cn('essay-filters space-y-3', className)} data-has-filters={hasActiveFilters}>
+      {/* Type filter - exclusive */}
+      <div
+        className="essay-filters-type flex flex-wrap items-center gap-x-2 gap-y-1"
+        role="group"
+        aria-label={translate(language, 'filter.byType')}
+      >
+        {essayTypeOptions.map(({ value, label }) => {
+          const isSelected = selectedType === value;
+          return (
+            <button
+              key={label}
+              type="button"
+              onClick={() => handleTypeChange(value)}
+              aria-pressed={isSelected}
+              className={cn(CHIP_BASE, isSelected ? CHIP_ACTIVE : CHIP_INACTIVE)}
+              data-type={value ?? 'all'}
+              data-selected={isSelected}
+            >
+              {label}
+            </button>
+          );
+        })}
       </div>
 
-      {/* Topic filter - toggleable badges */}
-      <div className="essay-filters-topics flex flex-wrap items-center gap-2">
-        <span className="essay-filters-label text-body-sm text-figure-muted">{topicsLabel}</span>
-        <div
-          className="essay-filters-topics-group flex flex-wrap gap-2"
-          role="group"
-          aria-label="Filter by topic"
-        >
-          {topicOptions.map(({ value, label }) => {
-            const isSelected = selectedTopics.includes(value);
-            return (
-              <button
-                key={value}
-                onClick={() => handleTopicToggle(value)}
-                aria-pressed={isSelected}
-                className="essay-filters-topic-btn focus:outline-none focus-visible:ring-2 focus-visible:ring-action-primary focus-visible:ring-offset-2 rounded-full"
-                data-topic={value}
-                data-selected={isSelected}
-              >
-                <Badge
-                  variant={isSelected ? 'primary' : 'outline'}
-                  size="md"
-                  className="cursor-pointer transition-colors"
-                >
-                  {label}
-                </Badge>
-              </button>
-            );
-          })}
-        </div>
+      {/* Topic filter - additive */}
+      <div
+        className="essay-filters-topics flex flex-wrap items-center gap-x-2 gap-y-1"
+        role="group"
+        aria-label={translate(language, 'filter.byTopic')}
+      >
+        {topicOptions.map(({ value, label }) => {
+          const isSelected = selectedTopics.includes(value);
+          return (
+            <button
+              key={value}
+              type="button"
+              onClick={() => handleTopicToggle(value)}
+              aria-pressed={isSelected}
+              className={cn(CHIP_BASE, isSelected ? CHIP_ACTIVE : CHIP_INACTIVE)}
+              data-topic={value}
+              data-selected={isSelected}
+            >
+              {label}
+            </button>
+          );
+        })}
       </div>
 
       {/* Clear filters */}
       {hasActiveFilters && (
-        <div className="essay-filters-clear pt-2">
-          <Button
-            variant="link"
-            size="sm"
-            onClick={handleClearAll}
-            className="essay-filters-clear-btn text-figure-muted hover:text-figure-primary"
-          >
-            {clearLabel}
-          </Button>
-        </div>
+        <button
+          type="button"
+          onClick={handleClearAll}
+          className={cn(
+            'essay-filters-clear-btn inline-flex min-h-[44px] items-center text-body-sm text-figure-muted',
+            'underline decoration-border underline-offset-4 transition-colors',
+            'hover:text-figure-primary hover:decoration-figure-primary',
+            'focus:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring',
+            'focus-visible:ring-offset-2 focus-visible:ring-offset-ground-primary'
+          )}
+        >
+          {translate(language, 'filter.clear')}
+        </button>
       )}
     </div>
   );

--- a/apps/blog/components/essay/EssayFiltersSkeleton.tsx
+++ b/apps/blog/components/essay/EssayFiltersSkeleton.tsx
@@ -12,35 +12,27 @@ export interface EssayFiltersSkeletonProps {
  */
 export function EssayFiltersSkeleton({ className }: EssayFiltersSkeletonProps) {
   return (
-    <div className={cn('essay-filters-skeleton space-y-4 animate-pulse', className)}>
-      {/* Type filter skeleton */}
-      <div className="flex flex-wrap items-center gap-2">
-        <span className="h-4 w-10 bg-ground-secondary rounded" />
-        <div className="flex flex-wrap gap-1">
-          {/* 6 type buttons: All, Guide, Deep Dive, Opinion, Review, Narrative */}
-          {[40, 48, 72, 56, 52, 64].map((width, i) => (
-            <div
-              key={i}
-              className="h-8 bg-ground-secondary rounded"
-              style={{ width: `${width}px` }}
-            />
-          ))}
-        </div>
+    <div className={cn('essay-filters-skeleton space-y-3 animate-pulse', className)}>
+      {/* Type chips: All, Guide, Deep Dive, Opinion, Review, Narrative */}
+      <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+        {[28, 40, 64, 48, 44, 56].map((width, i) => (
+          <div
+            key={i}
+            className="h-6 rounded bg-ground-secondary"
+            style={{ width: `${width}px` }}
+          />
+        ))}
       </div>
 
-      {/* Topic filter skeleton */}
-      <div className="flex flex-wrap items-center gap-2">
-        <span className="h-4 w-12 bg-ground-secondary rounded" />
-        <div className="flex flex-wrap gap-2">
-          {/* 4 topic badges: Technical, AI, Product, Career */}
-          {[72, 32, 56, 52].map((width, i) => (
-            <div
-              key={i}
-              className="h-7 bg-ground-secondary rounded-full"
-              style={{ width: `${width}px` }}
-            />
-          ))}
-        </div>
+      {/* Topic chips: 8 topics */}
+      <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+        {[48, 24, 44, 40, 48, 40, 44, 44].map((width, i) => (
+          <div
+            key={i}
+            className="h-6 rounded bg-ground-secondary"
+            style={{ width: `${width}px` }}
+          />
+        ))}
       </div>
     </div>
   );

--- a/apps/blog/components/essay/EssayList.tsx
+++ b/apps/blog/components/essay/EssayList.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 import { cn } from '@/lib/utils';
+import { translate } from '@/lib/i18n/translations';
 import { EssayCard } from './EssayCard';
+import { EssayRow } from './EssayRow';
 import type { EssayMeta, Language } from '@/types/content';
 
 export interface EssayListProps {
   /** Array of essays to display */
   essays: EssayMeta[];
-  /** Visual variant for cards */
+  /** Visual variant for cards (grid layout only) */
   variant?: 'default' | 'compact';
   /** Layout variant */
   layout?: 'grid' | 'list';
@@ -18,14 +20,16 @@ export interface EssayListProps {
   basePath?: string;
   /** Language for localized labels (defaults to en) */
   language?: Language;
+  /** Accessible label for the list landmark */
+  ariaLabel?: string;
 }
 
 /**
- * EssayList - Grid or list of essay cards
+ * EssayList - List or grid of essays
  *
  * Layouts:
- * - grid: Responsive grid (1 col mobile, 2 cols tablet, 3 cols desktop)
- * - list: Single column list with larger cards
+ * - list: Editorial rows (EssayRow), separated by hairline rules, left-aligned.
+ * - grid: Responsive card grid (EssayCard) for comparison-style browsing.
  */
 export function EssayList({
   essays,
@@ -35,26 +39,62 @@ export function EssayList({
   emptyMessage = 'No essays found.',
   basePath = '/essays',
   language = 'en',
+  ariaLabel,
 }: EssayListProps) {
+  const listLabel = ariaLabel ?? translate(language, 'essays.listLabel');
+
   if (essays.length === 0) {
     return (
-      <div className={cn('essay-list essay-list--empty py-12 text-center text-figure-muted', className)}>
-        <p className="essay-list-empty-message">{emptyMessage}</p>
+      <div
+        className={cn(
+          'essay-list essay-list--empty -mx-4 border-t border-border px-4 py-16 text-figure-muted',
+          className
+        )}
+      >
+        <p className="essay-list-empty-message text-body">{emptyMessage}</p>
       </div>
     );
   }
 
-  const layoutStyles = {
-    grid: 'grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3',
-    list: 'flex flex-col gap-4',
-  };
+  if (layout === 'list') {
+    return (
+      <ul
+        className={cn('essay-list -mx-4 flex flex-col', className)}
+        aria-label={listLabel}
+        data-layout="list"
+        data-count={essays.length}
+      >
+        {essays.map((essay) => (
+          <li
+            key={essay.slug}
+            className="essay-list-item border-t border-border"
+          >
+            <EssayRow
+              slug={essay.slug}
+              type={essay.type}
+              topics={essay.topics}
+              title={essay.title}
+              description={essay.description}
+              date={essay.date}
+              readingTime={essay.readingTime}
+              basePath={basePath}
+              language={language}
+            />
+          </li>
+        ))}
+      </ul>
+    );
+  }
 
   return (
     <div
-      className={cn('essay-list', layoutStyles[layout], className)}
+      className={cn(
+        'essay-list grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3',
+        className
+      )}
       role="list"
-      aria-label="Essay list"
-      data-layout={layout}
+      aria-label={listLabel}
+      data-layout="grid"
       data-count={essays.length}
     >
       {essays.map((essay) => (

--- a/apps/blog/components/essay/EssayRow.stories.tsx
+++ b/apps/blog/components/essay/EssayRow.stories.tsx
@@ -1,0 +1,71 @@
+import * as React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { EssayRow } from './EssayRow';
+
+const meta: Meta<typeof EssayRow> = {
+  title: 'Blog / Essay / EssayRow',
+  component: EssayRow,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    type: {
+      control: 'select',
+      options: ['guide', 'deep-dive', 'opinion', 'review', 'narrative'],
+    },
+    topics: {
+      control: 'check',
+      options: ['technical', 'ai', 'product', 'career'],
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="max-w-3xl">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof EssayRow>;
+
+export const Default: Story = {
+  args: {
+    slug: 'how-transformers-work',
+    type: 'guide',
+    topics: ['technical', 'ai'],
+    title: 'How Transformers Work',
+    description:
+      'A comprehensive guide to understanding the transformer architecture that powers modern AI systems and large language models.',
+    date: '2024-12-14',
+    readingTime: 15,
+  },
+};
+
+export const List: Story = {
+  render: (args) => (
+    <ul className="flex flex-col">
+      {[
+        { ...args, slug: 'a', title: 'Coding Agents Connect Desktop, iPhone, and Pixel', type: 'narrative' as const, topics: ['ai' as const], readingTime: 7 },
+        { ...args, slug: 'b', title: 'The Decision Game', type: 'opinion' as const, topics: ['career' as const], readingTime: 5 },
+        { ...args, slug: 'c', title: 'On Programmer Craftsmanship', type: 'guide' as const, topics: ['technical' as const], readingTime: 8 },
+      ].map((row) => (
+        <li key={row.slug} className="border-t border-border">
+          <EssayRow {...row} />
+        </li>
+      ))}
+    </ul>
+  ),
+  args: {
+    slug: 'placeholder',
+    type: 'narrative',
+    topics: ['ai'],
+    title: 'Placeholder',
+    description:
+      'When a coding agent links desktop, iPhone, and Pixel into one workflow loop, mobile development finally feels seamless.',
+    date: '2026-05-15',
+    readingTime: 7,
+  },
+};

--- a/apps/blog/components/essay/EssayRow.tsx
+++ b/apps/blog/components/essay/EssayRow.tsx
@@ -1,0 +1,117 @@
+import Link from 'next/link';
+import { cn } from '@/lib/utils';
+import { getEssayTypeLabel, getTopicLabel } from '@/lib/constants';
+import { formatDate, formatReadingTime, translate } from '@/lib/i18n/translations';
+import type { EssayType, Topic, Language } from '@/types/content';
+
+export interface EssayRowProps {
+  /** Essay slug for URL */
+  slug: string;
+  /** Essay type (guide, deep-dive, opinion, review, narrative) */
+  type: EssayType;
+  /** Topics covered by the essay */
+  topics: Topic[];
+  /** Essay title */
+  title: string;
+  /** Description (truncated to one line) */
+  description: string;
+  /** Publication date in ISO format (YYYY-MM-DD) */
+  date: string;
+  /** Reading time in minutes */
+  readingTime?: number;
+  /** Additional CSS classes */
+  className?: string;
+  /** Base path for essay links (defaults to /essays) */
+  basePath?: string;
+  /** Language for localized labels (defaults to en) */
+  language?: Language;
+}
+
+/**
+ * EssayRow - Editorial list row for essay listings
+ *
+ * A flat, left-aligned typographic row (no card chrome): meta line, serif
+ * title, one-line description, and date. The whole row is one link. Hover
+ * tints a slightly-bled background; keyboard focus shows a ring on the row.
+ * Text aligns to the same left edge as the page header and filters.
+ */
+export function EssayRow({
+  slug,
+  type,
+  topics,
+  title,
+  description,
+  date,
+  readingTime,
+  className,
+  basePath = '/essays',
+  language = 'en',
+}: EssayRowProps) {
+  const typeLabel = getEssayTypeLabel(type, language);
+
+  return (
+    <article
+      className={cn(
+        'essay-row group relative',
+        'transition-colors duration-150 hover:bg-ground-secondary',
+        className
+      )}
+      data-type={type}
+    >
+      <Link
+        href={`${basePath}/${slug}`}
+        aria-label={translate(language, 'essays.read', { title })}
+        className={cn(
+          'essay-row-link absolute inset-0 z-10',
+          'focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-focus-ring'
+        )}
+      />
+
+      <div className="flex flex-col gap-2 px-4 py-7">
+        {/* Meta: type kicker, then topic tags */}
+        <div className="essay-row-meta flex flex-wrap items-baseline gap-x-3 gap-y-1 text-caption">
+          <span className="essay-row-type font-semibold uppercase tracking-[0.08em] text-figure-secondary">
+            {typeLabel}
+          </span>
+          {topics.length > 0 && (
+            <span className="essay-row-topics flex flex-wrap items-center gap-x-2 text-figure-muted">
+              {topics.map((topic, i) => (
+                <span key={topic} className="flex items-center gap-x-2">
+                  {i > 0 && <span aria-hidden="true">·</span>}
+                  <span className="essay-row-topic">{getTopicLabel(topic, language)}</span>
+                </span>
+              ))}
+            </span>
+          )}
+        </div>
+
+        {/* Title */}
+        <h3 className="essay-row-title type-h4 text-balance text-figure-primary transition-colors group-hover:text-link">
+          {title}
+        </h3>
+
+        {/* Description - one line */}
+        {description && (
+          <p className="essay-row-description line-clamp-1 text-body text-figure-secondary">
+            {description}
+          </p>
+        )}
+
+        {/* Date and reading time */}
+        <div className="essay-row-footer flex items-center gap-2 text-caption text-figure-muted">
+          <time dateTime={date} className="essay-row-date">
+            {formatDate(language, date)}
+          </time>
+          {readingTime && (
+            <>
+              <span aria-hidden="true">·</span>
+              <span className="essay-row-reading-time">
+                {formatReadingTime(language, readingTime)}
+              </span>
+            </>
+          )}
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/apps/blog/components/essay/index.ts
+++ b/apps/blog/components/essay/index.ts
@@ -1,6 +1,7 @@
 export { EssayLayout, type EssayLayoutProps, type TocItem } from './EssayLayout';
 export { EssayHeader, type EssayHeaderProps } from './EssayHeader';
 export { EssayCard, type EssayCardProps } from './EssayCard';
+export { EssayRow, type EssayRowProps } from './EssayRow';
 export { EssayList, type EssayListProps } from './EssayList';
 export { EssayFilters, type EssayFiltersProps } from './EssayFilters';
 export { EssayFiltersSkeleton, type EssayFiltersSkeletonProps } from './EssayFiltersSkeleton';

--- a/apps/blog/components/pages/EssaysIndexPage.tsx
+++ b/apps/blog/components/pages/EssaysIndexPage.tsx
@@ -24,13 +24,13 @@ export function EssaysIndexPage({ language = 'en' }: EssaysIndexPageProps) {
   const allEssays = getAllEssays({ language, includeDrafts: false });
 
   return (
-    <main className="mx-auto max-w-5xl lg:max-w-6xl px-inset-lg py-12">
+    <main className="mx-auto max-w-3xl px-inset-lg py-16">
       {/* Page header - static content */}
-      <header className="mb-8">
-        <h1 className="text-display font-serif text-figure-primary mb-2">
+      <header className="mb-10">
+        <h1 className="type-display text-balance text-figure-primary">
           {t('nav.essays')}
         </h1>
-        <p className="text-body-lg text-figure-secondary">
+        <p className="mt-3 type-body text-figure-secondary">
           {t('site.tagline')}
         </p>
       </header>

--- a/apps/blog/components/pages/EssaysPageContent.tsx
+++ b/apps/blog/components/pages/EssaysPageContent.tsx
@@ -75,7 +75,11 @@ function EssaysContentInner({ essays, language, basePath }: EssaysPageContentPro
         language={language}
       />
 
-      <div className="mb-6 text-body-sm text-figure-muted">
+      <div
+        className="mb-2 text-caption text-figure-muted"
+        role="status"
+        aria-live="polite"
+      >
         {resultsText}
         {hasActiveFilters && <span> {matchingText}</span>}
       </div>
@@ -96,14 +100,17 @@ function EssaysContentInner({ essays, language, basePath }: EssaysPageContentPro
  */
 function EssaysLoadingSkeleton() {
   return (
-    <div className="space-y-4">
+    <div className="animate-pulse">
       <EssayFiltersSkeleton className="mb-8" />
-      <div className="mb-6">
-        <div className="h-4 w-24 bg-ground-secondary rounded animate-pulse" />
-      </div>
-      <div className="space-y-4">
-        {[1, 2, 3].map((i) => (
-          <div key={i} className="h-32 bg-ground-secondary rounded-lg animate-pulse" />
+      <div className="mb-2 h-3 w-20 rounded bg-ground-secondary" />
+      <div className="-mx-4 flex flex-col">
+        {[1, 2, 3, 4].map((i) => (
+          <div key={i} className="flex flex-col gap-2 border-t border-border px-4 py-7">
+            <div className="h-3 w-28 rounded bg-ground-secondary" />
+            <div className="h-6 w-3/4 rounded bg-ground-secondary" />
+            <div className="h-4 w-full rounded bg-ground-secondary" />
+            <div className="h-3 w-32 rounded bg-ground-secondary" />
+          </div>
         ))}
       </div>
     </div>

--- a/apps/blog/lib/i18n/locales/en.json
+++ b/apps/blog/lib/i18n/locales/en.json
@@ -38,6 +38,8 @@
   "filter.topics": "Topics",
   "filter.category": "Category",
   "filter.clear": "Clear filters",
+  "filter.byType": "Filter by type",
+  "filter.byTopic": "Filter by topic",
   "filter.results": "{count} essays",
   "filter.results.singular": "1 essay",
   "filter.noResults": "No essays found",
@@ -72,6 +74,8 @@
 
   "essays.matchingFilters": "matching filters",
   "essays.emptyFiltered": "No essays match the selected filters. Try adjusting your filters.",
+  "essays.read": "Read \"{title}\"",
+  "essays.listLabel": "Essays",
 
   "footer.copyright": "© {year} All rights reserved.",
   "footer.builtWith": "Built with Next.js",

--- a/apps/blog/lib/i18n/locales/zh.json
+++ b/apps/blog/lib/i18n/locales/zh.json
@@ -38,6 +38,8 @@
   "filter.topics": "主题",
   "filter.category": "分类",
   "filter.clear": "清除筛选",
+  "filter.byType": "按类型筛选",
+  "filter.byTopic": "按主题筛选",
   "filter.results": "{count} 篇文章",
   "filter.results.singular": "1 篇文章",
   "filter.noResults": "没有找到文章",
@@ -72,6 +74,8 @@
 
   "essays.matchingFilters": "符合筛选条件",
   "essays.emptyFiltered": "没有符合筛选条件的文章。请尝试调整筛选条件。",
+  "essays.read": "阅读《{title}》",
+  "essays.listLabel": "文章列表",
 
   "footer.copyright": "© {year} 版权所有",
   "footer.builtWith": "使用 Next.js 构建",


### PR DESCRIPTION
Redesigns the `/essays` index from a card grid into a calm, left-aligned editorial list. Started as an `impeccable audit`, then `shape` → `craft` with browser iteration across both locales, both themes, and all states.

## What changed
- **New `EssayRow`** — flat, hairline-divided rows (no card chrome). Replaces the `Card`-based rows whose internal padding double-indented the text past the page header.
- **Type vs. topic distinction** — the essay type now reads as an uppercase, letter-spaced, heavier kicker; topics stay as muted regular-weight tags.
- **Aligned hover/focus** — the hover highlight, focus ring, and hairline dividers all share one bled width, with the text padded back to the page's content edge. The highlight has internal left padding, its edges match the divider ends, and everything stays aligned with the header.
- **Visible keyboard focus ring** on each row (previously invisible — WCAG 2.4.7).
- **Unified quiet filter** — type (exclusive) and topics (additive) now share one chip language; the active chip is marked with an accent underline. No filled buttons, heavy borders, or `Type:`/`Topics:` label prefixes.
- **Typography tokens** — header moved onto the `type-*` system; reading measure narrowed.
- **a11y / i18n** — results count announced via `aria-live`; previously-hardcoded English ARIA strings localized (EN + ZH); 44px touch targets on chips.
- **States** — loading skeleton and empty state reworked to match the new row rhythm.

`EssayList`'s grid layout (using `EssayCard`) is unchanged for other consumers.

## Verification
- Browser-checked: EN + ZH, `nyt` (light) and `chinese-aesthetic` (dark) themes, desktop + mobile (390px); default, filtered, multi-filter, empty, hover, and keyboard-focus states.
- No horizontal overflow (16px bleed fits inside the page's 24px gutter).
- `tsc --noEmit` clean, ESLint clean, 177 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)