### PR TITLE
feat(skills): add Reddit + LessWrong playbooks to go-to-market

### DIFF
--- a/.claude/skills/go-to-market/SKILL.md
+++ b/.claude/skills/go-to-market/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: go-to-market
-description: Distribute an Algo Mind essay across channels and keep a writing cadence. Use when the user wants to promote, distribute, "go to market", or seed a published or draft essay (Substack, X, LinkedIn, Hacker News, Substack Notes, 知乎/小红书), generate platform-native copy and share assets, or check whether they are overdue to publish. Operationalizes the Distribute and Learn stages of plan/writing-workflow/README.md.
+description: Distribute an Algo Mind essay across channels and keep a writing cadence. Use when the user wants to promote, distribute, "go to market", or seed a published or draft essay (Substack, X, LinkedIn, Hacker News, Substack Notes, Reddit, LessWrong, 知乎/小红书), generate platform-native copy and share assets, or check whether they are overdue to publish. Operationalizes the Distribute and Learn stages of plan/writing-workflow/README.md.
 ---
 
 # Go-to-market for Algo Mind
@@ -39,24 +39,38 @@ Read `apps/blog/content/essays/<slug>.mdx` (and the `-zh` variant if present). P
 |------|----------|
 | Insider / agents | Minecraft + Fairies, agent I/O history, why agents fail |
 | Thesis / cog-sci | intelligence-as-algorithm, context-as-memory |
+| Opinion / discussion | access-denied-is-not-a-moat (AI strategy, field-coordination takes) |
 | Craft / build | ship-the-core, why software is hard, product principles |
 | Tooling / teaching | ds4 / local inference, system-design-interview tool |
 | Career / personal | job reflections, Silicon Valley |
+
+For an **Opinion / discussion** piece, the goal is *the quality of the conversation it
+provokes*, not reach or subscribers. Spine for every channel: **lead with the steelman**
+(the strongest case *against* your position) → the turn → **close on a genuine question you
+don't already know the answer to.** Leading good-faith is what buys a real thread instead of
+a dunk-fest. Keep it field-level (vendor-neutral guardrail) — let the essay carry the
+specifics.
 
 Note language(s): EN, ZH, or both.
 
 ### 2. Pick channels
 `✓` do · `◐` optional / if it fits · `✗` skip
 
-| Type | Substack | X | Notes | HN | LinkedIn | 知乎/小红书 |
-|------|:---:|:---:|:---:|:---:|:---:|:---:|
-| Insider / agents | ✓ | ✓ | ✓ | ✓ | ◐ | ZH only |
-| Thesis / cog-sci | ✓ | ✓ | ✓ | ◐ | ◐ | ZH only |
-| Craft / build | ✓ | ✓ | ✓ | ◐ | ✓ | ZH only |
-| Tooling / teaching | ✓ | ✓ | ✓ | ✓ | ◐ | ZH only |
-| Career / personal | ◐ (keep on blog) | ✓ | ◐ | ✗ | ✓ | ZH only |
+| Type | Substack | X | Notes | HN | LinkedIn | 知乎/小红书 | Reddit | Forums (LW) |
+|------|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| Insider / agents | ✓ | ✓ | ✓ | ✓ | ◐ | ZH only | ◐ | ◐ |
+| Thesis / cog-sci | ✓ | ✓ | ✓ | ◐ | ◐ | ZH only | ◐ | ✓ |
+| Opinion / discussion | ✓ | ✓ | ✓ | ✓ | ✓ | ZH only | ◐ | ✓ |
+| Craft / build | ✓ | ✓ | ✓ | ◐ | ✓ | ZH only | ◐ | ✗ |
+| Tooling / teaching | ✓ | ✓ | ✓ | ✓ | ◐ | ZH only | ◐ | ✗ |
+| Career / personal | ◐ (keep on blog) | ✓ | ◐ | ✗ | ✓ | ZH only | ✗ | ✗ |
 
 The blog is **always** canonical. **Don't** seed Substack with career pieces — wrong signal for the masthead.
+
+**Reddit and Forums are *discussion* venues, not broadcast — and they're gated:**
+- **Reddit** is *participation, not launch*: comment in live threads or post a text self-post with the link secondary; it punishes self-promo and the tribal product subs (`r/ClaudeAI`, `r/OpenAI`) light up the COI — prefer the least-tribal sub that fits (`r/LocalLLaMA` for model/infra takes). `◐` = only via participation.
+- **Forums (LessWrong)** only when the piece is **argument-shaped AND you can answer ~3 comments in 48h.** Start with LW; skip EA Forum/Alignment Forum unless you'll tend a second thread.
+- Both are the **most COI/disclosure-sensitive** channels — disclose affiliations or hold the post. If engagement bandwidth is zero, put it on X instead.
 
 ### 3. Format per channel
 - **Substack** — full text + canonical line + subscribe CTA (template below). Follow [references/substack-playbook.md](references/substack-playbook.md).
