### PR TITLE
[codex] Add win the battle draft

### DIFF
--- a/apps/blog/content/essays/win-the-battle.mdx
+++ b/apps/blog/content/essays/win-the-battle.mdx
@@ -1,0 +1,42 @@
+---
+title: "Win the Battle"
+description: ""
+date: "2026-06-19"
+type: narrative 
+topics:
+  - career
+lang: en
+draft: true
+---
+
+In March this year, I went back to China after 7 years, and had a chance to catch up with an old friend. He joined his company after the graduate school, while I wandered three companies after graduation: Google, Citadel, then the startup. We were talking about team building and leadership topics. 
+
+He asked what I think a good leader should be. I responded, a good leader can bring the team together and make them effective and productive, like a superstar coach who would train a team to win the championship. For example, the take the football team to win the superbowl, or take the basketball team to win the NBA championship.
+
+He mildly commented that your thoughts are very American. Those are typical American management style. In China, the good leader leads the team the win the battle. That's it. To win battles, after battlers (能打胜仗). That really is what matteres. 
+
+That comment was half surprising, half expected. The surprising part was how Westernized I was, and the expected part was the battle metaphor. I should have known that, but when I was talking about this topic, I fall back to the coach metaphor.
+
+---
+
+When it comes to enterpreneurship, in Chinese context, it is mostly about battlefield, and battle metaphor. The books, the talks, and the conversations, are full of that. When I first joining the startup, I was reading books about startup in Chinese and English. In English, I read "0 to 1", I read "lean startup", I also read "the leadership xx" from Harvard. In Chinese, I read "雷军", "创业课"。 
+
+The style of approaching startup is very different. In Chinese books I read, it is all about winning the battles. How to survive in fierce competition, when you were young. How to take a small piece of terrortory of users mental space. How to march on and expand your terrritory. However fight among hundreds of leagues, not being killed to killing others. What are strategies moves to place your resource of force, setting the battle field, then attack; what are tectics. 
+
+This didn't ring the bell for me early in my life when I was reading books in English enterprenuership and startup. Those books do talk about survive, talk about growth, but not really in the metaphor of war or battles, but more like organism or groups survive and grow in the wild west where the natural environment is harsh (I do not articulate this well as the imagery is a bit vague. the difference here is more like you are in a desert and try to survive versus you are in a hunger game where you want to survive)  
+
+But it should not be so surprising to me about how Chinese is taking a war/battle metaphor. There was always "business is like military war 商场如战场". In the best-selling leaderboard, "The art of the war" was always associated with business success / business bible, which I didn't fully understand when I was young. Recently years, Mao's reading has become more popular and people who read his volumes carefully learned a lot about mindset and methodologies of startups and they talk about it, and they talked about it that CCP was a very successful startup in 1940s, it has gone through a lot of hardship that a startup has to gone through but in the end became very successful.
+
+Chiense domestic market remains to have fiece competitions. Generations of people are used to competitions and the determinations, perservence and hardworking out from the competitions did help China to grow. So it should not be so surprinsg. But when it comes to my conversations with my friend, on the topic of leadership, and when I really heard from him using this metaphor, not reading from books, from remote source. That felt differently.
+
+
+In fact, despite I using the coach metaphor when I chatted with my friend, when I was at the startup and looking at our situations, I actually think in the battlefield metaphor. The leaders should be Generals who guide us, the employees, to direction and a winning strategy. As an employee, my main job is to execute and deliver the results, also working with my colleagues to deliver. After all, I am not one of the cofounders. And I do get upset and confused, when I see my leaders, who I think supposed to be General, are actually doing tactic moves and doesn't really talk about strategical plan, or fight a battle themselves instead of leading the entire team to fight the battle together.
+
+Lead a team to win a battle, doesn't really mean the leader fight all the enemies themselves and win, at least not in my mind.
+
+(OK, I think my topic is drifting...
+
+my main topic is not to complain my leaders who are not guiding the team to win the battle, my main points is I feel it interesting and culture difference to talk about enterpreneurship and startup, using very different metaphors, and try to discuss culture context and implications of using those metaphors.
+
+Certainly U.S. uses the knife-fight in the business context. maybe we need to do a bit more research
+)


### PR DESCRIPTION
## What
Adds the current snapshot of `apps/blog/content/essays/win-the-battle.mdx` as a draft essay.

## Why
This captures a new career / leadership narrative draft about business metaphors, leadership, and startup culture across Chinese and American contexts.

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm --filter @blog/tokens build`
- `pnpm --filter @blog/blog build:next`

The Next build passed. It reported existing unrelated lint warnings in `ZoomableImage.tsx`, `TimelineMap.tsx`, `EssayLayout.tsx`, and `ParticleGalaxy/Particles.tsx`, plus Browserslist/caniuse-lite staleness notices.