### PR TITLE
Expand review-essay skill: argument, fact-check, and structure passes

### DIFF
--- a/.claude/commands/review-essay.md
+++ b/.claude/commands/review-essay.md
@@ -1,4 +1,6 @@
-Review the essay as a Cartesian editor. Evaluate against these criteria:
+Review the essay as a Cartesian editor: work from clear foundations, change the least necessary, and preserve the author's voice. If the draft is still forming rather than finished, switch to developing it with the author (see brainstorm-essay) instead of reviewing it.
+
+Evaluate against these criteria:
 
 ## Clarity Check
 - Can each sentence be understood on first reading?
@@ -10,21 +12,44 @@ Review the essay as a Cartesian editor. Evaluate against these criteria:
 - Does each paragraph build on the previous?
 - Is the logical chain explicit and unbroken?
 
+## Argument Check
+Go past the prose to the claims themselves:
+- Is each claim literally true? What is the exact mechanism behind it?
+- Steelman the claim, then look for the counterexample.
+- Is this the most honest framing, or a comfortable one? Relocate the real cause when the stated one is a stand-in (for example, a "tension between teams" that is really one person's indecision).
+
+## Fact Check
+- Verify every named person, quotation, statistic, date, and public example against a source.
+- Flag anything you cannot confirm; never let an unverifiable claim about a real person stand.
+- Watch for half-remembered numbers and misattributed quotes, and check them before they ship.
+
 ## Engagement Check
 - Does the writer engage the reader directly?
 - Are objections anticipated and addressed?
 - Are questions posed and answered?
 
+## Structure Check (whole essay)
+- Within each point, does it move from the general claim, to public examples, to the author's own?
+- Is there a through-line, and do callbacks reinforce it without becoming a tic?
+- Does the opening or closing repeat the other? Cut the redundancy.
+- Are the sections balanced, or does one sprawl while another is thin?
+
 ## Simplicity Check
-- Count unnecessary words and suggest cuts
-- Identify passive constructions that should be active
-- Flag jargon that could be simpler
+- Count unnecessary words and suggest cuts.
+- Identify passive constructions that should be active.
+- Flag jargon that could be simpler.
+- Use em dashes sparingly, preferring commas, periods, and colons. Respect the author's standing style preferences.
+
+## How to deliver
+- Preserve the author's voice; make the smallest change that fixes the issue.
+- For judgment calls, offer two or three options rather than one imposed rewrite.
 
 ## Provide:
 1. **Overall Assessment** (1-2 sentences)
 2. **Strongest Passage** - Quote it, explain why it works
-3. **Weakest Passage** - Quote it, rewrite it in Cartesian style
+3. **Weakest Passage** - Quote it, propose a fix that keeps the author's voice
 4. **Line Edits** - Specific suggestions with before/after
-5. **Clarity Score** (1-10) with brief justification
+5. **Fact-check notes** - Claims to verify, correct, or source
+6. **Clarity Score** (1-10) with brief justification
 
 Content to review: $ARGUMENTS


### PR DESCRIPTION
## What
Expands the `review-essay` command from a prose checklist into a fuller editorial pass, drawn from a long real editing session.

## Changes
- **Argument Check** (new): test each claim's literal truth and exact mechanism; steelman, then find the counterexample; relocate the real cause when the stated framing is a stand-in (e.g. a "team tension" that is really one person's indecision).
- **Fact Check** (new): verify named people, quotes, statistics, dates, and public examples against sources; flag the unverifiable; catch half-remembered numbers and misattributed quotes before they ship.
- **Structure Check** (new, whole-essay): general → public → personal example ordering; through-line and callbacks that reinforce without becoming a tic; cut opening/closing redundancy; balance section lengths.
- **Delivery discipline**: preserve the author's voice, make the smallest change that fixes the issue, offer two or three options for judgment calls instead of one imposed rewrite.
- Em dashes used sparingly; respect standing style preferences.
- Pointer to `brainstorm-essay`: develop if the draft is still forming, review if finished.

## Why
These are the moves that did the most work in a recent essay edit: a fact-check caught a misattributed statistic and a misremembered quote, argument-level pushback relocated several framings, and the general → public → personal ordering tightened the examples. The old skill covered prose mechanics but none of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)