@@ -66,6 +80,8 @@ The blog is **always** canonical. **Don't** seed Substack with career pieces —
 - **HN** — submit the canonical URL with a plain, non-clickbait title; add a first comment with context. Best on weekday US mornings. Follow [references/hacker-news-playbook.md](references/hacker-news-playbook.md).
 - **知乎** — adapt, don't translate; lead with the takeaway. Follow [references/zhihu-playbook.md](references/zhihu-playbook.md).
 - **小红书** — turn the idea into a visual, concrete carousel or short video. Follow [references/rednote-playbook.md](references/rednote-playbook.md).
+- **Reddit** — *participation, not launch*: argument first, link secondary; pick the least-tribal sub that fits. Follow [references/reddit-playbook.md](references/reddit-playbook.md).
+- **Forums (LessWrong)** — full-text crosspost + canonical link; epistemic status, steelman-first, name your cruxes, close on a real question. Only if you'll engage. Follow [references/forums-playbook.md](references/forums-playbook.md).
 
 Templates:
 
@@ -132,6 +148,8 @@ To make it a true reminder, schedule it — a weekly cron, or a scheduled Claude
 - [references/hacker-news-playbook.md](references/hacker-news-playbook.md) — HN submission, Show HN, titles, and comments.
 - [references/zhihu-playbook.md](references/zhihu-playbook.md) — Q&A-native Chinese adaptation.
 - [references/rednote-playbook.md](references/rednote-playbook.md) — 小红书 / RedNote visual packaging.
+- [references/reddit-playbook.md](references/reddit-playbook.md) — participation-not-launch, self-promo norms, sub selection. Read before posting to Reddit.
+- [references/forums-playbook.md](references/forums-playbook.md) — LessWrong (+ EA Forum / Alignment Forum): crosspost format, steelman/cruxes bar, engagement gate, COI/disclosure. Best venue for opinion/discussion pieces.
 
 ## Notes
 - This skill is canonical at `.claude/skills/go-to-market/` and symlinked to `.codex/skills/go-to-market` (for Codex). Edit the canonical copy — the symlink follows. Mirror to other harness dirs the same way: `ln -s ../../.claude/skills/go-to-market <dir>/go-to-market`.

--- a/.claude/skills/go-to-market/references/forums-playbook.md
+++ b/.claude/skills/go-to-market/references/forums-playbook.md
@@ -1,0 +1,49 @@
+# Forums playbook — LessWrong (and adjacent: EA Forum, AI Alignment Forum)
+
+Best for: argument-shaped essays on AI strategy, safety, governance, race/coordination
+dynamics, recursive self-improvement, and the field's norms. This is the single best venue
+for a *cooperation/discussion* opinion piece — "how should the AI community behave" is the
+home turf.
+
+**Start with LessWrong.** EA Forum and the AI Alignment Forum are adjacent and overlap
+heavily; don't post to more than one forum you can't actively tend. One tended thread beats
+two neglected ones.
+
+## The gate: only post if you'll engage
+LessWrong rewards light-but-real author presence and penalizes drive-by posts. If you can't
+answer the **2–3 highest-karma comments within ~48h**, don't post here — put that bandwidth
+on X (much lower author-presence expectation) instead.
+
+## Format
+- **Full-text crosspost + canonical link** at top ("Crossposted from <blog URL>"). Full
+  crossposts far outperform bare link posts.
+- Strip the blog JSX; keep prose + section headers; references become a links/footnotes list.
+- Plain, descriptive title. No hype.
+
+## The bar (this is why the venue is good)
+- **Epistemic status** line up top — your real confidence, and that you're inviting pushback.
+- **Steelman first.** State the strongest version of the *opposing* case before your turn, or
+  the comments pattern-match a tribal take and pile on. (An essay that already steelmans its
+  opponent is a perfect fit.)
+- **Name your cruxes** — an explicit "what would change my mind" list. The community engages
+  cruxes, not vibes.
+- **Close on a genuine question** you actually want answered.
+
+## Disclosure / COI (forums are the most sensitive)
+These communities treat an **undisclosed conflict of interest as a serious epistemic foul** —
+worse than the conflict itself. Disclose relevant affiliations/motivations in one line, or
+**hold the post until you can.** A clean disclosure here *builds* credibility; an omission
+that surfaces later destroys it. This is the venue where the skill's vendor-neutral + "check
+comms policy" guardrails bite hardest.
+
+## Avoid
+- Drive-by posting you won't return to.
+- Thesis-with-no-counterargument (reads as advocacy).
+- Marketing voice, "launch" language, or burying the argument under the link.
+- Cross-posting to LW + EA + Alignment Forum at once when you can only tend one.
+
+## Source anchors
+- https://www.lesswrong.com/about
+- https://www.lesswrong.com/faq
+- https://forum.effectivealtruism.org/about
+- https://www.alignmentforum.org/about

