### PR TITLE
docs(skills): add argumentative essay editor

### DIFF
--- a/.claude/skills/argumentative-essay-editor/SKILL.md
+++ b/.claude/skills/argumentative-essay-editor/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: argumentative-essay-editor
+description: Strengthen argumentative essays by steelmanning the opposition, tightening the thesis spine, assigning citations clear jobs, moving supporting detail into notes, and checking the rendered reading experience. Use when editing opinion essays, public arguments, policy critiques, strategic essays, or bilingual essay drafts where structure, evidence, and reader objections matter.
+---
+
+# Argumentative Essay Editor
+
+Use this skill when the user wants to sharpen an essay's argument rather than merely line-edit prose. The goal is to make the essay harder to dismiss by hostile but serious readers.
+
+## Core Principles
+
+### Make The Opponent Harder To Beat
+
+Do not attack the most convenient version of the opposing view. First identify the opponent's strongest actual premise, preferably in language they would recognize. Then attack that. A credible essay makes the reader feel the author has understood the other side at full strength.
+
+### Name Your Framing
+
+If the essay uses a phrase, metaphor, or accusation that the opponent did not literally use, say so. Then identify the real underlying premise being attacked. This avoids the "they never said that" objection and keeps the argument honest.
+
+### Use Notes As Evidence, Not Self-Commentary
+
+Notes should help readers who will not click the source. Good notes provide direct quotes, factual context, terminology distinctions, source-specific details, or compact evidence. They should not sound like private editorial caveats, apologies, or second thoughts.
+
+### Concede The Strongest Case
+
+A strong essay can grant the parts of the opposing view that are true or plausible. The point is not to win every factual skirmish. The point is to show that after granting the opponent's best evidence, the essay's central conclusion still holds.
+
+### Separate Concession From Surrender
+
+Concession does not mean accepting the opponent's conclusion. Locate the exact step where the opponent moves from a plausible observation to an unsupported conclusion.
+
+Use this pattern:
+
+1. Concede the plausible mechanism or fact.
+2. Challenge the conclusion drawn from it.
+3. Show the missing step between "this could happen" and "therefore our strategy works."
+
+### Show Incentive Chains
+
+Avoid brittle causal claims like "X caused Y" unless the evidence is strong. Often the better argument is about incentives: X made Y more urgent, more rational, more likely, or more strategically necessary. Incentive-chain arguments are usually more defensible than monocausal claims.
+
+### Make Citations Perform Jobs
+
+Every citation should have a purpose. It can establish an event, quote an opponent's claim, document public reaction, support a trend, show a benchmark, or preserve a primary source. If a citation does not change the reader's confidence in a sentence, remove it or replace it.
+
+### Keep Main Text On The Spine
+
+The main essay should carry the thesis, opposition, turn, and conclusion. Supporting texture belongs in notes. Background, caveats, source details, and secondary examples should not interrupt the argument unless they are load-bearing.
+
+### Avoid Self-Defeating Caveats
+
+Precision is good. Timidity is not. A caveat should clarify the claim, not drain the sentence of force. If a sentence can be asserted cleanly, assert it cleanly.
+
+### Render As A Reader
+
+After editing source text, read the rendered page when possible. Notes, references, embeds, paragraph breaks, and punctuation often behave differently in the browser than in the source file. The essay should feel coherent on the page, not just valid in the editor.
+
+## Chinese And Bilingual Essay Polish
+
+Use this section when editing a Chinese version of an argumentative essay, or when syncing an English essay and a Chinese essay.
+
+### Write Chinese As Chinese, Not Translated English
+
+Prefer natural Chinese argumentation over literal translation. Watch for English skeletons that produce stiff Chinese, such as:
+
+- "clean causality" -> use "直接证明因果" or "证明某一次切断直接导致某一个结果."
+- "change incentives" -> use "改变对方的决策" or describe the concrete decision.
+- "stronger case" -> use "更容易成立的辩护" when the claim is narrower, not "更强的版本."
+- "steelman" -> use "强版本的论证" for an argument, or rewrite around the actual stance.
+- "roadmap item" / "backlog item" -> use "可以继续推迟的内部项目" when that is the real meaning.
+
+If a sentence feels like it was translated from English, rewrite the relationship in Chinese first, then restore any necessary technical term.
+
+### Use Chinese Main Text With English Term Anchors
+
+When a term has technical precision, put Chinese first and English in parentheses on first use:
+
+- 开放权重模型（open-weight models）
+- 编程代理（coding agents）
+- 推理轨迹（reasoning traces）
+- 前沿模型（frontier model）
+- 守门人（gatekeeper）
+- 基准测试（benchmark）
+- 递归自我改进（recursive self-improvement, RSI）
+- 事故报告（incident reporting）
+- 相互可见性（mutual visibility）
+- 共享底座（shared substrate）
+- 许可制俱乐部（permissioned club）
+
+Do not leave dense English clusters in Chinese prose. If several English terms appear in one paragraph, translate the paragraph's conceptual load into Chinese and keep only the necessary anchors.
+
+### Localize Names And Objects Readers Know
+
+Use common Chinese names where a Chinese reader would expect them:
+
+- Jensen Huang -> 黄仁勋
+- Huawei -> 华为
+- Huawei Ascend -> 华为昇腾 or 昇腾
+- Jie Tang -> 唐杰
+- Elon Musk -> 马斯克
+
+Keep original English inside citation titles, URLs, source metadata, and direct quotes.
+
+### Choose The Chinese Frame, Not The English Label
+
+For recurring concepts, pick the Chinese frame that carries the argument and keep it stable. If "access denial" functions like supply cutoff in the Chinese argument, use "断供" for the strategic concept, while preserving "访问权限" or "访问路径" for literal API or product-access mechanics.
+
+Avoid switching among near-synonyms such as "拒绝访问," "访问拒绝," "访问控制," and "断供" unless each one marks a real distinction.
+
+### Explain Metaphors Or Replace Them
+
+English metaphors often do not survive directly in Chinese. If a metaphor is not immediately legible, either replace it or expand it into the mechanism.
+
+Example:
+
+- Weak: "你手里有一个旋钮。如果你把线剪断，你就失去了这个旋钮。"
+- Stronger: "只要竞争对手还依赖你，你就仍然能影响它的选择。价格、速度、条款、可用性，都可以成为杠杆。一旦你把这条依赖切断，对方的目标就会变得简单得多：尽快摆脱你。"
+
+### Use Familiar Chinese Phrases Only When Grounded
+
+Chinese idioms and political-philosophy phrases can add force, but only when tied to the essay's mechanism. For example, "历史不是原地打转，而是螺旋上升" works when immediately grounded in the specific claim that each round of catch-up raises the baseline for the next round.
+
+Do not leave a slogan standing alone.
+
+### Keep The Argument's Causal Boundary Clear
+
+When evidence supports sequence and pressure but not direct causality, say so in natural Chinese:
+
+- "这未必能证明某一次切断直接导致了某一个模型。"
+- "我的假设是..."
+- "它很可能缩短了反应时间。"
+
+Then state the strategic mechanism concretely:
+
+- "一旦访问变得不可靠，自食其力、自给自足就不再是口号，而是重要且紧急的任务。"
+
+### Polish Section By Section
+
+For Chinese drafts, review one section at a time. In each section:
+
+1. Identify the paragraph's job in the argument.
+2. Remove English terms that are not needed for precision.
+3. Convert literal translations into Chinese causal relationships.
+4. Make recurring terms consistent.
+5. Keep direct quotes and citation metadata faithful to the source.
+6. Read the rendered paragraph as a Chinese reader would.
+
+## Workflow
+
+1. State the essay's thesis in one sentence.
+2. State the opponent's strongest position in one sentence.
+3. Identify any framing that belongs to the author rather than the opponent.
+4. Mark where the essay overclaims causality, certainty, motive, or evidence.
+5. Identify the main argument spine: setup, opposition, turn, proof, implication, ending.
+6. Move source detail, caveats, quotes, and secondary evidence into notes when they slow the spine.
+7. For each citation, name its job. Delete citations with no job.
+8. Add or tighten concessions where they make the argument more credible.
+9. Convert weak causal claims into incentive-chain claims when the evidence supports sequence and pressure but not proof.
+10. If the essay has translations, mirror structural changes across versions.
+11. Render locally and inspect the reading experience before finishing.
+
+## Review Checklist
+
+- Does the essay attack the opponent's real premise rather than a convenient label?
+- Does it acknowledge when a key phrase is the author's framing?
+- Does each note add evidence, quote, context, or source detail?
+- Do any notes sound like editorial self-criticism?
+- Does the essay concede what must be conceded?
+- Does it distinguish a plausible mechanism from the conclusion drawn from that mechanism?
+- Are causal claims supported, or should they become incentive claims?
+- Does every citation have a clear job?
+- Is the main text still readable without opening the notes?
+- Does the rendered page look and read cleanly?
+
+## Output Style
+
+When reviewing, lead with the highest-leverage structural issues before line edits. Be direct about weak arguments, strawmen, overclaims, citation clutter, and notes that undercut the essay.
+
+When editing, preserve the user's authorship. Prefer targeted rewrites, paragraph inserts, note rewrites, and structural moves over replacing the whole essay unless the user asks for a full redraft.


### PR DESCRIPTION
## Summary
- add a repo-owned argumentative essay editor skill under .claude/skills
- capture the steelman/citation/note workflow from the access-denial essay edit
- include Chinese and bilingual essay polish guidance for future drafts

## Validation
- docs-only change; no tests run