### PR TITLE
fix(blog): use const for interval in XEmbed to fix Pages deploy

### DIFF
--- a/apps/blog/components/content/XEmbed.tsx
+++ b/apps/blog/components/content/XEmbed.tsx
@@ -23,7 +23,6 @@ export function XEmbed({ tweetId, className }: XEmbedProps) {
     const container = containerRef.current;
     if (!container) return;
     let cancelled = false;
-    let interval: ReturnType<typeof setInterval> | undefined;
 
     function render() {
       if (cancelled || !container || renderedRef.current || !window.twttr?.widgets) {
@@ -59,9 +58,9 @@ export function XEmbed({ tweetId, className }: XEmbedProps) {
     }
 
     // Script tag may exist before widgets are ready, especially in React Strict Mode.
-    interval = setInterval(() => {
+    const interval = setInterval(() => {
       if (window.twttr?.widgets) {
-        if (interval) clearInterval(interval);
+        clearInterval(interval);
         render();
       }
     }, 100);


### PR DESCRIPTION
## Problem

The [Deploy to GitHub Pages](https://github.com/ftvision/ftvision.github.io/actions/runs/27799069848) workflow failed in the **Build** step. `next build` aborts during its lint/type-check phase on a single ESLint **error**:

```
./components/content/XEmbed.tsx
62:5  Error: 'interval' is never reassigned. Use 'const' instead.  prefer-const
```

Next.js treats lint errors as build failures, so the deploy never produced an artifact. (The other items in the log — `prevMargin`, `SharedTocItem`, `useRef` — are warnings only and were not the cause.)

## Fix

In `apps/blog/components/content/XEmbed.tsx`, `interval` was declared with `let` but only ever assigned once. Declared it as `const` at the assignment site and dropped the now-redundant `if (interval)` guard inside the polling callback. The `const` is still in scope for the effect's cleanup closure, so behavior is unchanged.

## Verification

- `pnpm --filter @blog/blog lint` → exits 0 (only pre-existing warnings remain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)