--- a/.claude/skills/go-to-market/references/reddit-playbook.md
+++ b/.claude/skills/go-to-market/references/reddit-playbook.md
@@ -1,0 +1,43 @@
+# Reddit playbook
+
+Best for: discussion-shaped essays — opinion/strategy, tooling, agent interfaces, local
+inference, engineering tradeoffs, "is X actually worth it" debates.
+
+Reddit is the most discussion-native venue there is, which makes it tempting. But it
+**punishes self-promotion harder than anywhere** and is **tribal by subreddit**. Treat it as
+a *participation* channel, not a launch channel. The default move is to be *in* a
+conversation, with the link secondary — never a bare blog-link post in a big sub.
+
+## The self-promo rule (don't get removed/buried)
+- Lead with the argument or the useful thing. If the link adds (full case + sources), put it
+  at the *end* — "I wrote the long version here" — not as the headline.
+- Reddit's own guidance: if every post is your own content, you're doing it wrong. Mix
+  genuine participation with the occasional self-link.
+- Don't cross-post the same text to multiple subs at once — it reads as spam.
+- Never ask for upvotes.
+
+## How
+- **Comment in a live thread** where the topic is already up — the highest-signal, lowest-risk move.
+- **Or a text self-post** that makes the argument and ends on one genuine question. Text posts beat link posts for discussion.
+- Be present in replies; answer like a person.
+
+## Picking the sub (this is the whole game)
+- Choose the **least tribal sub that fits the content**. For AI-model/infra/diffusion takes, `r/LocalLLaMA` is smart, open-weight-literate, and relatively neutral on the lab-vs-lab axis.
+- `r/MachineLearning` `[D]` only as a well-argued text post; strict on opinion/blogspam.
+- `r/artificial`, `r/singularity` — bigger, noisier; reach over signal.
+- **Avoid the tribal product subs for launch** (e.g. `r/ClaudeAI`, `r/OpenAI`) — they will dig into affiliation, and a competitor-adjacent take lights up the COI. This is where the vendor-neutral guardrail matters most.
+
+## Good shapes
+- "The thing I keep coming back to is..." → argument → one real question.
+- "Does X actually create a moat, or just speed up substitution?" (decision/debate framing).
+- A concrete counter-example or benchmark observation that invites correction.
+
+## Avoid
+- Bare blog-link posts in big subs (removed or buried).
+- Posting the same copy to several subs simultaneously.
+- Defensive replies; arguing with mods.
+- Dodging affiliation questions — be straightforward.
+
+## Source anchors
+- https://www.reddit.com/wiki/selfpromotion
+- https://support.reddithelp.com/hc/en-us/articles/205926439-Reddiquette


### PR DESCRIPTION
## What

Adds two distribution channels to the `go-to-market` skill, surfaced while distributing the *Access Denied Is Not a Moat* essay (#144).

### New playbooks
- **`references/reddit-playbook.md`** — Reddit as a *participation, not launch* channel: self-promo norms (argument first, link secondary), and sub selection (least-tribal-that-fits; `r/LocalLLaMA` for model/infra takes; avoid the tribal product subs `r/ClaudeAI`/`r/OpenAI`).
- **`references/forums-playbook.md`** — LessWrong (with EA Forum / Alignment Forum as adjacent): full-text crosspost format, the steelman / epistemic-status / cruxes bar, the engagement gate (only post if you'll answer ~3 comments in 48h), and COI/disclosure sensitivity. The best venue for opinion/discussion pieces.

### Wired into `SKILL.md`
- Triggering description now lists Reddit + LessWrong.
- New **`Opinion / discussion`** essay type, with a steelman-first discussion spine (lead with the strongest opposing case → the turn → close on a genuine question; keep it field-level).
- Two new channel-table columns (Reddit, Forums) with per-type ratings + a gating note (discussion venues, not broadcast; most COI-sensitive).
- Per-channel format bullets and references entries for both.

## Why

The skill had no home for a discussion-goal opinion piece, and its strongest discussion venues (Reddit, LessWrong) weren't covered — so distribution had to be derived by hand. This bakes that in for the next essay.

## Notes
- The `.codex/skills/go-to-market` symlink picks the new reference files up automatically.
- Docs-only change to a skill; no app/build code touched. Draft social copy for the essay was kept local (`dist/` is gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)