### PR TITLE
[codex] Add 2026 career reflection essay

### DIFF
--- a/apps/blog/content/essays/job-career-2026.mdx
+++ b/apps/blog/content/essays/job-career-2026.mdx
@@ -1,0 +1,46 @@
+---
+title: "Career perspectives - 2026"
+description: "After two years as a founding engineer at a startup, I have lots of new thoughts about my career."
+date: "2026-06-17"
+type: narrative
+topics:
+  - career
+lang: en
+---
+
+It has been eight years since I first started searching for an industry job. Things have changed a lot since my [first record of job search](./job-search-reflection.mdx), but in retrospect, there are core things that have never changed, and have become more clear.
+
+What has made a huge impact was my past two-year experiences as a founding engineer at Fundamental Research Labs/Altera. This is my first startup job, and it is a very different experience. It has opened a lot of doors for me and also helped me think a lot of the careers.
+
+# Things that changed
+
+I have never done anything related to AR/VR or visual science. Neither have I done anything related to machine learning engineering. I spent my first three years to learn large scale distributed system and that is extermely interesting to me: to build a scalable, distributed system that allow huge amount of data processing and embeding the intelligence inside this processing. There's a lot of beauty of software design, the computer system technologies. it is just so many things to leanr and so many layers of depth can be revealed.
+
+I never did any research role. It turns out engineering, which leave me out of open-ended research, provides lots of assurance to my mind. I am way better at structured thinking for solving a long term engineering problem, not only I am more excited, but also I have geniunely developed knowledge that I can see a long term vision of engieering project. That is probably because I have seen  the world's best engineering system from Google, their practices, their processes, their philosophies, and their culture.
+
+Luckily I have never ended up being a data scientist. I am not that 
+
+so regarding the ranking in my 2017 essay, I was at rank 3. Not bad when looking back. And personally I would not put the Vision/VR/AR to my top. In that sense, I have changed a lot as a person.
+
+another thing i didn't realize is I actually want to take more risks. Although I only joined my first start up after 6 years of indsutry work, I did find that I want to work at the startup vibe, but I do need a better startup workspace culture.
+
+
+# Things that never changed, but strenghthen
+
+topic: people/team and the project being interesting are two most important things. Although I think we need to be more commercial and care about the business world. that means, I need to participage in getting involve in the larger world more.
+
+turns out I have a good, consistent understanding of my self, and that personal profile remains to be true from 2017 to 2023 to 2026.
+
+What I didn't realize, but now I realize more, is I am leaning towards being a people-person. I really care about the team I am in and really care about the people I work with. I also really, really want to have a collaborative buddy-pair-coding relationship with my team. It turned that that if I have a team mate with a very close working relationship, two of us can do a lot of work together at a very fast pace, with or without AI. I didn't have that buddy when I was at Google, but I was lucky to have one when I was at Citadel, and one when I was at Altera. So all the previous emphasize on the team is actually about this.
+
+the work also needs to be interesting to me. At this point, since I have tasted the experience of making a product, and we are now living in an AI era. I start to want spend more time on really making product. When I read my previous eassy, I realize I always want to make products that a lot of people to use. However, previous I don't really know what that means. I also find that I am more excited to make products that I would love to use. The only problem is how to translate that initial seed into a product that a LOT of people enjoy to use. 
+
+Also, I finally have come to a determination that I am not interested in becoming a quant researcher working at a quant firm. That is a successful result from my experience at Citadel. It has become very clear recently that I cannot even fake the passion to interview with quant firms, even though I know they pay a lot of money. That being said, Citadel did teach me some interesting things about the world through which information can be used to trade. When I come to a clearer understanding of the problem per se and when it is not just making money for the sake of making money, but instead lending me a tool to gain deper and broader understand of the world, it becomes more interesting. Then it would falls into the category of interesting work.
+
+# Perspectives on the next 3 to 5 years
+
+The world is changing rapidly day by day.
+
+I have never been so excited as a software developer. At the same time, I was quite burned out from the past two years at the startup. It was not just the work that causing the burnout, but more from the chaotic nature of a startup. I guess chaotic is a normal for a startup, maybe? I don't know, I have only one startup experience.
+
+in to small scope: i want to try more 0 to 1, from idea to the market.


### PR DESCRIPTION
## What
Adds the current snapshot of `apps/blog/content/essays/job-career-2026.mdx` as a new career reflection essay.

## Why
This picks up the `Job reflection 2026` item from the editorial plan as a personal archive / ritual essay.

Refs #128

## Validation
Could not run `pnpm --filter @blog/blog build:next` because dependencies are not installed in either checkout: `next: command not found`, `node_modules` missing.