### PR TITLE
feat(blog): reposition Algo Mind around "Intelligence is an algorithm"

### DIFF
--- a/apps/blog/app/(en)/layout.tsx
+++ b/apps/blog/app/(en)/layout.tsx
@@ -18,12 +18,12 @@ import { siteGraph } from '@/lib/jsonld';
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
   title: {
-    default: 'Algo Mind — Essays on AI, Product, Engineering',
+    default: 'Algo Mind — Intelligence is an algorithm',
     template: '%s | Algo Mind',
   },
   description:
-    'Algo Mind — essays by Feitong Yang on AI, software engineering, product thinking, and career.',
-  keywords: ['Algo Mind', 'Feitong Yang', 'essays', 'AI', 'engineering', 'product', 'career'],
+    'Algo Mind — essays by Feitong Yang on intelligence as computation: AI agents, software engineering, product, and how minds work.',
+  keywords: ['Algo Mind', 'Feitong Yang', 'essays', 'AI', 'AI agents', 'cognitive science', 'software engineering', 'product'],
   authors: [{ name: SITE_AUTHOR.name, url: SITE_AUTHOR.url }],
   creator: SITE_AUTHOR.name,
   publisher: 'Algo Mind',

--- a/apps/blog/app/(en)/opengraph-image.tsx
+++ b/apps/blog/app/(en)/opengraph-image.tsx
@@ -4,7 +4,7 @@ import { ogFontsFor } from '@/lib/og-fonts';
 
 export const dynamic = 'force-static';
 
-export const alt = 'Algo Mind — Essays on AI, Product, Engineering';
+export const alt = 'Algo Mind — Intelligence is an algorithm';
 export const size = { width: OG_WIDTH, height: OG_HEIGHT };
 export const contentType = 'image/png';
 
