### PR TITLE
[codex] Add progressive reading passes for essays

### DIFF
--- a/apps/blog/app/(en)/essays/[slug]/page.tsx
+++ b/apps/blog/app/(en)/essays/[slug]/page.tsx
@@ -2,9 +2,11 @@ import { notFound, redirect } from 'next/navigation';
 import type { Metadata } from 'next';
 import { MDXRemote } from 'next-mdx-remote/rsc';
 import { getEssayBySlug, getEssaySlugs, getRelatedEssays, getTranslation } from '@/lib/essays';
+import { getEssayReadingDepth } from '@/lib/essay-reading';
 import { getMDXComponents } from '@/components/mdx/MDXComponents';
 import { mdxOptions } from '@/lib/mdx-options';
 import { EssayLayout, EssayHeader, RelatedEssays } from '@/components/essay';
+import { EssayReadingDepth } from '@/components/essay/EssayReadingDepth';
 import { JsonLd } from '@/components/seo';
 import { breadcrumbSchema, essayPostingSchema } from '@/lib/jsonld';
 
@@ -169,6 +171,10 @@ export default async function EssayPage({ params }: EssayPageProps) {
     essay;
   const urlPath = `/essays/${slug}`;
   const related = getRelatedEssays(slug, { limit: 3 });
+  const readingDepth = getEssayReadingDepth(slug);
+  const fullContent = (
+    <MDXRemote source={content} components={getMDXComponents()} options={{ mdxOptions }} />
+  );
 
   return (
     <>
@@ -194,7 +200,11 @@ export default async function EssayPage({ params }: EssayPageProps) {
         }
         footer={<RelatedEssays essays={related} language="en" />}
       >
-        <MDXRemote source={content} components={getMDXComponents()} options={{ mdxOptions }} />
+        {readingDepth ? (
+          <EssayReadingDepth readingDepth={readingDepth} full={fullContent} />
+        ) : (
+          fullContent
+        )}
       </EssayLayout>
     </>
   );

--- a/apps/blog/app/(zh)/zh/essays/[slug]/page.tsx
+++ b/apps/blog/app/(zh)/zh/essays/[slug]/page.tsx
@@ -2,9 +2,11 @@ import { notFound, redirect } from 'next/navigation';
 import type { Metadata } from 'next';
 import { MDXRemote } from 'next-mdx-remote/rsc';
 import { getEssayBySlug, getEssaySlugs, getRelatedEssays, getTranslation } from '@/lib/essays';
+import { getEssayReadingDepth } from '@/lib/essay-reading';
 import { getMDXComponents } from '@/components/mdx/MDXComponents';
 import { mdxOptions } from '@/lib/mdx-options';
 import { EssayLayout, EssayHeader, RelatedEssays } from '@/components/essay';
+import { EssayReadingDepth } from '@/components/essay/EssayReadingDepth';
 import { JsonLd } from '@/components/seo';
 import { breadcrumbSchema, essayPostingSchema } from '@/lib/jsonld';
 
@@ -167,6 +169,10 @@ export default async function ZhEssayPage({ params }: ZhEssayPageProps) {
     essay;
   const urlPath = `/zh/essays/${slug}`;
   const related = getRelatedEssays(slug, { limit: 3 });
+  const readingDepth = getEssayReadingDepth(slug);
+  const fullContent = (
+    <MDXRemote source={content} components={getMDXComponents()} options={{ mdxOptions }} />
+  );
 
   return (
     <>
@@ -193,7 +199,11 @@ export default async function ZhEssayPage({ params }: ZhEssayPageProps) {
         }
         footer={<RelatedEssays essays={related} language="zh" />}
       >
-        <MDXRemote source={content} components={getMDXComponents()} options={{ mdxOptions }} />
+        {readingDepth ? (
+          <EssayReadingDepth readingDepth={readingDepth} full={fullContent} />
+        ) : (
+          fullContent
+        )}
       </EssayLayout>
     </>
   );

--- a/apps/blog/components/content/ReadingDepth.tsx
+++ b/apps/blog/components/content/ReadingDepth.tsx
@@ -1,0 +1,295 @@
+'use client';
+
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export type ReadingPass = 'full' | 'argument' | 'spine';
+
+export type ReadingPassCopy = {
+  label: string;
+  time: string;
+  summary: string;
+};
+
+interface ReadingDepthContextValue {
+  activePass: ReadingPass;
+  setActivePass: (pass: ReadingPass) => void;
+}
+
+const ReadingDepthContext = React.createContext<ReadingDepthContextValue | null>(
+  null
+);
+
+const PASS_COPY: Record<ReadingPass, ReadingPassCopy> = {
+  full: {
+    label: 'Full',
+    time: '45 min',
+    summary: 'Complete essay, examples, notes, and source detail.',
+  },
+  argument: {
+    label: 'Argument',
+    time: '15 min',
+    summary: 'Load-bearing passages, examples, and consequences.',
+  },
+  spine: {
+    label: 'Spine',
+    time: '5 min',
+    summary: 'Opening claim and section list.',
+  },
+};
+
+export interface ReadingDepthProps {
+  children: React.ReactNode;
+  className?: string;
+  defaultPass?: ReadingPass;
+  passCopy?: Partial<Record<ReadingPass, Partial<ReadingPassCopy>>>;
+  storageKey?: string;
+}
+
+export interface PassContentProps {
+  pass: ReadingPass;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export interface ReadingDepthPointProps {
+  number?: number | string;
+  title: string;
+  claim: string;
+  explanation: string;
+  example?: string;
+  takeaway?: string;
+  className?: string;
+}
+
+export interface ReadingDepthExcerptProps {
+  number?: number | string;
+  title: string;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export interface ReadingDepthListProps {
+  items: string[];
+  className?: string;
+}
+
+function useReadingDepth() {
+  const context = React.useContext(ReadingDepthContext);
+  if (!context) {
+    throw new Error('ReadingDepth components must be used inside ReadingDepth.');
+  }
+  return context;
+}
+
+export function ReadingDepth({
+  children,
+  className,
+  defaultPass = 'full',
+  passCopy,
+  storageKey,
+}: ReadingDepthProps) {
+  const [activePass, setActivePassState] = React.useState<ReadingPass>(defaultPass);
+  const copy = React.useMemo(
+    () => ({
+      full: { ...PASS_COPY.full, ...passCopy?.full },
+      argument: { ...PASS_COPY.argument, ...passCopy?.argument },
+      spine: { ...PASS_COPY.spine, ...passCopy?.spine },
+    }),
+    [passCopy]
+  );
+
+  React.useEffect(() => {
+    if (!storageKey) return;
+    const storedPass = window.localStorage.getItem(storageKey);
+    if (
+      storedPass === 'full' ||
+      storedPass === 'argument' ||
+      storedPass === 'spine'
+    ) {
+      setActivePassState(storedPass);
+    }
+  }, [storageKey]);
+
+  const setActivePass = React.useCallback(
+    (pass: ReadingPass) => {
+      setActivePassState(pass);
+      if (storageKey) {
+        window.localStorage.setItem(storageKey, pass);
+      }
+    },
+    [storageKey]
+  );
+
+  const value = React.useMemo(
+    () => ({ activePass, setActivePass }),
+    [activePass, setActivePass]
+  );
+
+  React.useEffect(() => {
+    document.documentElement.dataset.readingPass = activePass;
+    return () => {
+      delete document.documentElement.dataset.readingPass;
+    };
+  }, [activePass]);
+
+  return (
+    <ReadingDepthContext.Provider value={value}>
+      <section className={cn('reading-depth my-8', className)}>
+        <div className="sticky top-4 z-10 mb-8 border border-border bg-ground-primary/95 p-3 shadow-sm backdrop-blur">
+          <div className="mb-3 flex flex-wrap items-baseline justify-between gap-2">
+            <div>
+              <p className="type-overline text-figure-muted">Reading depth</p>
+              <p className="mt-1 text-body-sm text-figure-secondary">
+                {copy[activePass].summary}
+              </p>
+            </div>
+            <p className="text-caption text-figure-muted">
+              {copy[activePass].time}
+            </p>
+          </div>
+
+          <div
+            className="grid grid-cols-3 gap-1 border border-border bg-ground-secondary p-1"
+            role="tablist"
+            aria-label="Reading depth"
+          >
+            {(['spine', 'argument', 'full'] as ReadingPass[]).map((pass) => {
+              const isActive = activePass === pass;
+              return (
+                <button
+                  key={pass}
+                  type="button"
+                  role="tab"
+                  aria-selected={isActive}
+                  onClick={() => setActivePass(pass)}
+                  className={cn(
+                    'min-h-10 px-3 py-2 text-left transition-colors',
+                    'focus:outline-none focus-visible:ring-2 focus-visible:ring-link',
+                    isActive
+                      ? 'bg-ground-primary text-figure-primary shadow-sm'
+                      : 'text-figure-muted hover:bg-ground-primary hover:text-figure-primary'
+                  )}
+                >
+                  <span className="block text-label font-semibold">
+                    {copy[pass].label}
+                  </span>
+                  <span className="block text-caption">{copy[pass].time}</span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        {children}
+      </section>
+    </ReadingDepthContext.Provider>
+  );
+}
+
+export function PassContent({ pass, children, className }: PassContentProps) {
+  const { activePass } = useReadingDepth();
+  const isActive = activePass === pass;
+
+  return (
+    <div
+      hidden={!isActive}
+      data-reading-pass-content={pass}
+      className={cn('reading-depth-pass', className)}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function ReadingDepthPoint({
+  number,
+  title,
+  claim,
+  explanation,
+  example,
+  takeaway,
+  className,
+}: ReadingDepthPointProps) {
+  return (
+    <article className={cn('border-t border-border py-5 first:border-t-0', className)}>
+      <div className="mb-3 flex gap-3">
+        {number !== undefined && (
+          <span className="mt-1 flex h-7 w-7 shrink-0 items-center justify-center border border-border text-caption font-semibold text-figure-secondary">
+            {number}
+          </span>
+        )}
+        <div
+          role="heading"
+          aria-level={3}
+          className="m-0 text-body-lg font-semibold leading-snug text-figure-primary"
+        >
+          {title}
+        </div>
+      </div>
+      <div className="space-y-3 pl-10">
+        <p className="m-0 text-body-sm leading-relaxed text-figure-primary">
+          <span className="font-semibold">Claim: </span>
+          {claim}
+        </p>
+        <p className="m-0 text-body-sm leading-relaxed text-figure-secondary">
+          <span className="font-semibold text-figure-primary">Reason: </span>
+          {explanation}
+        </p>
+        {example ? (
+          <p className="m-0 text-body-sm leading-relaxed text-figure-secondary">
+            <span className="font-semibold text-figure-primary">Example: </span>
+            {example}
+          </p>
+        ) : null}
+        {takeaway ? (
+          <p className="m-0 border-l border-border pl-3 text-body-sm leading-relaxed text-figure-primary">
+            {takeaway}
+          </p>
+        ) : null}
+      </div>
+    </article>
+  );
+}
+
+export function ReadingDepthExcerpt({
+  number,
+  title,
+  children,
+  className,
+}: ReadingDepthExcerptProps) {
+  return (
+    <article className={cn('border-t border-border py-6 first:border-t-0', className)}>
+      <div className="mb-3 flex gap-3">
+        {number !== undefined && (
+          <span className="mt-1 flex h-7 w-7 shrink-0 items-center justify-center border border-border text-caption font-semibold text-figure-secondary">
+            {number}
+          </span>
+        )}
+        <div
+          role="heading"
+          aria-level={3}
+          className="m-0 text-body-lg font-semibold leading-snug text-figure-primary"
+        >
+          {title}
+        </div>
+      </div>
+      <div className="space-y-3 pl-10 text-figure-secondary [&>p]:m-0 [&>p]:text-body-sm [&>p]:leading-relaxed">
+        {children}
+      </div>
+    </article>
+  );
+}
+
+export function ReadingDepthList({ items, className }: ReadingDepthListProps) {
+  return (
+    <div role="list" className={cn('space-y-3', className)}>
+      {items.map((item, index) => (
+        <div key={`${index}-${item}`} role="listitem" className="flex gap-3">
+          <span className="shrink-0 text-figure-muted">{index + 1}.</span>
+          <span>{item}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/blog/components/content/index.ts
+++ b/apps/blog/components/content/index.ts
@@ -35,6 +35,21 @@ export type {
   ContrastBlockProps,
 } from './ContrastPair';
 
+export {
+  ReadingDepth,
+  ReadingDepthExcerpt,
+  ReadingDepthList,
+  PassContent,
+  ReadingDepthPoint,
+} from './ReadingDepth';
+export type {
+  ReadingDepthProps,
+  ReadingDepthExcerptProps,
+  ReadingDepthListProps,
+  PassContentProps,
+  ReadingDepthPointProps,
+} from './ReadingDepth';
+
 // Embed components
 export { XEmbed } from './XEmbed';
 

--- a/apps/blog/components/essay/EssayReadingDepth.tsx
+++ b/apps/blog/components/essay/EssayReadingDepth.tsx
@@ -1,0 +1,44 @@
+import type { ReactNode } from 'react';
+import { MDXRemote } from 'next-mdx-remote/rsc';
+import type { EssayReadingDepth as EssayReadingDepthData } from '@/lib/essay-reading';
+import { mdxOptions } from '@/lib/mdx-options';
+import { getMDXComponents } from '@/components/mdx/MDXComponents';
+import { PassContent, ReadingDepth } from '@/components/content/ReadingDepth';
+
+export interface EssayReadingDepthProps {
+  readingDepth: EssayReadingDepthData;
+  full: ReactNode;
+}
+
+export function EssayReadingDepth({ readingDepth, full }: EssayReadingDepthProps) {
+  const mdxComponents = getMDXComponents();
+
+  return (
+    <ReadingDepth
+      defaultPass={readingDepth.defaultPass}
+      passCopy={readingDepth.passCopy}
+    >
+      {readingDepth.passes.spine ? (
+        <PassContent pass="spine">
+          <MDXRemote
+            source={readingDepth.passes.spine}
+            components={mdxComponents}
+            options={{ mdxOptions }}
+          />
+        </PassContent>
+      ) : null}
+
+      {readingDepth.passes.argument ? (
+        <PassContent pass="argument">
+          <MDXRemote
+            source={readingDepth.passes.argument}
+            components={mdxComponents}
+            options={{ mdxOptions }}
+          />
+        </PassContent>
+      ) : null}
+
+      <PassContent pass="full">{full}</PassContent>
+    </ReadingDepth>
+  );
+}

--- a/apps/blog/components/mdx/MDXComponents.tsx
+++ b/apps/blog/components/mdx/MDXComponents.tsx
@@ -33,6 +33,11 @@ import {
   ContrastPair,
   ContrastPositive,
   ContrastNegative,
+  ReadingDepth,
+  ReadingDepthExcerpt,
+  ReadingDepthList,
+  PassContent,
+  ReadingDepthPoint,
 } from '../content';
 
 // Editorial components for magazine-style layouts
@@ -277,6 +282,13 @@ export function getMDXComponents(): MDXComponentMap {
     ContrastPair,
     ContrastPositive,
     ContrastNegative,
+
+    // Progressive reading
+    ReadingDepth,
+    ReadingDepthExcerpt,
+    ReadingDepthList,
+    PassContent,
+    ReadingDepthPoint,
 
     // UI components exposed to MDX
     Blockquote,

--- a/apps/blog/content/essay-reading/README.md
+++ b/apps/blog/content/essay-reading/README.md
@@ -1,0 +1,39 @@
+# Essay Reading Sidecars
+
+Optional progressive-reading data for essays lives here.
+
+Keep the canonical essay in `content/essays/<slug>.mdx`. To add Spine and
+Argument modes for that essay, create `content/essay-reading/<slug>.mdx`.
+
+The sidecar is not routed, included in `raw.md`, or used for reading time. It is
+only composed into the rendered essay page.
+
+## Format
+
+```mdx
+---
+defaultPass: full
+passes:
+  spine:
+    time: "5 min"
+    summary: "Opening claim and section list."
+  argument:
+    time: "15 min"
+    summary: "Load-bearing passages, examples, and consequences."
+  full:
+    time: "45 min"
+    summary: "Complete essay, examples, notes, and source detail."
+---
+
+<!-- reading-pass:spine -->
+
+Short opening paragraphs and the section list.
+
+<!-- reading-pass:argument -->
+
+Short opening paragraphs, the section list, and self-contained argument
+excerpts.
+```
+
+Use normal MDX in each pass. Do not include the Full pass here; Full is always
+the canonical essay MDX.

--- a/apps/blog/content/essay-reading/ten-commandments-for-product.mdx
+++ b/apps/blog/content/essay-reading/ten-commandments-for-product.mdx
@@ -1,0 +1,93 @@
+---
+defaultPass: full
+passes:
+  spine:
+    time: "5 min"
+    summary: "Opening claim and section list."
+  argument:
+    time: "15 min"
+    summary: "Load-bearing passages, examples, and consequences."
+  full:
+    time: "45 min"
+    summary: "Complete essay, examples, notes, and source detail."
+---
+
+<!-- reading-pass:spine -->
+
+I spent the past two years at an AI agent startup. We took three swings: a Minecraft coplayer, a general-purpose desktop agent called Fairies, and an Excel coworker called Shortcut. This is a record of mistakes, not a recipe for success.
+
+AI makes product self-deception more dangerous, not less. It lowers the cost of building so far that old ways of avoiding reality now look like extraordinary productivity.
+
+### The ten
+
+1. You shall be honest about whether you are committed to the product, or only in love with the idea.
+2. You shall not mistake self-expression for knowledge of your user.
+3. You shall not pretend to know your user.
+4. You shall not mistake a breakthrough for a product.
+5. You shall not throw the problem of how to use your product onto your users.
+6. You shall not treat every feature as equal, nor chase one more feature before launch.
+7. You shall be driven by outcomes, not activity, and ship early enough to face the verdict.
+8. You shall not build for a million users before you have a thousand.
+9. You shall not assume a good product sells itself; you are its missionary.
+10. You shall have patience; attention is a spark, not the fuel.
+
+<!-- reading-pass:argument -->
+
+I spent the past two years at an AI agent startup. We took three swings: a Minecraft coplayer, a general-purpose desktop agent called Fairies, and an Excel coworker called Shortcut. This is a record of mistakes, not a recipe for success.
+
+AI makes product self-deception more dangerous, not less. It lowers the cost of building so far that old ways of avoiding reality now look like extraordinary productivity.
+
+### The ten
+
+1. You shall be honest about whether you are committed to the product, or only in love with the idea.
+2. You shall not mistake self-expression for knowledge of your user.
+3. You shall not pretend to know your user.
+4. You shall not mistake a breakthrough for a product.
+5. You shall not throw the problem of how to use your product onto your users.
+6. You shall not treat every feature as equal, nor chase one more feature before launch.
+7. You shall be driven by outcomes, not activity, and ship early enough to face the verdict.
+8. You shall not build for a million users before you have a thousand.
+9. You shall not assume a good product sells itself; you are its missionary.
+10. You shall have patience; attention is a spark, not the fuel.
+
+---
+
+### 1. You shall be honest about whether you are committed to the product, or only in love with the idea.
+
+Building means enduring its pain yourself, and any move to delegate that pain is proof the commitment was never there. The pain you cannot delegate is the grounding and the rejection: figuring out who your users actually are, going to them yourself, selling the thing yourself, watching them ignore what you built, being told no to your face, and sitting in the uncertainty without a dashboard to hide behind. The most flattering disguise for avoiding that pain is the belief that you are Steve Jobs or Elon Musk. Their certainty was never that they were right about everything; it was a narrow, earned conviction about the few things they would not compromise, paired with relentless honesty about all the rest they had gotten wrong and had to fix. If you borrow only the certainty and apply it to every product call, you are just avoiding the work that would tell you where you are wrong.
+
+### 2. You shall not mistake self-expression for knowledge of your user.
+
+Let your taste seed the product, but never let it certify the market. Your taste is a legitimate seed, the point of view and conviction a product needs to begin. But a seed is a hypothesis, not knowledge. It is not the claim that your taste is good. It is a claim about other people: that you are a stand-in for a real group, that what you find compelling they will find compelling, that the thing you want is a thing they need. Self-expression is not the enemy; it becomes product only when it earns the user's endorsement. The line between this commandment and the next is simple: users own the problem; you own the solution.
+
+### 3. You shall not pretend to know your user.
+
+Not knowing who your user is is bad, but pretending you know is much worse, because it quietly sets the priorities for everything you build, and sets them toward a user you invented instead of one you found. "Developers" is not a user. Neither is "builders," or "AI pioneers," or "Minecraft players." We learned this with the Minecraft coplayer, where "Minecraft players" hid builders, PvP players, and people who only wanted to hang out; with Fairies, where "white-collar workers" named people we wanted as users more than people who saw themselves that way; and with Shortcut, where "all Excel users" only slowly became the finance users doing high-caliber work to a high standard. Speed makes selection feel optional. It never is. Logs tell you what; you are starving for why. Each broad label, feature hedge, and premature metric is the same move: avoiding the specific, first-hand work and calling the avoidance progress.
+
+### 4. You shall not mistake a breakthrough for a product.
+
+The last four years made this trap almost irresistible. Model capability jumped so far, so fast, that a generation of researchers and engineers came to feel a breakthrough is self-evidently powerful, and ChatGPT seemed to prove the rest: that a breakthrough can simply become a product. It is a myth. A product is the translation of capability into a met need, and the translation, figuring out whose problem this solves and how anyone would actually use it, is the entire job, not a footnote to the breakthrough. Even OpenAI did not jump from breakthrough to product; it shipped an API and learned its way toward one. On the Minecraft coplayer, we got excited that our agent could build a diamond pickaxe, and that a group of agents could build more than three hundred items together, both genuine technical feats, and it won us a lot of attention on X and Hacker News. But it was never clear that the attention reflected a need anyone actually had.
+
+### 5. You shall not throw the problem of how to use your product onto your users.
+
+Great products carry clear functional affordance: the user simply *sees* how to use them. Products built on genuinely new technology arrive with neither, and articulating the usage is your job, not the user's. Fairies was a blank chat box, much like ChatGPT, and we wanted users to grasp that it was something more, a general-purpose agent. We never managed to say what that meant, not to them and not to ourselves: we could not articulate how a user would benefit, what problem it solved, or even how to begin. Shortcut was the opposite. On day one it looked like a spreadsheet with an agent panel beside it, and every user understood at a glance, without a word from us, that this was about automating spreadsheet work with an agent. Clear affordance did not finish the job, it let us start it.
+
+### 6. You shall not treat every feature as equal, nor chase one more feature before launch.
+
+Focus is the discipline of saying no. It is not working hard on everything; it is deciding what *not* to build, and that refusal is the muscle. And the reason runs deeper than effort: your features are the message you send users about what your product is. A product enters a user's mental space through a single clear wedge, one thing they immediately understand it is for. We shipped exactly the wrong kind of feature in Fairies. A developer added a way to ask the agent to change the app's color theme: no settings to dig through, just tell it and watch the whole app recolor. It felt wonderful, genuinely agentic, the software rearranging itself from a single sentence. But I could not have told you why it deserved to exist, how we would explain it to anyone, or which user needed it while their real problems sat untouched. It flattered us and said nothing to them.
+
+### 7. You shall be driven by outcomes, not activity, and ship early enough to face the verdict.
+
+Shipping ten pull requests and five features is activity. It feels like progress and frequently isn't. When an agent writes the lines, the count measures its throughput and nothing else. Whether anyone wants the result is a different question, and no line count will ever answer it. AI can compress implementation time. It cannot compress the market's verdict. A real outcome is the market voting with something it cannot fake and you cannot manufacture: people coming back, people bringing others, people paying, a company signing. So move your most uncomfortable moment, being rejected by real users, to the left. Then read the right number. Not signups, not applause, not vanity counts: *return*.
+
+### 8. You shall not build for a million users before you have a thousand.
+
+Your product is an organism, not a spec. Standing up a system that holds a million users when you have zero feels like rigor. It is procrastination with excellent posture. The sharper edge of this trap is new. Coding agents now make it *feel free* to build the final architecture on day one, as if you could skip exploration entirely and arrive directly at THE correct answer. You can't. The right system is found as the product finds its users; it is not dictated like a blueprint by someone who imagines he already sees the whole thing.
+
+### 9. You shall not assume a good product sells itself; you are its missionary.
+
+Finishing the first version is the starting line, not the finish. A good product does not introduce itself, and it does not get paid for on its own. Most of the people who would love what you built will never know it exists or see what it can do, unless someone makes them, and that someone is you. We think Shortcut is the best spreadsheet agent on the market. Believing that quietly is worth nothing; the job is to make people know it, to put it in front of them until they see what it does. The proof that your selling worked is not applause or signups, which are free and forgettable. It is what happens after first contact: whether people come back, whether they bring others, whether usage deepens, whether a buyer is willing to pay.
+
+### 10. You shall have patience; attention is a spark, not the fuel.
+
+Building a product takes patience. The work is to keep making it better, week after week, long after the first version's thrill is gone. But attention is not growth. Attention is a spark; the product is the fuel, and a spark over an empty tank goes out in seconds. The fundamental reason a product spreads is never the launch. It is that the thing is good enough that attention, however it arrives, turns into people who stay and bring others. We saw this with Shortcut: the launch video had a real viral moment, and the daily actives spiked, then fell almost as fast as they came. The spike was never the win. The eruption got us looked at; only the product got us kept.

--- a/apps/blog/lib/essay-reading.ts
+++ b/apps/blog/lib/essay-reading.ts
@@ -1,0 +1,72 @@
+import fs from 'fs';
+import path from 'path';
+import matter from 'gray-matter';
+import type { ReadingPass, ReadingPassCopy } from '@/components/content/ReadingDepth';
+
+const ESSAY_READING_DIRECTORY = path.join(process.cwd(), 'content', 'essay-reading');
+
+type CondensedReadingPass = Exclude<ReadingPass, 'full'>;
+
+export interface EssayReadingDepth {
+  slug: string;
+  defaultPass: ReadingPass;
+  passCopy: Partial<Record<ReadingPass, Partial<ReadingPassCopy>>>;
+  passes: Partial<Record<CondensedReadingPass, string>>;
+}
+
+interface EssayReadingFrontmatter {
+  defaultPass?: ReadingPass;
+  passes?: Partial<Record<ReadingPass, Partial<ReadingPassCopy>>>;
+}
+
+const PASS_MARKER = /<!--\s*reading-pass:(spine|argument)\s*-->/g;
+
+export function getEssayReadingDepth(slug: string): EssayReadingDepth | null {
+  const filePath = path.join(ESSAY_READING_DIRECTORY, `${slug}.mdx`);
+
+  if (!fs.existsSync(filePath)) {
+    return null;
+  }
+
+  try {
+    const fileContent = fs.readFileSync(filePath, 'utf-8');
+    const { data, content } = matter(fileContent);
+    const frontmatter = data as EssayReadingFrontmatter;
+    const passes = splitReadingPasses(content);
+
+    if (!passes.spine && !passes.argument) {
+      return null;
+    }
+
+    return {
+      slug,
+      defaultPass: frontmatter.defaultPass ?? 'full',
+      passCopy: frontmatter.passes ?? {},
+      passes,
+    };
+  } catch (error) {
+    console.error(`Error parsing essay reading depth ${slug}:`, error);
+    return null;
+  }
+}
+
+function splitReadingPasses(
+  content: string
+): Partial<Record<CondensedReadingPass, string>> {
+  const matches = Array.from(content.matchAll(PASS_MARKER));
+  const passes: Partial<Record<CondensedReadingPass, string>> = {};
+
+  for (let index = 0; index < matches.length; index += 1) {
+    const match = matches[index];
+    const pass = match[1] as CondensedReadingPass;
+    const start = (match.index ?? 0) + match[0].length;
+    const end = matches[index + 1]?.index ?? content.length;
+    const passContent = content.slice(start, end).trim();
+
+    if (passContent) {
+      passes[pass] = passContent;
+    }
+  }
+
+  return passes;
+}

--- a/apps/blog/styles/essay.css
+++ b/apps/blog/styles/essay.css
@@ -131,3 +131,8 @@
   background-color: transparent;
   padding: 0;
 }
+
+html[data-reading-pass='spine'] .essay-layout-wrapper > aside:first-child,
+html[data-reading-pass='argument'] .essay-layout-wrapper > aside:first-child {
+  visibility: hidden;
+}


### PR DESCRIPTION
## Summary
- add a reusable ReadingDepth UI for Spine / Argument / Full essay modes
- load optional essay reading sidecars from `content/essay-reading/<slug>.mdx`
- move Ten Commandments condensed reading content out of canonical essay MDX so `raw.md`, generated reading time, and SEO-facing full text stay clean

## Validation
- `pnpm --filter @blog/blog build:next`
- `git diff --check`

## Notes
- Full remains the default reading mode.
- The first sidecar is for `ten-commandments-for-product` and keeps the ten commandments wording verbatim across Spine and Argument.