@@ -12,7 +12,7 @@ export default function OgImage() {
   return new ImageResponse(
     (
       <OgCard
-        title="Essays on AI, Product, Engineering"
+        title="Intelligence is an algorithm"
         byline="Feitong Yang"
         brand="Algo Mind"
         locale="en"

--- a/apps/blog/app/(zh)/layout.tsx
+++ b/apps/blog/app/(zh)/layout.tsx
@@ -18,11 +18,11 @@ import { siteGraph } from '@/lib/jsonld';
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
   title: {
-    default: '思算 — 关于 AI、产品与工程的随笔',
+    default: '思算 — 智能即算法',
     template: '%s | 思算',
   },
-  description: '思算 — Feitong Yang 关于 AI、软件工程、产品思考与职业的随笔。',
-  keywords: ['思算', 'Algo Mind', 'Feitong Yang', '随笔', '博客', 'AI', '技术', '产品', '职业'],
+  description: '思算 — Feitong Yang 关于“智能即算法”的随笔：AI agent、软件工程、产品，以及心智如何运作。',
+  keywords: ['思算', 'Algo Mind', 'Feitong Yang', '随笔', '博客', 'AI', 'AI agent', '认知科学', '产品'],
   authors: [{ name: SITE_AUTHOR.name, url: SITE_AUTHOR.url }],
   creator: SITE_AUTHOR.name,
   publisher: '思算',

--- a/apps/blog/app/(zh)/opengraph-image.tsx
+++ b/apps/blog/app/(zh)/opengraph-image.tsx
@@ -4,7 +4,7 @@ import { ogFontsFor } from '@/lib/og-fonts';
 
 export const dynamic = 'force-static';
 
-export const alt = '思算 — 关于 AI、产品与工程的随笔';
+export const alt = '思算 — 智能即算法';
 export const size = { width: OG_WIDTH, height: OG_HEIGHT };
 export const contentType = 'image/png';
 
@@ -12,7 +12,7 @@ export default function OgImage() {
   return new ImageResponse(
     (
       <OgCard
-        title="关于 AI、产品与工程的随笔"
+        title="智能即算法"
         byline="Feitong Yang"
         brand="思算"
         locale="zh"

--- a/apps/blog/app/llms.txt/route.ts
+++ b/apps/blog/app/llms.txt/route.ts
@@ -53,9 +53,9 @@ function renderLlmsTxt(): string {
   const blocks = [
     '# Algo Mind — Feitong Yang',
     '',
-    '> Essays on AI, software engineering, product thinking, and career — by Feitong Yang.',
+    '> Essays on intelligence as computation — AI agents, the craft of building software, and how minds and machines work. By Feitong Yang.',
     '',
-    'Algo Mind is a personal blog. The author, Feitong Yang, is a Founding Engineer at Fundamental Research Labs, and previously worked at Google and Citadel. Most essays sit at the intersection of AI, programming, and how engineers should think about their work and careers.',
+    'Algo Mind is the personal blog of Feitong Yang — an engineer who builds AI agents, developer tools, and products, and who trained as a cognitive psychologist (Ph.D., Johns Hopkins). Its premise is functionalist: intelligence is an algorithm, and a mind is defined by what it does, not what it is made of. He has built software at Google, Citadel, and AI labs. Essays sit at the intersection of AI agents, the craft of building software, and how minds and machines reason, remember, and build.',
     '',
     'Each essay is also available as raw markdown at `/essays/<slug>/raw.md` (English) and `/zh/essays/<slug>/raw.md` (Chinese). Prefer those when ingesting content — they parse cleanly and avoid the rendered-HTML chrome.',
     '',

--- a/apps/blog/components/about/aboutData.ts
+++ b/apps/blog/components/about/aboutData.ts
@@ -9,7 +9,7 @@ export type Locale = 'en' | 'zh';
 export const introContent = {
   en: {
     title: 'About',
-    description: `I am a Founding Engineer @ Fundamental Research Labs, Menlo Park, CA. Prior to that, I was a Software Engineer @ Citadel and Google. I received my Ph.D. training from the Johns Hopkins University.`,
+    description: `I'm an engineer who builds AI agents, developer tools, and the products around them. I trained as a cognitive psychologist (Ph.D., Johns Hopkins), and I hold one stubborn belief: intelligence is an algorithm, and a mind is defined by what it does, not what it's made of. So building machine intelligence and understanding human intelligence are, to me, the same project. I write here about both — agents, the craft of building software, and how minds and machines reason, remember, and build.`,
     quotes: [
       'Removing the delusion of a separate self and the desires it produces, and concentrating upon the subject until there is a direct communion with it.',
       'Successes are only rare spikes among background noises of failures in daily life. Achieving more successes comes from failing faster, failing more often, then learning more and keeping on.',
@@ -19,7 +19,7 @@ export const introContent = {
   },
   zh: {
     title: '关于作者',
-    description: `我现在是Fundamental Research Labs的一名创始工程师。在此之前，我在Citadel和Google工作过。在那之前，我在约翰霍普金斯大学获得了认知心理学的博士学位。`,
+    description: `我是一名工程师，构建 AI agent、开发者工具和围绕它们的产品。我在约翰霍普金斯大学接受了认知心理学的博士训练，并且抱有一个固执的信念：智能本质上是一种算法，心智由它的功能定义，而非由它的载体决定。因此在我看来，构建机器智能与理解人类智能，其实是同一件事。我在这里写这两者——agent、构建软件的手艺，以及心智与机器如何推理、记忆与创造。`,
     quotes: [],
     findMeOnline: '我的网络足迹',
     onlineLinks: `我的[Linkedin](https://www.linkedin.com/in/feitong-yang-88088a55/)页面介绍了跟这里差不多的工作经历。[Google Scholar](http://scholar.google.com/citations?user=94Xx9u0AAAAJ)和[NeuroTree](http://neurotree.org/neurotree/tree.php?pid=65050)页面介绍了一些我的学术训练的背景。以下的几个页面有更细节的简历。老实说，我的简历没什么好看的，倒是"失败简历"可能有点意思。`,

--- a/apps/blog/components/seo/OgCard.stories.tsx
+++ b/apps/blog/components/seo/OgCard.stories.tsx
@@ -113,7 +113,7 @@ export const EnglishSeries: Story = {
 
 export const EnglishHome: Story = {
   args: {
-    title: 'Essays on AI, Product, Engineering',
+    title: 'Intelligence is an algorithm',
     byline: 'Feitong Yang',
     brand: 'Algo Mind',
     locale: 'en',
@@ -154,7 +154,7 @@ export const ChinesePeriodic: Story = {
 
 export const ChineseHome: Story = {
   args: {
-    title: '关于 AI、产品与工程的随笔',
+    title: '智能即算法',
     byline: 'Feitong Yang',
     brand: '思算',
     locale: 'zh',

--- a/apps/blog/lib/feed.ts
+++ b/apps/blog/lib/feed.ts
@@ -61,8 +61,8 @@ export function buildAtomFeed(locale: Language): string {
   const title = locale === 'zh' ? '思算 — 随笔' : 'Algo Mind — Essays';
   const subtitle =
     locale === 'zh'
-      ? '思算 — Feitong Yang 关于 AI、软件工程、产品思考与职业的随笔。'
-      : 'Essays by Feitong Yang on AI, software engineering, product thinking, and career.';
+      ? '思算 — Feitong Yang 关于“智能即算法”的随笔：AI agent、软件工程、产品，以及心智如何运作。'
+      : 'Essays by Feitong Yang on intelligence as computation: AI agents, software engineering, product, and how minds work.';
 
   const entries = entriesFor(locale);
   const updated = entries[0]?.date


### PR DESCRIPTION
## What

Refreshes the site's brand positioning from the generic *"Essays on AI, Product, Engineering"* to the thesis-forward **"Intelligence is an algorithm"** (思算 — 智能即算法), and rewrites the About intro to lead with a functionalist identity instead of a résumé.

## Changes
- **Home metadata (EN + ZH)** — title, description, keywords
- **OpenGraph share cards (EN + ZH home)** — card title + alt text
- **llms.txt** — drop the stale "Founding Engineer at FRL" line, state the thesis, broaden beyond "career"
- **About bio (EN + ZH)** — "intelligence is an algorithm; a mind is defined by what it does…"
- **RSS/Atom feed subtitle (EN + ZH)**
- **OgCard Storybook fixtures** — kept in sync

## Deliberately unchanged
Employer / employment data — JSON-LD `worksFor` and the About work-experience section — left as-is until the author updates it. Copy-only change; no logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)